### PR TITLE
integration with bitcoin-spv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 Cargo.lock
 /target/
 **/*.rs.bk
+#IntelliJ IDEA files
+.idea
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ bitcoin = "0.11"
 rust-crypto = "0.2"
 rand = "0.4"
 secp256k1 = "0.8"
-bitcoin-spv = { git = "https://github.com/tamasblummer/bitcoin-spv", branch = "master", optional = true }
+bitcoin-spv = { git = "https://github.com/tamasblummer/bitcoin-spv", branch = "integration", optional = true }
 
 [patch.crates-io]
 bitcoin = { git = "https://github.com/tamasblummer/rust-bitcoin", branch = "prs"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,15 @@ Still super-early code-dump quality and is missing large chunks. See README in g
 [features]
 # Supports tracking channels with a non-bitcoin chain hashes. Currently enables all kinds of fun DoS attacks.
 non_bitcoin_chain_hash_routing = []
+spv = ["bitcoin-spv"]
 
 [dependencies]
 bitcoin = "0.11"
 rust-crypto = "0.2"
 rand = "0.4"
 secp256k1 = "0.8"
+bitcoin-spv = { git = "https://github.com/tamasblummer/bitcoin-spv", branch = "master", optional = true }
+
+[patch.crates-io]
+bitcoin = { git = "https://github.com/tamasblummer/rust-bitcoin", branch = "prs"  }
+


### PR DESCRIPTION
bitcoin-spv now offers an implementation of ChainWatchInterface. Although it is work in progess, it works with a single local peer. Downloads (and stores) headers than serves the above interface.

I added it as a feature as it comes with a lot of dependencies. I want to cut down on those later, but want to get it work before optimizing. Do we really want to rewrite futures, async IO or logging code ?

Unfortunately bitcoin-spv needs a patched version of rust-bitcoin as my trivial PR's are still pending.

Please let me know if useful and what further functions you need on lightning side.
See bitcoin_spv::SPV:new (...)  for simple use