### PR TITLE
Remove `bitcoin` as a development dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,3 @@ secp256k1 = "0.9"
 
 [build-dependencies]
 gcc = "0.3"
-
-[dev-dependencies.bitcoin]
-version = "0.13"
-features = ["bitcoinconsensus"]


### PR DESCRIPTION
It isn't used as a development dependency and doesn't build on my computer because of the `bitcoinconsensus` feature.