### PR TITLE
Fix channel_target crash fp

### DIFF
--- a/fuzz/fuzz_targets/channel_target.rs
+++ b/fuzz/fuzz_targets/channel_target.rs
@@ -158,7 +158,7 @@ pub fn do_test(data: &[u8]) {
 	macro_rules! return_err {
 		($expr: expr) => {
 			match $expr {
-				Ok(_) => {},
+				Ok(r) => r,
 				Err(_) => return,
 			}
 		}
@@ -278,10 +278,14 @@ pub fn do_test(data: &[u8]) {
 			9 => {
 				let shutdown = decode_msg_with_len16!(msgs::Shutdown, 32, 1);
 				return_err!(channel.shutdown(&fee_est, &shutdown));
+				if channel.is_shutdown() { return; }
 			},
 			10 => {
 				let closing_signed = decode_msg!(msgs::ClosingSigned, 32+8+64);
-				return_err!(channel.closing_signed(&fee_est, &closing_signed));
+				if return_err!(channel.closing_signed(&fee_est, &closing_signed)).1.is_some() {
+					assert!(channel.is_shutdown());
+					return;
+				}
 			},
 			_ => return,
 		}

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -608,7 +608,7 @@ impl Channel {
 			ins
 		};
 
-		let mut txouts: Vec<(TxOut, Option<HTLCOutputInCommitment>)> = Vec::new();
+		let mut txouts: Vec<(TxOut, Option<HTLCOutputInCommitment>)> = Vec::with_capacity(self.pending_htlcs.len() + 2);
 
 		let dust_limit_satoshis = if local { self.our_dust_limit_satoshis } else { self.their_dust_limit_satoshis };
 		let mut remote_htlc_total_msat = 0;
@@ -699,8 +699,8 @@ impl Channel {
 
 		transaction_utils::sort_outputs(&mut txouts);
 
-		let mut outputs: Vec<TxOut> = Vec::new();
-		let mut htlcs_used: Vec<HTLCOutputInCommitment> = Vec::new();
+		let mut outputs: Vec<TxOut> = Vec::with_capacity(txouts.len());
+		let mut htlcs_used: Vec<HTLCOutputInCommitment> = Vec::with_capacity(txouts.len());
 		for (idx, out) in txouts.drain(..).enumerate() {
 			outputs.push(out.0);
 			if let Some(out_htlc) = out.1 {


### PR DESCRIPTION
Channel now has more requirements from the caller, which the fuzz tester violates, but ChannelManager does not.