### PR TITLE
Format code with rustfmt

### DIFF
--- a/fuzz/fuzz_targets/channel_target.rs
+++ b/fuzz/fuzz_targets/channel_target.rs
@@ -4,55 +4,52 @@ extern crate secp256k1;
 
 use bitcoin::blockdata::block::BlockHeader;
 use bitcoin::blockdata::transaction::{Transaction, TxOut};
-use bitcoin::util::hash::Sha256dHash;
 use bitcoin::network::serialize::{serialize, BitcoinHash};
+use bitcoin::util::hash::Sha256dHash;
 
+use lightning::chain::chaininterface::{ConfirmationTarget, FeeEstimator};
+use lightning::chain::transaction::OutPoint;
 use lightning::ln::channel::{Channel, ChannelKeys};
 use lightning::ln::channelmanager::{HTLCFailReason, PendingForwardHTLCInfo};
 use lightning::ln::msgs;
 use lightning::ln::msgs::MsgDecodable;
-use lightning::chain::chaininterface::{FeeEstimator, ConfirmationTarget};
-use lightning::chain::transaction::OutPoint;
 use lightning::util::reset_rng_state;
 
 use secp256k1::key::{PublicKey, SecretKey};
 use secp256k1::Secp256k1;
 
-use std::sync::atomic::{AtomicUsize,Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[inline]
 pub fn slice_to_be16(v: &[u8]) -> u16 {
-	((v[0] as u16) << 8*1) |
-	((v[1] as u16) << 8*0)
+	((v[0] as u16) << 8 * 1) | ((v[1] as u16) << 8 * 0)
 }
 
 #[inline]
 pub fn slice_to_be32(v: &[u8]) -> u32 {
-	((v[0] as u32) << 8*3) |
-	((v[1] as u32) << 8*2) |
-	((v[2] as u32) << 8*1) |
-	((v[3] as u32) << 8*0)
+	((v[0] as u32) << 8 * 3)
+		| ((v[1] as u32) << 8 * 2)
+		| ((v[2] as u32) << 8 * 1)
+		| ((v[3] as u32) << 8 * 0)
 }
 
 #[inline]
 pub fn slice_to_be64(v: &[u8]) -> u64 {
-	((v[0] as u64) << 8*7) |
-	((v[1] as u64) << 8*6) |
-	((v[2] as u64) << 8*5) |
-	((v[3] as u64) << 8*4) |
-	((v[4] as u64) << 8*3) |
-	((v[5] as u64) << 8*2) |
-	((v[6] as u64) << 8*1) |
-	((v[7] as u64) << 8*0)
+	((v[0] as u64) << 8 * 7)
+		| ((v[1] as u64) << 8 * 6)
+		| ((v[2] as u64) << 8 * 5)
+		| ((v[3] as u64) << 8 * 4)
+		| ((v[4] as u64) << 8 * 3)
+		| ((v[5] as u64) << 8 * 2)
+		| ((v[6] as u64) << 8 * 1)
+		| ((v[7] as u64) << 8 * 0)
 }
 
 #[inline]
 fn slice_to_be24(v: &[u8]) -> u64 {
 	//TODO: We should probably be returning a Result for channel creation, not panic!()ing on
 	//>2**24 values...
-	((v[0] as u64) << 8*2) |
-	((v[1] as u64) << 8*1) |
-	((v[2] as u64) << 8*0)
+	((v[0] as u64) << 8 * 2) | ((v[1] as u64) << 8 * 1) | ((v[2] as u64) << 8 * 0)
 }
 
 struct InputData<'a> {
@@ -84,7 +81,7 @@ impl<'a> FeeEstimator for FuzzEstimator<'a> {
 		//TODO: We should actually be testing at least much more than 64k...
 		match self.input.get_slice(2) {
 			Some(slice) => slice_to_be16(slice) as u64,
-			None => 0
+			None => 0,
 		}
 	}
 }
@@ -97,21 +94,19 @@ pub fn do_test(data: &[u8]) {
 		data,
 		read_pos: AtomicUsize::new(0),
 	};
-	let fee_est = FuzzEstimator {
-		input: &input,
-	};
+	let fee_est = FuzzEstimator { input: &input };
 
 	macro_rules! get_slice {
-		($len: expr) => {
+		($len:expr) => {
 			match input.get_slice($len as usize) {
 				Some(slice) => slice,
 				None => return,
-			}
-		}
+				}
+		};
 	}
 
 	macro_rules! decode_msg {
-		($MsgType: path, $len: expr) => {
+		($MsgType:path, $len:expr) => {
 			match <($MsgType)>::decode(get_slice!($len)) {
 				Ok(msg) => msg,
 				Err(e) => match e {
@@ -120,30 +115,32 @@ pub fn do_test(data: &[u8]) {
 					msgs::DecodeError::BadSignature => return,
 					msgs::DecodeError::ExtraAddressesPerType => return,
 					msgs::DecodeError::WrongLength => panic!("We picked the length..."),
+					},
 				}
-			}
-		}
+		};
 	}
 
 	macro_rules! decode_msg_with_len16 {
-		($MsgType: path, $begin_len: expr, $factor: expr) => {
-			{
-				let extra_len = slice_to_be16(&match input.get_slice_nonadvancing($begin_len as usize + 2) {
+		($MsgType:path, $begin_len:expr, $factor:expr) => {{
+			let extra_len = slice_to_be16(
+				&match input.get_slice_nonadvancing($begin_len as usize + 2) {
 					Some(slice) => slice,
 					None => return,
-				}[$begin_len..$begin_len + 2]);
-				match <($MsgType)>::decode(get_slice!($begin_len as usize + 2 + (extra_len as usize)*$factor)) {
-					Ok(msg) => msg,
-					Err(e) => match e {
-						msgs::DecodeError::UnknownRealmByte => return,
-						msgs::DecodeError::BadPublicKey => return,
-						msgs::DecodeError::BadSignature => return,
-						msgs::DecodeError::ExtraAddressesPerType => return,
-						msgs::DecodeError::WrongLength => panic!("We picked the length..."),
-					}
+				}[$begin_len..$begin_len + 2],
+				);
+			match <($MsgType)>::decode(get_slice!(
+				$begin_len as usize + 2 + (extra_len as usize) * $factor
+			)) {
+				Ok(msg) => msg,
+				Err(e) => match e {
+					msgs::DecodeError::UnknownRealmByte => return,
+					msgs::DecodeError::BadPublicKey => return,
+					msgs::DecodeError::BadSignature => return,
+					msgs::DecodeError::ExtraAddressesPerType => return,
+					msgs::DecodeError::WrongLength => panic!("We picked the length..."),
+				},
 				}
-			}
-		}
+			}};
 	}
 
 	let secp_ctx = Secp256k1::new();
@@ -152,43 +149,101 @@ pub fn do_test(data: &[u8]) {
 			match PublicKey::from_slice(&secp_ctx, get_slice!(33)) {
 				Ok(key) => key,
 				Err(_) => return,
-			}
-		}
+				}
+		};
 	}
 
 	macro_rules! return_err {
-		($expr: expr) => {
+		($expr:expr) => {
 			match $expr {
 				Ok(r) => r,
 				Err(_) => return,
-			}
-		}
+				}
+		};
 	}
 
 	macro_rules! chan_keys {
 		() => {
 			ChannelKeys {
-				funding_key:               SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				revocation_base_key:       SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				payment_base_key:          SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				delayed_payment_base_key:  SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				htlc_base_key:             SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				channel_close_key:         SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				channel_monitor_claim_key: SecretKey::from_slice(&secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				commitment_seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-			}
-		}
+				funding_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				revocation_base_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				payment_base_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				delayed_payment_base_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				htlc_base_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				channel_close_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				channel_monitor_claim_key: SecretKey::from_slice(
+					&secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				commitment_seed: [
+					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0, 0,
+					],
+				}
+		};
 	}
 
 	let their_pubkey = get_pubkey!();
 
-	let mut tx = Transaction { version: 0, lock_time: 0, input: Vec::new(), output: Vec::new() };
+	let mut tx = Transaction {
+		version: 0,
+		lock_time: 0,
+		input: Vec::new(),
+		output: Vec::new(),
+	};
 
 	let mut channel = if get_slice!(1)[0] != 0 {
 		let chan_value = slice_to_be24(get_slice!(3));
 
-		let mut chan = Channel::new_outbound(&fee_est, chan_keys!(), their_pubkey, chan_value, get_slice!(1)[0] == 0, slice_to_be64(get_slice!(8)));
-		chan.get_open_channel(Sha256dHash::from(get_slice!(32)), &fee_est).unwrap();
+		let mut chan = Channel::new_outbound(
+			&fee_est,
+			chan_keys!(),
+			their_pubkey,
+			chan_value,
+			get_slice!(1)[0] == 0,
+			slice_to_be64(get_slice!(8)),
+		);
+		chan.get_open_channel(Sha256dHash::from(get_slice!(32)), &fee_est)
+			.unwrap();
 		let accept_chan = if get_slice!(1)[0] == 0 {
 			decode_msg_with_len16!(msgs::AcceptChannel, 270, 1)
 		} else {
@@ -196,98 +251,148 @@ pub fn do_test(data: &[u8]) {
 		};
 		return_err!(chan.accept_channel(&accept_chan));
 
-		tx.output.push(TxOut{ value: chan_value, script_pubkey: chan.get_funding_redeemscript().to_v0_p2wsh() });
+		tx.output.push(TxOut {
+			value: chan_value,
+			script_pubkey: chan.get_funding_redeemscript().to_v0_p2wsh(),
+		});
 		let funding_output = OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);
 
 		chan.get_outbound_funding_created(funding_output).unwrap();
-		let funding_signed = decode_msg!(msgs::FundingSigned, 32+64);
+		let funding_signed = decode_msg!(msgs::FundingSigned, 32 + 64);
 		return_err!(chan.funding_signed(&funding_signed));
 		chan
 	} else {
 		let open_chan = if get_slice!(1)[0] == 0 {
-			decode_msg_with_len16!(msgs::OpenChannel, 2*32+6*8+4+2*2+6*33+1, 1)
+			decode_msg_with_len16!(
+				msgs::OpenChannel,
+				2 * 32 + 6 * 8 + 4 + 2 * 2 + 6 * 33 + 1,
+				1
+			)
 		} else {
-			decode_msg!(msgs::OpenChannel, 2*32+6*8+4+2*2+6*33+1)
+			decode_msg!(msgs::OpenChannel, 2 * 32 + 6 * 8 + 4 + 2 * 2 + 6 * 33 + 1)
 		};
-		let mut chan = match Channel::new_from_req(&fee_est, chan_keys!(), their_pubkey, &open_chan, slice_to_be64(get_slice!(8)), get_slice!(1)[0] == 0) {
+		let mut chan = match Channel::new_from_req(
+			&fee_est,
+			chan_keys!(),
+			their_pubkey,
+			&open_chan,
+			slice_to_be64(get_slice!(8)),
+			get_slice!(1)[0] == 0,
+		) {
 			Ok(chan) => chan,
 			Err(_) => return,
 		};
 		chan.get_accept_channel().unwrap();
 
-		tx.output.push(TxOut{ value: open_chan.funding_satoshis, script_pubkey: chan.get_funding_redeemscript().to_v0_p2wsh() });
+		tx.output.push(TxOut {
+			value: open_chan.funding_satoshis,
+			script_pubkey: chan.get_funding_redeemscript().to_v0_p2wsh(),
+		});
 		let funding_output = OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);
 
-		let mut funding_created = decode_msg!(msgs::FundingCreated, 32+32+2+64);
+		let mut funding_created = decode_msg!(msgs::FundingCreated, 32 + 32 + 2 + 64);
 		funding_created.funding_txid = funding_output.txid.clone();
 		funding_created.funding_output_index = funding_output.index;
 		return_err!(chan.funding_created(&funding_created));
 		chan
 	};
 
-	let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	let mut header = BlockHeader {
+		version: 0x20000000,
+		prev_blockhash: Default::default(),
+		merkle_root: Default::default(),
+		time: 42,
+		bits: 42,
+		nonce: 42,
+	};
 	channel.block_connected(&header, 1, &[&tx; 1], &[42; 1]);
 	for i in 2..100 {
-		header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		header = BlockHeader {
+			version: 0x20000000,
+			prev_blockhash: header.bitcoin_hash(),
+			merkle_root: Default::default(),
+			time: 42,
+			bits: 42,
+			nonce: 42,
+		};
 		channel.block_connected(&header, i, &[&tx; 0], &[0; 0]);
 	}
 
-	let funding_locked = decode_msg!(msgs::FundingLocked, 32+33);
+	let funding_locked = decode_msg!(msgs::FundingLocked, 32 + 33);
 	return_err!(channel.funding_locked(&funding_locked));
 
 	loop {
 		match get_slice!(1)[0] {
 			0 => {
-				return_err!(channel.send_htlc(slice_to_be64(get_slice!(8)), [42; 32], slice_to_be32(get_slice!(4)), msgs::OnionPacket {
-					version: get_slice!(1)[0],
-					public_key: get_pubkey!(),
-					hop_data: [0; 20*65],
-					hmac: [0; 32],
-				}));
-			},
+				return_err!(channel.send_htlc(
+					slice_to_be64(get_slice!(8)),
+					[42; 32],
+					slice_to_be32(get_slice!(4)),
+					msgs::OnionPacket {
+						version: get_slice!(1)[0],
+						public_key: get_pubkey!(),
+						hop_data: [0; 20 * 65],
+						hmac: [0; 32],
+					}
+				));
+			}
 			1 => {
 				return_err!(channel.send_commitment());
-			},
+			}
 			2 => {
-				let update_add_htlc = decode_msg!(msgs::UpdateAddHTLC, 32+8+8+32+4+4+33+20*65+32);
-				return_err!(channel.update_add_htlc(&update_add_htlc, PendingForwardHTLCInfo::dummy()));
-			},
+				let update_add_htlc = decode_msg!(
+					msgs::UpdateAddHTLC,
+					32 + 8 + 8 + 32 + 4 + 4 + 33 + 20 * 65 + 32
+				);
+				return_err!(
+					channel.update_add_htlc(&update_add_htlc, PendingForwardHTLCInfo::dummy())
+				);
+			}
 			3 => {
 				let update_fulfill_htlc = decode_msg!(msgs::UpdateFulfillHTLC, 32 + 8 + 32);
 				return_err!(channel.update_fulfill_htlc(&update_fulfill_htlc));
-			},
+			}
 			4 => {
 				let update_fail_htlc = decode_msg_with_len16!(msgs::UpdateFailHTLC, 32 + 8, 1);
 				return_err!(channel.update_fail_htlc(&update_fail_htlc, HTLCFailReason::dummy()));
-			},
+			}
 			5 => {
-				let update_fail_malformed_htlc = decode_msg!(msgs::UpdateFailMalformedHTLC, 32+8+32+2);
-				return_err!(channel.update_fail_malformed_htlc(&update_fail_malformed_htlc, HTLCFailReason::dummy()));
-			},
+				let update_fail_malformed_htlc =
+					decode_msg!(msgs::UpdateFailMalformedHTLC, 32 + 8 + 32 + 2);
+				return_err!(channel.update_fail_malformed_htlc(
+					&update_fail_malformed_htlc,
+					HTLCFailReason::dummy()
+				));
+			}
 			6 => {
-				let commitment_signed = decode_msg_with_len16!(msgs::CommitmentSigned, 32+64, 64);
+				let commitment_signed = decode_msg_with_len16!(msgs::CommitmentSigned, 32 + 64, 64);
 				return_err!(channel.commitment_signed(&commitment_signed));
-			},
+			}
 			7 => {
-				let revoke_and_ack = decode_msg!(msgs::RevokeAndACK, 32+32+33);
+				let revoke_and_ack = decode_msg!(msgs::RevokeAndACK, 32 + 32 + 33);
 				return_err!(channel.revoke_and_ack(&revoke_and_ack));
-			},
+			}
 			8 => {
-				let update_fee = decode_msg!(msgs::UpdateFee, 32+4);
+				let update_fee = decode_msg!(msgs::UpdateFee, 32 + 4);
 				return_err!(channel.update_fee(&fee_est, &update_fee));
-			},
+			}
 			9 => {
 				let shutdown = decode_msg_with_len16!(msgs::Shutdown, 32, 1);
 				return_err!(channel.shutdown(&fee_est, &shutdown));
-				if channel.is_shutdown() { return; }
-			},
+				if channel.is_shutdown() {
+					return;
+				}
+			}
 			10 => {
-				let closing_signed = decode_msg!(msgs::ClosingSigned, 32+8+64);
-				if return_err!(channel.closing_signed(&fee_est, &closing_signed)).1.is_some() {
+				let closing_signed = decode_msg!(msgs::ClosingSigned, 32 + 8 + 64);
+				if return_err!(channel.closing_signed(&fee_est, &closing_signed))
+					.1
+					.is_some()
+				{
 					assert!(channel.is_shutdown());
 					return;
 				}
-			},
+			}
 			_ => return,
 		}
 	}
@@ -303,7 +408,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -4,64 +4,63 @@ extern crate lightning;
 extern crate secp256k1;
 
 use bitcoin::blockdata::block::BlockHeader;
-use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::blockdata::script::Script;
+use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::network::constants::Network;
 use bitcoin::network::serialize::{serialize, BitcoinHash};
 use bitcoin::util::hash::Sha256dHash;
 use bitcoin::util::uint::Uint256;
 
-use crypto::sha2::Sha256;
 use crypto::digest::Digest;
+use crypto::sha2::Sha256;
 
-use lightning::chain::chaininterface::{BroadcasterInterface,ConfirmationTarget,ChainListener,FeeEstimator,ChainWatchInterfaceUtil};
+use lightning::chain::chaininterface::{
+	BroadcasterInterface, ChainListener, ChainWatchInterfaceUtil, ConfirmationTarget, FeeEstimator,
+};
 use lightning::chain::transaction::OutPoint;
-use lightning::ln::channelmonitor;
 use lightning::ln::channelmanager::ChannelManager;
-use lightning::ln::peer_handler::{MessageHandler,PeerManager,SocketDescriptor};
+use lightning::ln::channelmonitor;
+use lightning::ln::peer_handler::{MessageHandler, PeerManager, SocketDescriptor};
 use lightning::ln::router::Router;
-use lightning::util::events::{EventsProvider,Event};
+use lightning::util::events::{Event, EventsProvider};
 use lightning::util::reset_rng_state;
 
-use secp256k1::key::{PublicKey,SecretKey};
+use secp256k1::key::{PublicKey, SecretKey};
 use secp256k1::Secp256k1;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize,Ordering};
 
 #[inline]
 pub fn slice_to_be16(v: &[u8]) -> u16 {
-	((v[0] as u16) << 8*1) |
-	((v[1] as u16) << 8*0)
+	((v[0] as u16) << 8 * 1) | ((v[1] as u16) << 8 * 0)
 }
 
 #[inline]
 pub fn slice_to_be24(v: &[u8]) -> u32 {
-	((v[0] as u32) << 8*2) |
-	((v[1] as u32) << 8*1) |
-	((v[2] as u32) << 8*0)
+	((v[0] as u32) << 8 * 2) | ((v[1] as u32) << 8 * 1) | ((v[2] as u32) << 8 * 0)
 }
 
 #[inline]
 pub fn slice_to_be32(v: &[u8]) -> u32 {
-	((v[0] as u32) << 8*3) |
-	((v[1] as u32) << 8*2) |
-	((v[2] as u32) << 8*1) |
-	((v[3] as u32) << 8*0)
+	((v[0] as u32) << 8 * 3)
+		| ((v[1] as u32) << 8 * 2)
+		| ((v[2] as u32) << 8 * 1)
+		| ((v[3] as u32) << 8 * 0)
 }
 
 #[inline]
 pub fn be64_to_array(u: u64) -> [u8; 8] {
 	let mut v = [0; 8];
-	v[0] = ((u >> 8*7) & 0xff) as u8;
-	v[1] = ((u >> 8*6) & 0xff) as u8;
-	v[2] = ((u >> 8*5) & 0xff) as u8;
-	v[3] = ((u >> 8*4) & 0xff) as u8;
-	v[4] = ((u >> 8*3) & 0xff) as u8;
-	v[5] = ((u >> 8*2) & 0xff) as u8;
-	v[6] = ((u >> 8*1) & 0xff) as u8;
-	v[7] = ((u >> 8*0) & 0xff) as u8;
+	v[0] = ((u >> 8 * 7) & 0xff) as u8;
+	v[1] = ((u >> 8 * 6) & 0xff) as u8;
+	v[2] = ((u >> 8 * 5) & 0xff) as u8;
+	v[3] = ((u >> 8 * 4) & 0xff) as u8;
+	v[4] = ((u >> 8 * 3) & 0xff) as u8;
+	v[5] = ((u >> 8 * 2) & 0xff) as u8;
+	v[6] = ((u >> 8 * 1) & 0xff) as u8;
+	v[7] = ((u >> 8 * 0) & 0xff) as u8;
 	v
 }
 
@@ -87,14 +86,18 @@ impl FeeEstimator for FuzzEstimator {
 		//TODO: We should actually be testing at least much more than 64k...
 		match self.input.get_slice(2) {
 			Some(slice) => slice_to_be16(slice) as u64,
-			None => 0
+			None => 0,
 		}
 	}
 }
 
 struct TestChannelMonitor {}
 impl channelmonitor::ManyChannelMonitor for TestChannelMonitor {
-	fn add_update_monitor(&self, _funding_txo: OutPoint, _monitor: channelmonitor::ChannelMonitor) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
+	fn add_update_monitor(
+		&self,
+		_funding_txo: OutPoint,
+		_monitor: channelmonitor::ChannelMonitor,
+	) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
 		//TODO!
 		Ok(())
 	}
@@ -129,12 +132,12 @@ pub fn do_test(data: &[u8]) {
 	});
 
 	macro_rules! get_slice {
-		($len: expr) => {
+		($len:expr) => {
 			match input.get_slice($len as usize) {
 				Some(slice) => slice,
 				None => return,
-			}
-		}
+				}
+		};
 	}
 
 	let secp_ctx = Secp256k1::new();
@@ -143,8 +146,8 @@ pub fn do_test(data: &[u8]) {
 			match PublicKey::from_slice(&secp_ctx, get_slice!(33)) {
 				Ok(key) => key,
 				Err(_) => return,
-			}
-		}
+				}
+		};
 	}
 
 	let our_network_key = match SecretKey::from_slice(&secp_ctx, get_slice!(32)) {
@@ -152,17 +155,31 @@ pub fn do_test(data: &[u8]) {
 		Err(_) => return,
 	};
 
-	let monitor = Arc::new(TestChannelMonitor{});
+	let monitor = Arc::new(TestChannelMonitor {});
 	let watch = Arc::new(ChainWatchInterfaceUtil::new());
-	let broadcast = Arc::new(TestBroadcaster{});
+	let broadcast = Arc::new(TestBroadcaster {});
 
-	let channelmanager = ChannelManager::new(our_network_key, slice_to_be32(get_slice!(4)), get_slice!(1)[0] != 0, Network::Bitcoin, fee_est.clone(), monitor.clone(), watch.clone(), broadcast.clone()).unwrap();
-	let router = Arc::new(Router::new(PublicKey::from_secret_key(&secp_ctx, &our_network_key).unwrap()));
+	let channelmanager = ChannelManager::new(
+		our_network_key,
+		slice_to_be32(get_slice!(4)),
+		get_slice!(1)[0] != 0,
+		Network::Bitcoin,
+		fee_est.clone(),
+		monitor.clone(),
+		watch.clone(),
+		broadcast.clone(),
+	).unwrap();
+	let router = Arc::new(Router::new(
+		PublicKey::from_secret_key(&secp_ctx, &our_network_key).unwrap(),
+	));
 
-	let handler = PeerManager::new(MessageHandler {
-		chan_handler: channelmanager.clone(),
-		route_handler: router.clone(),
-	}, our_network_key);
+	let handler = PeerManager::new(
+		MessageHandler {
+			chan_handler: channelmanager.clone(),
+			route_handler: router.clone(),
+		},
+		our_network_key,
+	);
 
 	let mut peers = [false; 256];
 	let mut should_forward = false;
@@ -177,41 +194,65 @@ pub fn do_test(data: &[u8]) {
 			0 => {
 				let mut new_id = 0;
 				for i in 1..256 {
-					if !peers[i-1] {
+					if !peers[i - 1] {
 						new_id = i;
 						break;
 					}
 				}
-				if new_id == 0 { return; }
+				if new_id == 0 {
+					return;
+				}
 				peers[new_id - 1] = true;
-				handler.new_outbound_connection(get_pubkey!(), Peer{id: (new_id - 1) as u8}).unwrap();
-			},
+				handler
+					.new_outbound_connection(
+						get_pubkey!(),
+						Peer {
+							id: (new_id - 1) as u8,
+						},
+					)
+					.unwrap();
+			}
 			1 => {
 				let mut new_id = 0;
 				for i in 1..256 {
-					if !peers[i-1] {
+					if !peers[i - 1] {
 						new_id = i;
 						break;
 					}
 				}
-				if new_id == 0 { return; }
+				if new_id == 0 {
+					return;
+				}
 				peers[new_id - 1] = true;
-				handler.new_inbound_connection(Peer{id: (new_id - 1) as u8}).unwrap();
-			},
+				handler
+					.new_inbound_connection(Peer {
+						id: (new_id - 1) as u8,
+					})
+					.unwrap();
+			}
 			2 => {
 				let peer_id = get_slice!(1)[0];
-				if !peers[peer_id as usize] { return; }
+				if !peers[peer_id as usize] {
+					return;
+				}
 				peers[peer_id as usize] = false;
-				handler.disconnect_event(&Peer{id: peer_id});
-			},
+				handler.disconnect_event(&Peer { id: peer_id });
+			}
 			3 => {
 				let peer_id = get_slice!(1)[0];
-				if !peers[peer_id as usize] { return; }
-				match handler.read_event(&mut Peer{id: peer_id}, get_slice!(get_slice!(1)[0]).to_vec()) {
-					Ok(res) => assert!(!res),
-					Err(_) => { peers[peer_id as usize] = false; }
+				if !peers[peer_id as usize] {
+					return;
 				}
-			},
+				match handler.read_event(
+					&mut Peer { id: peer_id },
+					get_slice!(get_slice!(1)[0]).to_vec(),
+				) {
+					Ok(res) => assert!(!res),
+					Err(_) => {
+						peers[peer_id as usize] = false;
+					}
+				}
+			}
 			4 => {
 				let value = slice_to_be24(get_slice!(3)) as u64;
 				let route = match router.get_route(&get_pubkey!(), &Vec::new(), value, 42) {
@@ -223,34 +264,50 @@ pub fn do_test(data: &[u8]) {
 				let mut sha = Sha256::new();
 				sha.input(&payment_hash);
 				sha.result(&mut payment_hash);
-				for i in 1..32 { payment_hash[i] = 0; }
+				for i in 1..32 {
+					payment_hash[i] = 0;
+				}
 				payments_sent += 1;
 				match channelmanager.send_payment(route, payment_hash) {
-					Ok(_) => {},
+					Ok(_) => {}
 					Err(_) => return,
 				}
-			},
+			}
 			5 => {
 				let peer_id = get_slice!(1)[0];
-				if !peers[peer_id as usize] { return; }
+				if !peers[peer_id as usize] {
+					return;
+				}
 				let their_key = get_pubkey!();
 				let chan_value = slice_to_be24(get_slice!(3)) as u64;
-				if channelmanager.create_channel(their_key, chan_value, 0).is_err() { return; }
-			},
+				if channelmanager
+					.create_channel(their_key, chan_value, 0)
+					.is_err()
+				{
+					return;
+				}
+			}
 			6 => {
 				let mut channels = channelmanager.list_channels();
 				let channel_id = get_slice!(1)[0] as usize;
-				if channel_id >= channels.len() { return; }
-				channels.sort_by(|a, b| { a.channel_id.cmp(&b.channel_id) });
-				if channelmanager.close_channel(&channels[channel_id].channel_id).is_err() { return; }
-			},
+				if channel_id >= channels.len() {
+					return;
+				}
+				channels.sort_by(|a, b| a.channel_id.cmp(&b.channel_id));
+				if channelmanager
+					.close_channel(&channels[channel_id].channel_id)
+					.is_err()
+				{
+					return;
+				}
+			}
 			7 => {
 				if should_forward {
 					channelmanager.process_pending_htlc_forward();
 					handler.process_events();
 					should_forward = false;
 				}
-			},
+			}
 			8 => {
 				for payment in payments_received.drain(..) {
 					let mut payment_preimage = None;
@@ -260,7 +317,9 @@ pub fn do_test(data: &[u8]) {
 						let mut sha = Sha256::new();
 						sha.input(&payment_hash);
 						sha.result(&mut payment_hash);
-						for i in 1..32 { payment_hash[i] = 0; }
+						for i in 1..32 {
+							payment_hash[i] = 0;
+						}
 						if payment_hash == payment {
 							payment_hash = [0; 32];
 							payment_hash[0..8].copy_from_slice(&be64_to_array(i));
@@ -270,22 +329,32 @@ pub fn do_test(data: &[u8]) {
 					}
 					channelmanager.claim_funds(payment_preimage.unwrap());
 				}
-			},
+			}
 			9 => {
 				for payment in payments_received.drain(..) {
 					channelmanager.fail_htlc_backwards(&payment);
 				}
-			},
+			}
 			10 => {
-				for funding_generation in  pending_funding_generation.drain(..) {
-					let mut tx = Transaction { version: 0, lock_time: 0, input: Vec::new(), output: vec![TxOut {
-							value: funding_generation.1, script_pubkey: funding_generation.2,
-						}] };
-					let funding_output = OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);
-					channelmanager.funding_transaction_generated(&funding_generation.0, funding_output.clone());
+				for funding_generation in pending_funding_generation.drain(..) {
+					let mut tx = Transaction {
+						version: 0,
+						lock_time: 0,
+						input: Vec::new(),
+						output: vec![TxOut {
+							value: funding_generation.1,
+							script_pubkey: funding_generation.2,
+						}],
+					};
+					let funding_output =
+						OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);
+					channelmanager.funding_transaction_generated(
+						&funding_generation.0,
+						funding_output.clone(),
+					);
 					pending_funding_signatures.insert(funding_output, tx);
 				}
-			},
+			}
 			11 => {
 				if !pending_funding_relay.is_empty() {
 					let mut txn = Vec::with_capacity(pending_funding_relay.len());
@@ -295,36 +364,60 @@ pub fn do_test(data: &[u8]) {
 						txn_idxs.push(idx as u32 + 1);
 					}
 
-					let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+					let mut header = BlockHeader {
+						version: 0x20000000,
+						prev_blockhash: Default::default(),
+						merkle_root: Default::default(),
+						time: 42,
+						bits: 42,
+						nonce: 42,
+					};
 					channelmanager.block_connected(&header, 1, &txn[..], &txn_idxs[..]);
 					txn.clear();
 					txn_idxs.clear();
 					for i in 2..100 {
-						header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+						header = BlockHeader {
+							version: 0x20000000,
+							prev_blockhash: header.bitcoin_hash(),
+							merkle_root: Default::default(),
+							time: 42,
+							bits: 42,
+							nonce: 42,
+						};
 						channelmanager.block_connected(&header, i, &txn[..], &txn_idxs[..]);
 					}
 				}
 				pending_funding_relay.clear();
-			},
+			}
 			_ => return,
 		}
 		for event in handler.get_and_clear_pending_events() {
 			match event {
-				Event::FundingGenerationReady { temporary_channel_id, channel_value_satoshis, output_script, .. } => {
-					pending_funding_generation.push((temporary_channel_id, channel_value_satoshis, output_script));
-				},
+				Event::FundingGenerationReady {
+					temporary_channel_id,
+					channel_value_satoshis,
+					output_script,
+					..
+				} => {
+					pending_funding_generation.push((
+						temporary_channel_id,
+						channel_value_satoshis,
+						output_script,
+					));
+				}
 				Event::FundingBroadcastSafe { funding_txo, .. } => {
-					pending_funding_relay.push(pending_funding_signatures.remove(&funding_txo).unwrap());
-				},
+					pending_funding_relay
+						.push(pending_funding_signatures.remove(&funding_txo).unwrap());
+				}
 				Event::PaymentReceived { payment_hash, .. } => {
 					payments_received.push(payment_hash);
-				},
-				Event::PaymentSent {..} => {},
-				Event::PaymentFailed {..} => {},
+				}
+				Event::PaymentSent { .. } => {}
+				Event::PaymentFailed { .. } => {}
 
-				Event::PendingHTLCsForwardable {..} => {
+				Event::PendingHTLCsForwardable { .. } => {
 					should_forward = true;
-				},
+				}
 				_ => panic!("Unknown event"),
 			}
 		}
@@ -341,7 +434,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_ping_target.rs
+++ b/fuzz/fuzz_targets/msg_ping_target.rs
@@ -5,7 +5,7 @@ extern crate lightning;
 
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable, Ping};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable, Ping};
 
 #[inline]
 pub fn do_test(data: &[u8]) {
@@ -25,7 +25,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_pong_target.rs
+++ b/fuzz/fuzz_targets/msg_pong_target.rs
@@ -5,7 +5,7 @@ extern crate lightning;
 
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable, Pong};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable, Pong};
 
 #[inline]
 pub fn do_test(data: &[u8]) {
@@ -25,7 +25,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_accept_channel_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_accept_channel_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_closing_signed_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_closing_signed_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_commitment_signed_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_commitment_signed_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_funding_created_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_funding_created_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_funding_locked_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_funding_locked_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_funding_signed_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_funding_signed_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_open_channel_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_open_channel_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_revoke_and_ack_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_revoke_and_ack_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_shutdown_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_shutdown_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_update_add_htlc_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_update_add_htlc_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_update_fail_htlc_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_update_fail_htlc_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_update_fail_malformed_htlc_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_update_fee_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_update_fee_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/fuzz_targets/msg_targets/msg_update_fulfill_htlc_target.rs
@@ -6,7 +6,7 @@ extern crate lightning;
 use lightning::ln::msgs;
 use lightning::util::reset_rng_state;
 
-use lightning::ln::msgs::{MsgEncodable, MsgDecodable};
+use lightning::ln::msgs::{MsgDecodable, MsgEncodable};
 
 mod utils;
 
@@ -26,7 +26,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/fuzz/fuzz_targets/msg_targets/utils.rs
+++ b/fuzz/fuzz_targets/msg_targets/utils.rs
@@ -2,14 +2,12 @@
 
 #[macro_export]
 macro_rules! test_msg {
-	($MsgType: path, $data: ident) => {
-		{
-			if let Ok(msg) = <$MsgType as MsgDecodable>::decode($data){
-				let enc = msg.encode();
-				assert_eq!(&$data[..enc.len()], &enc[..]);
+	($MsgType:path, $data:ident) => {{
+		if let Ok(msg) = <$MsgType as MsgDecodable>::decode($data) {
+			let enc = msg.encode();
+			assert_eq!(&$data[..enc.len()], &enc[..]);
 			}
-		}
-	}
+		}};
 }
 
 #[allow(dead_code)]

--- a/fuzz/fuzz_targets/peer_crypt_target.rs
+++ b/fuzz/fuzz_targets/peer_crypt_target.rs
@@ -4,13 +4,12 @@ extern crate secp256k1;
 use lightning::ln::peer_channel_encryptor::PeerChannelEncryptor;
 use lightning::util::reset_rng_state;
 
-use secp256k1::key::{PublicKey,SecretKey};
+use secp256k1::key::{PublicKey, SecretKey};
 use secp256k1::Secp256k1;
 
 #[inline]
 fn slice_to_be16(v: &[u8]) -> u16 {
-	((v[0] as u16) << 8*1) |
-	((v[1] as u16) << 8*0)
+	((v[0] as u16) << 8 * 1) | ((v[1] as u16) << 8 * 0)
 }
 
 #[inline]
@@ -19,16 +18,14 @@ pub fn do_test(data: &[u8]) {
 
 	let mut read_pos = 0;
 	macro_rules! get_slice {
-		($len: expr) => {
-			{
-				let slice_len = $len as usize;
-				if data.len() < read_pos + slice_len {
-					return;
+		($len:expr) => {{
+			let slice_len = $len as usize;
+			if data.len() < read_pos + slice_len {
+				return;
 				}
-				read_pos += slice_len;
-				&data[read_pos - slice_len..read_pos]
-			}
-		}
+			read_pos += slice_len;
+			&data[read_pos - slice_len..read_pos]
+			}};
 	}
 
 	let secp_ctx = Secp256k1::new();
@@ -45,7 +42,7 @@ pub fn do_test(data: &[u8]) {
 		let mut crypter = PeerChannelEncryptor::new_outbound(their_pubkey);
 		crypter.get_act_one();
 		match crypter.process_act_two(get_slice!(50), &our_network_key) {
-			Ok(_) => {},
+			Ok(_) => {}
 			Err(_) => return,
 		}
 		assert!(crypter.is_ready_for_encryption());
@@ -53,11 +50,11 @@ pub fn do_test(data: &[u8]) {
 	} else {
 		let mut crypter = PeerChannelEncryptor::new_inbound(&our_network_key);
 		match crypter.process_act_one_with_key(get_slice!(50), &our_network_key) {
-			Ok(_) => {},
+			Ok(_) => {}
 			Err(_) => return,
 		}
 		match crypter.process_act_three(get_slice!(66)) {
-			Ok(_) => {},
+			Ok(_) => {}
 			Err(_) => return,
 		}
 		assert!(crypter.is_ready_for_encryption());
@@ -67,12 +64,12 @@ pub fn do_test(data: &[u8]) {
 		if get_slice!(1)[0] == 0 {
 			crypter.encrypt_message(get_slice!(slice_to_be16(get_slice!(2))));
 		} else {
-			let len = match crypter.decrypt_length_header(get_slice!(16+2)) {
+			let len = match crypter.decrypt_length_header(get_slice!(16 + 2)) {
 				Ok(len) => len,
 				Err(_) => return,
 			};
 			match crypter.decrypt_message(get_slice!(len as usize + 16)) {
-				Ok(_) => {},
+				Ok(_) => {}
 				Err(_) => return,
 			}
 		}
@@ -89,7 +86,8 @@ fn main() {
 }
 
 #[cfg(feature = "honggfuzz")]
-#[macro_use] extern crate honggfuzz;
+#[macro_use]
+extern crate honggfuzz;
 #[cfg(feature = "honggfuzz")]
 fn main() {
 	loop {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+hard_tabs = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![crate_name = "lightning"]
 
 extern crate bitcoin;
-extern crate secp256k1;
-extern crate rand;
 extern crate crypto;
+extern crate rand;
+extern crate secp256k1;
 
 pub mod chain;
 pub mod ln;

--- a/src/ln/chan_utils.rs
+++ b/src/ln/chan_utils.rs
@@ -1,11 +1,11 @@
-use bitcoin::blockdata::script::{Script,Builder};
 use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::transaction::{TxIn,TxOut,Transaction};
-use bitcoin::util::hash::{Hash160,Sha256dHash};
+use bitcoin::blockdata::script::{Builder, Script};
+use bitcoin::blockdata::transaction::{Transaction, TxIn, TxOut};
+use bitcoin::util::hash::{Hash160, Sha256dHash};
 
-use secp256k1::key::{PublicKey,SecretKey};
-use secp256k1::Secp256k1;
 use secp256k1;
+use secp256k1::key::{PublicKey, SecretKey};
+use secp256k1::Secp256k1;
 
 use crypto::digest::Digest;
 use crypto::ripemd160::Ripemd160;
@@ -32,10 +32,16 @@ pub fn build_commitment_secret(commitment_seed: [u8; 32], idx: u64) -> [u8; 32] 
 	res
 }
 
-pub fn derive_private_key(secp_ctx: &Secp256k1, per_commitment_point: &PublicKey, base_secret: &SecretKey) -> Result<SecretKey, secp256k1::Error> {
+pub fn derive_private_key(
+	secp_ctx: &Secp256k1,
+	per_commitment_point: &PublicKey,
+	base_secret: &SecretKey,
+) -> Result<SecretKey, secp256k1::Error> {
 	let mut sha = Sha256::new();
 	sha.input(&per_commitment_point.serialize());
-	sha.input(&PublicKey::from_secret_key(&secp_ctx, &base_secret).unwrap().serialize());
+	sha.input(&PublicKey::from_secret_key(&secp_ctx, &base_secret)
+		.unwrap()
+		.serialize());
 	let mut res = [0; 32];
 	sha.result(&mut res);
 
@@ -44,21 +50,32 @@ pub fn derive_private_key(secp_ctx: &Secp256k1, per_commitment_point: &PublicKey
 	Ok(key)
 }
 
-pub fn derive_public_key(secp_ctx: &Secp256k1, per_commitment_point: &PublicKey, base_point: &PublicKey) -> Result<PublicKey, secp256k1::Error> {
+pub fn derive_public_key(
+	secp_ctx: &Secp256k1,
+	per_commitment_point: &PublicKey,
+	base_point: &PublicKey,
+) -> Result<PublicKey, secp256k1::Error> {
 	let mut sha = Sha256::new();
 	sha.input(&per_commitment_point.serialize());
 	sha.input(&base_point.serialize());
 	let mut res = [0; 32];
 	sha.result(&mut res);
 
-	let hashkey = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &res)?).unwrap();
+	let hashkey =
+		PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &res)?).unwrap();
 	base_point.combine(&secp_ctx, &hashkey)
 }
 
 /// Derives a revocation key from its constituent parts
-pub fn derive_private_revocation_key(secp_ctx: &Secp256k1, per_commitment_secret: &SecretKey, revocation_base_secret: &SecretKey) -> Result<SecretKey, secp256k1::Error> {
-	let revocation_base_point = PublicKey::from_secret_key(&secp_ctx, &revocation_base_secret).unwrap();
-	let per_commitment_point = PublicKey::from_secret_key(&secp_ctx, &per_commitment_secret).unwrap();
+pub fn derive_private_revocation_key(
+	secp_ctx: &Secp256k1,
+	per_commitment_secret: &SecretKey,
+	revocation_base_secret: &SecretKey,
+) -> Result<SecretKey, secp256k1::Error> {
+	let revocation_base_point =
+		PublicKey::from_secret_key(&secp_ctx, &revocation_base_secret).unwrap();
+	let per_commitment_point =
+		PublicKey::from_secret_key(&secp_ctx, &per_commitment_secret).unwrap();
 
 	let rev_append_commit_hash_key = {
 		let mut sha = Sha256::new();
@@ -87,7 +104,11 @@ pub fn derive_private_revocation_key(secp_ctx: &Secp256k1, per_commitment_secret
 	Ok(part_a)
 }
 
-pub fn derive_public_revocation_key(secp_ctx: &Secp256k1, per_commitment_point: &PublicKey, revocation_base_point: &PublicKey) -> Result<PublicKey, secp256k1::Error> {
+pub fn derive_public_revocation_key(
+	secp_ctx: &Secp256k1,
+	per_commitment_point: &PublicKey,
+	revocation_base_point: &PublicKey,
+) -> Result<PublicKey, secp256k1::Error> {
 	let rev_append_commit_hash_key = {
 		let mut sha = Sha256::new();
 		sha.input(&revocation_base_point.serialize());
@@ -124,13 +145,29 @@ pub struct TxCreationKeys {
 }
 
 impl TxCreationKeys {
-	pub fn new(secp_ctx: &Secp256k1, per_commitment_point: &PublicKey, a_delayed_payment_base: &PublicKey, a_htlc_base: &PublicKey, b_revocation_base: &PublicKey, b_payment_base: &PublicKey, b_htlc_base: &PublicKey) -> Result<TxCreationKeys, secp256k1::Error> {
+	pub fn new(
+		secp_ctx: &Secp256k1,
+		per_commitment_point: &PublicKey,
+		a_delayed_payment_base: &PublicKey,
+		a_htlc_base: &PublicKey,
+		b_revocation_base: &PublicKey,
+		b_payment_base: &PublicKey,
+		b_htlc_base: &PublicKey,
+	) -> Result<TxCreationKeys, secp256k1::Error> {
 		Ok(TxCreationKeys {
 			per_commitment_point: per_commitment_point.clone(),
-			revocation_key: derive_public_revocation_key(&secp_ctx, &per_commitment_point, &b_revocation_base)?,
+			revocation_key: derive_public_revocation_key(
+				&secp_ctx,
+				&per_commitment_point,
+				&b_revocation_base,
+			)?,
 			a_htlc_key: derive_public_key(&secp_ctx, &per_commitment_point, &a_htlc_base)?,
 			b_htlc_key: derive_public_key(&secp_ctx, &per_commitment_point, &b_htlc_base)?,
-			a_delayed_payment_key: derive_public_key(&secp_ctx, &per_commitment_point, &a_delayed_payment_base)?,
+			a_delayed_payment_key: derive_public_key(
+				&secp_ctx,
+				&per_commitment_point,
+				&a_delayed_payment_base,
+			)?,
 			b_payment_key: derive_public_key(&secp_ctx, &per_commitment_point, &b_payment_base)?,
 		})
 	}
@@ -138,17 +175,22 @@ impl TxCreationKeys {
 
 /// Gets the "to_local" output redeemscript, ie the script which is time-locked or spendable by
 /// the revocation key
-pub fn get_revokeable_redeemscript(revocation_key: &PublicKey, to_self_delay: u16, delayed_payment_key: &PublicKey) -> Script {
-	Builder::new().push_opcode(opcodes::All::OP_IF)
-	              .push_slice(&revocation_key.serialize())
-	              .push_opcode(opcodes::All::OP_ELSE)
-	              .push_int(to_self_delay as i64)
-	              .push_opcode(opcodes::OP_CSV)
-	              .push_opcode(opcodes::All::OP_DROP)
-	              .push_slice(&delayed_payment_key.serialize())
-	              .push_opcode(opcodes::All::OP_ENDIF)
-	              .push_opcode(opcodes::All::OP_CHECKSIG)
-	              .into_script()
+pub fn get_revokeable_redeemscript(
+	revocation_key: &PublicKey,
+	to_self_delay: u16,
+	delayed_payment_key: &PublicKey,
+) -> Script {
+	Builder::new()
+		.push_opcode(opcodes::All::OP_IF)
+		.push_slice(&revocation_key.serialize())
+		.push_opcode(opcodes::All::OP_ELSE)
+		.push_int(to_self_delay as i64)
+		.push_opcode(opcodes::OP_CSV)
+		.push_opcode(opcodes::All::OP_DROP)
+		.push_slice(&delayed_payment_key.serialize())
+		.push_opcode(opcodes::All::OP_ENDIF)
+		.push_opcode(opcodes::All::OP_CHECKSIG)
+		.into_script()
 }
 
 #[derive(Clone)]
@@ -161,7 +203,12 @@ pub struct HTLCOutputInCommitment {
 }
 
 #[inline]
-pub fn get_htlc_redeemscript_with_explicit_keys(htlc: &HTLCOutputInCommitment, a_htlc_key: &PublicKey, b_htlc_key: &PublicKey, revocation_key: &PublicKey) -> Script {
+pub fn get_htlc_redeemscript_with_explicit_keys(
+	htlc: &HTLCOutputInCommitment,
+	a_htlc_key: &PublicKey,
+	b_htlc_key: &PublicKey,
+	revocation_key: &PublicKey,
+) -> Script {
 	let payment_hash160 = {
 		let mut ripemd = Ripemd160::new();
 		ripemd.input(&htlc.payment_hash);
@@ -170,64 +217,66 @@ pub fn get_htlc_redeemscript_with_explicit_keys(htlc: &HTLCOutputInCommitment, a
 		res
 	};
 	if htlc.offered {
-		Builder::new().push_opcode(opcodes::All::OP_DUP)
-		              .push_opcode(opcodes::All::OP_HASH160)
-		              .push_slice(&Hash160::from_data(&revocation_key.serialize())[..])
-		              .push_opcode(opcodes::All::OP_EQUAL)
-		              .push_opcode(opcodes::All::OP_IF)
-		              .push_opcode(opcodes::All::OP_CHECKSIG)
-		              .push_opcode(opcodes::All::OP_ELSE)
-		              .push_slice(&b_htlc_key.serialize()[..])
-		              .push_opcode(opcodes::All::OP_SWAP)
-		              .push_opcode(opcodes::All::OP_SIZE)
-		              .push_int(32)
-		              .push_opcode(opcodes::All::OP_EQUAL)
-		              .push_opcode(opcodes::All::OP_NOTIF)
-		              .push_opcode(opcodes::All::OP_DROP)
-		              .push_int(2)
-		              .push_opcode(opcodes::All::OP_SWAP)
-		              .push_slice(&a_htlc_key.serialize()[..])
-		              .push_int(2)
-		              .push_opcode(opcodes::All::OP_CHECKMULTISIG)
-		              .push_opcode(opcodes::All::OP_ELSE)
-		              .push_opcode(opcodes::All::OP_HASH160)
-		              .push_slice(&payment_hash160)
-		              .push_opcode(opcodes::All::OP_EQUALVERIFY)
-		              .push_opcode(opcodes::All::OP_CHECKSIG)
-		              .push_opcode(opcodes::All::OP_ENDIF)
-		              .push_opcode(opcodes::All::OP_ENDIF)
-		              .into_script()
+		Builder::new()
+			.push_opcode(opcodes::All::OP_DUP)
+			.push_opcode(opcodes::All::OP_HASH160)
+			.push_slice(&Hash160::from_data(&revocation_key.serialize())[..])
+			.push_opcode(opcodes::All::OP_EQUAL)
+			.push_opcode(opcodes::All::OP_IF)
+			.push_opcode(opcodes::All::OP_CHECKSIG)
+			.push_opcode(opcodes::All::OP_ELSE)
+			.push_slice(&b_htlc_key.serialize()[..])
+			.push_opcode(opcodes::All::OP_SWAP)
+			.push_opcode(opcodes::All::OP_SIZE)
+			.push_int(32)
+			.push_opcode(opcodes::All::OP_EQUAL)
+			.push_opcode(opcodes::All::OP_NOTIF)
+			.push_opcode(opcodes::All::OP_DROP)
+			.push_int(2)
+			.push_opcode(opcodes::All::OP_SWAP)
+			.push_slice(&a_htlc_key.serialize()[..])
+			.push_int(2)
+			.push_opcode(opcodes::All::OP_CHECKMULTISIG)
+			.push_opcode(opcodes::All::OP_ELSE)
+			.push_opcode(opcodes::All::OP_HASH160)
+			.push_slice(&payment_hash160)
+			.push_opcode(opcodes::All::OP_EQUALVERIFY)
+			.push_opcode(opcodes::All::OP_CHECKSIG)
+			.push_opcode(opcodes::All::OP_ENDIF)
+			.push_opcode(opcodes::All::OP_ENDIF)
+			.into_script()
 	} else {
-		Builder::new().push_opcode(opcodes::All::OP_DUP)
-		              .push_opcode(opcodes::All::OP_HASH160)
-		              .push_slice(&Hash160::from_data(&revocation_key.serialize())[..])
-		              .push_opcode(opcodes::All::OP_EQUAL)
-		              .push_opcode(opcodes::All::OP_IF)
-		              .push_opcode(opcodes::All::OP_CHECKSIG)
-		              .push_opcode(opcodes::All::OP_ELSE)
-		              .push_slice(&b_htlc_key.serialize()[..])
-		              .push_opcode(opcodes::All::OP_SWAP)
-		              .push_opcode(opcodes::All::OP_SIZE)
-		              .push_int(32)
-		              .push_opcode(opcodes::All::OP_EQUAL)
-		              .push_opcode(opcodes::All::OP_IF)
-		              .push_opcode(opcodes::All::OP_HASH160)
-		              .push_slice(&payment_hash160)
-		              .push_opcode(opcodes::All::OP_EQUALVERIFY)
-		              .push_int(2)
-		              .push_opcode(opcodes::All::OP_SWAP)
-		              .push_slice(&a_htlc_key.serialize()[..])
-		              .push_int(2)
-		              .push_opcode(opcodes::All::OP_CHECKMULTISIG)
-		              .push_opcode(opcodes::All::OP_ELSE)
-		              .push_opcode(opcodes::All::OP_DROP)
-		              .push_int(htlc.cltv_expiry as i64)
-		              .push_opcode(opcodes::OP_CLTV)
-		              .push_opcode(opcodes::All::OP_DROP)
-		              .push_opcode(opcodes::All::OP_CHECKSIG)
-		              .push_opcode(opcodes::All::OP_ENDIF)
-		              .push_opcode(opcodes::All::OP_ENDIF)
-		              .into_script()
+		Builder::new()
+			.push_opcode(opcodes::All::OP_DUP)
+			.push_opcode(opcodes::All::OP_HASH160)
+			.push_slice(&Hash160::from_data(&revocation_key.serialize())[..])
+			.push_opcode(opcodes::All::OP_EQUAL)
+			.push_opcode(opcodes::All::OP_IF)
+			.push_opcode(opcodes::All::OP_CHECKSIG)
+			.push_opcode(opcodes::All::OP_ELSE)
+			.push_slice(&b_htlc_key.serialize()[..])
+			.push_opcode(opcodes::All::OP_SWAP)
+			.push_opcode(opcodes::All::OP_SIZE)
+			.push_int(32)
+			.push_opcode(opcodes::All::OP_EQUAL)
+			.push_opcode(opcodes::All::OP_IF)
+			.push_opcode(opcodes::All::OP_HASH160)
+			.push_slice(&payment_hash160)
+			.push_opcode(opcodes::All::OP_EQUALVERIFY)
+			.push_int(2)
+			.push_opcode(opcodes::All::OP_SWAP)
+			.push_slice(&a_htlc_key.serialize()[..])
+			.push_int(2)
+			.push_opcode(opcodes::All::OP_CHECKMULTISIG)
+			.push_opcode(opcodes::All::OP_ELSE)
+			.push_opcode(opcodes::All::OP_DROP)
+			.push_int(htlc.cltv_expiry as i64)
+			.push_opcode(opcodes::OP_CLTV)
+			.push_opcode(opcodes::All::OP_DROP)
+			.push_opcode(opcodes::All::OP_CHECKSIG)
+			.push_opcode(opcodes::All::OP_ENDIF)
+			.push_opcode(opcodes::All::OP_ENDIF)
+			.into_script()
 	}
 }
 
@@ -235,10 +284,22 @@ pub fn get_htlc_redeemscript_with_explicit_keys(htlc: &HTLCOutputInCommitment, a
 /// commitment secret. 'htlc' does *not* need to have its previous_output_index filled.
 #[inline]
 pub fn get_htlc_redeemscript(htlc: &HTLCOutputInCommitment, keys: &TxCreationKeys) -> Script {
-	get_htlc_redeemscript_with_explicit_keys(htlc, &keys.a_htlc_key, &keys.b_htlc_key, &keys.revocation_key)
+	get_htlc_redeemscript_with_explicit_keys(
+		htlc,
+		&keys.a_htlc_key,
+		&keys.b_htlc_key,
+		&keys.revocation_key,
+	)
 }
 
-pub fn build_htlc_transaction(prev_hash: &Sha256dHash, feerate_per_kw: u64, to_self_delay: u16, htlc: &HTLCOutputInCommitment, a_delayed_payment_key: &PublicKey, revocation_key: &PublicKey) -> Transaction {
+pub fn build_htlc_transaction(
+	prev_hash: &Sha256dHash,
+	feerate_per_kw: u64,
+	to_self_delay: u16,
+	htlc: &HTLCOutputInCommitment,
+	a_delayed_payment_key: &PublicKey,
+	revocation_key: &PublicKey,
+) -> Transaction {
 	let mut txins: Vec<TxIn> = Vec::new();
 	txins.push(TxIn {
 		prev_hash: prev_hash.clone(),
@@ -249,20 +310,28 @@ pub fn build_htlc_transaction(prev_hash: &Sha256dHash, feerate_per_kw: u64, to_s
 	});
 
 	let total_fee = if htlc.offered {
-			feerate_per_kw * HTLC_TIMEOUT_TX_WEIGHT / 1000
-		} else {
-			feerate_per_kw * HTLC_SUCCESS_TX_WEIGHT / 1000
-		};
+		feerate_per_kw * HTLC_TIMEOUT_TX_WEIGHT / 1000
+	} else {
+		feerate_per_kw * HTLC_SUCCESS_TX_WEIGHT / 1000
+	};
 
 	let mut txouts: Vec<TxOut> = Vec::new();
 	txouts.push(TxOut {
-		script_pubkey: get_revokeable_redeemscript(revocation_key, to_self_delay, a_delayed_payment_key).to_v0_p2wsh(),
-		value: htlc.amount_msat / 1000 - total_fee //TODO: BOLT 3 does not specify if we should add amount_msat before dividing or if we should divide by 1000 before subtracting (as we do here)
+		script_pubkey: get_revokeable_redeemscript(
+			revocation_key,
+			to_self_delay,
+			a_delayed_payment_key,
+		).to_v0_p2wsh(),
+		value: htlc.amount_msat / 1000 - total_fee, //TODO: BOLT 3 does not specify if we should add amount_msat before dividing or if we should divide by 1000 before subtracting (as we do here)
 	});
 
 	Transaction {
 		version: 2,
-		lock_time: if htlc.offered { htlc.cltv_expiry } else { 0 },
+		lock_time: if htlc.offered {
+			htlc.cltv_expiry
+		} else {
+			0
+		},
 		input: txins,
 		output: txouts,
 	}

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1,38 +1,40 @@
 use bitcoin::blockdata::block::BlockHeader;
-use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::network::constants::Network;
 use bitcoin::network::serialize::BitcoinHash;
 use bitcoin::util::hash::Sha256dHash;
 use bitcoin::util::uint::Uint256;
 
-use secp256k1::key::{SecretKey,PublicKey};
-use secp256k1::{Secp256k1,Message};
-use secp256k1::ecdh::SharedSecret;
 use secp256k1;
+use secp256k1::ecdh::SharedSecret;
+use secp256k1::key::{PublicKey, SecretKey};
+use secp256k1::{Message, Secp256k1};
 
-use chain::chaininterface::{BroadcasterInterface,ChainListener,ChainWatchInterface,FeeEstimator};
+use chain::chaininterface::{
+	BroadcasterInterface, ChainListener, ChainWatchInterface, FeeEstimator,
+};
 use chain::transaction::OutPoint;
 use ln::channel::{Channel, ChannelKeys};
 use ln::channelmonitor::ManyChannelMonitor;
-use ln::router::{Route,RouteHop};
 use ln::msgs;
-use ln::msgs::{HandleError,ChannelMessageHandler,MsgEncodable,MsgDecodable};
-use util::{byte_utils, events, internal_traits, rng};
+use ln::msgs::{ChannelMessageHandler, HandleError, MsgDecodable, MsgEncodable};
+use ln::router::{Route, RouteHop};
 use util::sha2::Sha256;
+use util::{byte_utils, events, internal_traits, rng};
 
 use crypto;
-use crypto::mac::{Mac,MacResult};
-use crypto::hmac::Hmac;
-use crypto::digest::Digest;
-use crypto::symmetriccipher::SynchronousStreamCipher;
 use crypto::chacha20::ChaCha20;
+use crypto::digest::Digest;
+use crypto::hmac::Hmac;
+use crypto::mac::{Mac, MacResult};
+use crypto::symmetriccipher::SynchronousStreamCipher;
 
-use std::sync::{Mutex,MutexGuard,Arc};
-use std::collections::HashMap;
 use std::collections::hash_map;
-use std::{ptr, mem};
-use std::time::{Instant,Duration};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{Duration, Instant};
+use std::{mem, ptr};
 
 mod channel_held_info {
 	use ln::msgs;
@@ -63,20 +65,16 @@ mod channel_held_info {
 
 	#[derive(Clone)] // See Channel::revoke_and_ack for why, tl;dr: Rust bug
 	pub enum HTLCFailReason {
-		ErrorPacket {
-			err: msgs::OnionErrorPacket,
-		},
-		Reason {
-			failure_code: u16,
-			data: Vec<u8>,
-		}
+		ErrorPacket { err: msgs::OnionErrorPacket },
+		Reason { failure_code: u16, data: Vec<u8> },
 	}
 
 	#[cfg(feature = "fuzztarget")]
 	impl HTLCFailReason {
 		pub fn dummy() -> Self {
 			HTLCFailReason::Reason {
-				failure_code: 0, data: Vec::new(),
+				failure_code: 0,
+				data: Vec::new(),
 			}
 		}
 	}
@@ -101,7 +99,7 @@ enum PendingOutboundHTLC {
 		incoming_packet_shared_secret: SharedSecret,
 		route: Route,
 		session_priv: SecretKey,
-	}
+	},
 }
 
 /// We hold back HTLCs we intend to relay for a random interval in the range (this, 5*this). This
@@ -163,12 +161,17 @@ pub struct ChannelManager {
 const CLTV_EXPIRY_DELTA: u16 = 6 * 24 * 2; //TODO?
 
 macro_rules! secp_call {
-	( $res : expr ) => {
+	($res:expr) => {
 		match $res {
 			Ok(key) => key,
 			//TODO: Make the err a parameter!
-			Err(_) => return Err(HandleError{err: "Key error", msg: None})
-		}
+			Err(_) => {
+				return Err(HandleError {
+					err: "Key error",
+					msg: None,
+				})
+				}
+			}
 	};
 }
 
@@ -203,7 +206,16 @@ impl ChannelManager {
 	/// fee_proportional_millionths is an optional fee to charge any payments routed through us.
 	/// Non-proportional fees are fixed according to our risk using the provided fee estimator.
 	/// panics if channel_value_satoshis is >= `MAX_FUNDING_SATOSHIS`!
-	pub fn new(our_network_key: SecretKey, fee_proportional_millionths: u32, announce_channels_publicly: bool, network: Network, feeest: Arc<FeeEstimator>, monitor: Arc<ManyChannelMonitor>, chain_monitor: Arc<ChainWatchInterface>, tx_broadcaster: Arc<BroadcasterInterface>) -> Result<Arc<ChannelManager>, secp256k1::Error> {
+	pub fn new(
+		our_network_key: SecretKey,
+		fee_proportional_millionths: u32,
+		announce_channels_publicly: bool,
+		network: Network,
+		feeest: Arc<FeeEstimator>,
+		monitor: Arc<ManyChannelMonitor>,
+		chain_monitor: Arc<ChainWatchInterface>,
+		tx_broadcaster: Arc<BroadcasterInterface>,
+	) -> Result<Arc<ChannelManager>, secp256k1::Error> {
 		let secp_ctx = Secp256k1::new();
 
 		let res = Arc::new(ChannelManager {
@@ -217,7 +229,7 @@ impl ChannelManager {
 			fee_proportional_millionths,
 			secp_ctx,
 
-			channel_state: Mutex::new(ChannelHolder{
+			channel_state: Mutex::new(ChannelHolder {
 				by_id: HashMap::new(),
 				short_to_id: HashMap::new(),
 				next_forward: Instant::now(),
@@ -233,33 +245,90 @@ impl ChannelManager {
 		Ok(res)
 	}
 
-	pub fn create_channel(&self, their_network_key: PublicKey, channel_value_satoshis: u64, user_id: u64) -> Result<msgs::OpenChannel, HandleError> {
+	pub fn create_channel(
+		&self,
+		their_network_key: PublicKey,
+		channel_value_satoshis: u64,
+		user_id: u64,
+	) -> Result<msgs::OpenChannel, HandleError> {
 		let chan_keys = if cfg!(feature = "fuzztarget") {
 			ChannelKeys {
-				funding_key:               SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				revocation_base_key:       SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				payment_base_key:          SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				delayed_payment_base_key:  SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				htlc_base_key:             SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				channel_close_key:         SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				channel_monitor_claim_key: SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				commitment_seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+				funding_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				revocation_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				payment_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				delayed_payment_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				htlc_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				channel_close_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				channel_monitor_claim_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				commitment_seed: [
+					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0,
+				],
 			}
 		} else {
 			let mut key_seed = [0u8; 32];
 			rng::fill_bytes(&mut key_seed);
 			match ChannelKeys::new_from_seed(&key_seed) {
 				Ok(key) => key,
-				Err(_) => panic!("RNG is busted!")
+				Err(_) => panic!("RNG is busted!"),
 			}
 		};
 
-		let channel = Channel::new_outbound(&*self.fee_estimator, chan_keys, their_network_key, channel_value_satoshis, self.announce_channels_publicly, user_id);
+		let channel = Channel::new_outbound(
+			&*self.fee_estimator,
+			chan_keys,
+			their_network_key,
+			channel_value_satoshis,
+			self.announce_channels_publicly,
+			user_id,
+		);
 		let res = channel.get_open_channel(self.genesis_hash.clone(), &*self.fee_estimator)?;
 		let mut channel_state = self.channel_state.lock().unwrap();
 		match channel_state.by_id.insert(channel.channel_id(), channel) {
 			Some(_) => panic!("RNG is bad???"),
-			None => Ok(res)
+			None => Ok(res),
 		}
 	}
 
@@ -295,21 +364,33 @@ impl ChannelManager {
 							channel_state.short_to_id.remove(&short_id);
 						}
 						(res, Some(chan_entry.remove_entry().1))
-					} else { (res, None) }
-				},
-				hash_map::Entry::Vacant(_) => return Err(HandleError{err: "No such channel", msg: None})
+					} else {
+						(res, None)
+					}
+				}
+				hash_map::Entry::Vacant(_) => {
+					return Err(HandleError {
+						err: "No such channel",
+						msg: None,
+					})
+				}
 			}
 		};
 		for payment_hash in res.1 {
 			// unknown_next_peer...I dunno who that is anymore....
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), &payment_hash, HTLCFailReason::Reason { failure_code: 0x4000 | 10, data: Vec::new() });
+			self.fail_htlc_backwards_internal(
+				self.channel_state.lock().unwrap(),
+				&payment_hash,
+				HTLCFailReason::Reason {
+					failure_code: 0x4000 | 10,
+					data: Vec::new(),
+				},
+			);
 		}
 		if let Some(chan) = chan_option {
 			if let Ok(update) = self.get_channel_update(&chan) {
 				let mut events = self.pending_events.lock().unwrap();
-				events.push(events::Event::BroadcastChannelUpdate {
-					msg: update
-				});
+				events.push(events::Event::BroadcastChannelUpdate { msg: update });
 			}
 		}
 		Ok(res.0)
@@ -317,20 +398,22 @@ impl ChannelManager {
 
 	#[inline]
 	fn gen_rho_mu_from_shared_secret(shared_secret: &SharedSecret) -> ([u8; 32], [u8; 32]) {
-		({
-			let mut hmac = Hmac::new(Sha256::new(), &[0x72, 0x68, 0x6f]); // rho
-			hmac.input(&shared_secret[..]);
-			let mut res = [0; 32];
-			hmac.raw_result(&mut res);
-			res
-		},
-		{
-			let mut hmac = Hmac::new(Sha256::new(), &[0x6d, 0x75]); // mu
-			hmac.input(&shared_secret[..]);
-			let mut res = [0; 32];
-			hmac.raw_result(&mut res);
-			res
-		})
+		(
+			{
+				let mut hmac = Hmac::new(Sha256::new(), &[0x72, 0x68, 0x6f]); // rho
+				hmac.input(&shared_secret[..]);
+				let mut res = [0; 32];
+				hmac.raw_result(&mut res);
+				res
+			},
+			{
+				let mut hmac = Hmac::new(Sha256::new(), &[0x6d, 0x75]); // mu
+				hmac.input(&shared_secret[..]);
+				let mut res = [0; 32];
+				hmac.raw_result(&mut res);
+				res
+			},
+		)
 	}
 
 	#[inline]
@@ -353,7 +436,12 @@ impl ChannelManager {
 
 	// can only fail if an intermediary hop has an invalid public key or session_priv is invalid
 	#[inline]
-	fn construct_onion_keys_callback<FType: FnMut(SharedSecret, [u8; 32], PublicKey, &RouteHop)> (secp_ctx: &Secp256k1, route: &Route, session_priv: &SecretKey, mut callback: FType) -> Result<(), HandleError> {
+	fn construct_onion_keys_callback<FType: FnMut(SharedSecret, [u8; 32], PublicKey, &RouteHop)>(
+		secp_ctx: &Secp256k1,
+		route: &Route,
+		session_priv: &SecretKey,
+		mut callback: FType,
+	) -> Result<(), HandleError> {
 		let mut blinded_priv = session_priv.clone();
 		let mut blinded_pub = secp_call!(PublicKey::from_secret_key(secp_ctx, &blinded_priv));
 		let mut first_iteration = true;
@@ -373,7 +461,10 @@ impl ChannelManager {
 			}
 			let ephemeral_pubkey = blinded_pub;
 
-			secp_call!(blinded_priv.mul_assign(secp_ctx, &secp_call!(SecretKey::from_slice(secp_ctx, &blinding_factor))));
+			secp_call!(blinded_priv.mul_assign(
+				secp_ctx,
+				&secp_call!(SecretKey::from_slice(secp_ctx, &blinding_factor))
+			));
 			blinded_pub = secp_call!(PublicKey::from_secret_key(secp_ctx, &blinded_priv));
 
 			callback(shared_secret, blinding_factor, ephemeral_pubkey, hop);
@@ -383,41 +474,62 @@ impl ChannelManager {
 	}
 
 	// can only fail if an intermediary hop has an invalid public key or session_priv is invalid
-	fn construct_onion_keys(secp_ctx: &Secp256k1, route: &Route, session_priv: &SecretKey) -> Result<Vec<OnionKeys>, HandleError> {
+	fn construct_onion_keys(
+		secp_ctx: &Secp256k1,
+		route: &Route,
+		session_priv: &SecretKey,
+	) -> Result<Vec<OnionKeys>, HandleError> {
 		let mut res = Vec::with_capacity(route.hops.len());
 
-		Self::construct_onion_keys_callback(secp_ctx, route, session_priv, |shared_secret, _blinding_factor, ephemeral_pubkey, _| {
-			let (rho, mu) = ChannelManager::gen_rho_mu_from_shared_secret(&shared_secret);
+		Self::construct_onion_keys_callback(
+			secp_ctx,
+			route,
+			session_priv,
+			|shared_secret, _blinding_factor, ephemeral_pubkey, _| {
+				let (rho, mu) = ChannelManager::gen_rho_mu_from_shared_secret(&shared_secret);
 
-			res.push(OnionKeys {
-				#[cfg(test)]
-				shared_secret,
-				#[cfg(test)]
-				blinding_factor: _blinding_factor,
-				ephemeral_pubkey,
-				rho,
-				mu,
-			});
-		})?;
+				res.push(OnionKeys {
+					#[cfg(test)]
+					shared_secret,
+					#[cfg(test)]
+					blinding_factor: _blinding_factor,
+					ephemeral_pubkey,
+					rho,
+					mu,
+				});
+			},
+		)?;
 
 		Ok(res)
 	}
 
 	/// returns the hop data, as well as the first-hop value_msat and CLTV value we should send.
-	fn build_onion_payloads(route: &Route) -> Result<(Vec<msgs::OnionHopData>, u64, u32), HandleError> {
+	fn build_onion_payloads(
+		route: &Route,
+	) -> Result<(Vec<msgs::OnionHopData>, u64, u32), HandleError> {
 		let mut cur_value_msat = 0u64;
 		let mut cur_cltv = 0u32;
 		let mut last_short_channel_id = 0;
 		let mut res: Vec<msgs::OnionHopData> = Vec::with_capacity(route.hops.len());
 		internal_traits::test_no_dealloc::<msgs::OnionHopData>(None);
-		unsafe { res.set_len(route.hops.len()); }
+		unsafe {
+			res.set_len(route.hops.len());
+		}
 
 		for (idx, hop) in route.hops.iter().enumerate().rev() {
 			// First hop gets special values so that it can check, on receipt, that everything is
 			// exactly as it should be (and the next hop isn't trying to probe to find out if we're
 			// the intended recipient).
-			let value_msat = if cur_value_msat == 0 { hop.fee_msat } else { cur_value_msat };
-			let cltv = if cur_cltv == 0 { hop.cltv_expiry_delta } else { cur_cltv };
+			let value_msat = if cur_value_msat == 0 {
+				hop.fee_msat
+			} else {
+				cur_value_msat
+			};
+			let cltv = if cur_cltv == 0 {
+				hop.cltv_expiry_delta
+			} else {
+				cur_cltv
+			};
 			res[idx] = msgs::OnionHopData {
 				realm: 0,
 				data: msgs::OnionRealm0HopData {
@@ -429,11 +541,17 @@ impl ChannelManager {
 			};
 			cur_value_msat += hop.fee_msat;
 			if cur_value_msat >= 21000000 * 100000000 * 1000 {
-				return Err(HandleError{err: "Channel fees overflowed?!", msg: None});
+				return Err(HandleError {
+					err: "Channel fees overflowed?!",
+					msg: None,
+				});
 			}
 			cur_cltv += hop.cltv_expiry_delta as u32;
 			if cur_cltv >= 500000000 {
-				return Err(HandleError{err: "Channel CLTV overflowed?!", msg: None});
+				return Err(HandleError {
+					err: "Channel CLTV overflowed?!",
+					msg: None,
+				});
 			}
 			last_short_channel_id = hop.short_channel_id;
 		}
@@ -441,9 +559,9 @@ impl ChannelManager {
 	}
 
 	#[inline]
-	fn shift_arr_right(arr: &mut [u8; 20*65]) {
+	fn shift_arr_right(arr: &mut [u8; 20 * 65]) {
 		unsafe {
-			ptr::copy(arr[0..].as_ptr(), arr[65..].as_mut_ptr(), 19*65);
+			ptr::copy(arr[0..].as_ptr(), arr[65..].as_mut_ptr(), 19 * 65);
 		}
 		for i in 0..65 {
 			arr[i] = 0;
@@ -451,7 +569,7 @@ impl ChannelManager {
 	}
 
 	#[inline]
-	fn xor_bufs(dst: &mut[u8], src: &[u8]) {
+	fn xor_bufs(dst: &mut [u8], src: &[u8]) {
 		assert_eq!(dst.len(), src.len());
 
 		for i in 0..dst.len() {
@@ -459,10 +577,14 @@ impl ChannelManager {
 		}
 	}
 
-	const ZERO:[u8; 21*65] = [0; 21*65];
-	fn construct_onion_packet(mut payloads: Vec<msgs::OnionHopData>, onion_keys: Vec<OnionKeys>, associated_data: Vec<u8>) -> Result<msgs::OnionPacket, HandleError> {
-		let mut buf = Vec::with_capacity(21*65);
-		buf.resize(21*65, 0);
+	const ZERO: [u8; 21 * 65] = [0; 21 * 65];
+	fn construct_onion_packet(
+		mut payloads: Vec<msgs::OnionHopData>,
+		onion_keys: Vec<OnionKeys>,
+		associated_data: Vec<u8>,
+	) -> Result<msgs::OnionPacket, HandleError> {
+		let mut buf = Vec::with_capacity(21 * 65);
+		buf.resize(21 * 65, 0);
 
 		let filler = {
 			let iters = payloads.len() - 1;
@@ -471,15 +593,17 @@ impl ChannelManager {
 			res.resize(end_len, 0);
 
 			for (i, keys) in onion_keys.iter().enumerate() {
-				if i == payloads.len() - 1 { continue; }
+				if i == payloads.len() - 1 {
+					continue;
+				}
 				let mut chacha = ChaCha20::new(&keys.rho, &[0u8; 8]);
 				chacha.process(&ChannelManager::ZERO, &mut buf); // We don't have a seek function :(
-				ChannelManager::xor_bufs(&mut res[0..(i + 1)*65], &buf[(20 - i)*65..21*65]);
+				ChannelManager::xor_bufs(&mut res[0..(i + 1) * 65], &buf[(20 - i) * 65..21 * 65]);
 			}
 			res
 		};
 
-		let mut packet_data = [0; 20*65];
+		let mut packet_data = [0; 20 * 65];
 		let mut hmac_res = [0; 32];
 
 		for (i, (payload, keys)) in payloads.iter_mut().zip(onion_keys.iter()).rev().enumerate() {
@@ -488,11 +612,11 @@ impl ChannelManager {
 			packet_data[0..65].copy_from_slice(&payload.encode()[..]);
 
 			let mut chacha = ChaCha20::new(&keys.rho, &[0u8; 8]);
-			chacha.process(&packet_data, &mut buf[0..20*65]);
-			packet_data[..].copy_from_slice(&buf[0..20*65]);
+			chacha.process(&packet_data, &mut buf[0..20 * 65]);
+			packet_data[..].copy_from_slice(&buf[0..20 * 65]);
 
 			if i == 0 {
-				packet_data[20*65 - filler.len()..20*65].copy_from_slice(&filler[..]);
+				packet_data[20 * 65 - filler.len()..20 * 65].copy_from_slice(&filler[..]);
 			}
 
 			let mut hmac = Hmac::new(Sha256::new(), &keys.mu);
@@ -501,7 +625,7 @@ impl ChannelManager {
 			hmac.raw_result(&mut hmac_res);
 		}
 
-		Ok(msgs::OnionPacket{
+		Ok(msgs::OnionPacket {
 			version: 0,
 			public_key: onion_keys.first().unwrap().ephemeral_pubkey,
 			hop_data: packet_data,
@@ -511,7 +635,10 @@ impl ChannelManager {
 
 	/// Encrypts a failure packet. raw_packet can either be a
 	/// msgs::DecodedOnionErrorPacket.encode() result or a msgs::OnionErrorPacket.data element.
-	fn encrypt_failure_packet(shared_secret: &SharedSecret, raw_packet: &[u8]) -> msgs::OnionErrorPacket {
+	fn encrypt_failure_packet(
+		shared_secret: &SharedSecret,
+		raw_packet: &[u8],
+	) -> msgs::OnionErrorPacket {
 		let ammag = ChannelManager::gen_ammag_from_shared_secret(&shared_secret);
 
 		let mut packet_crypted = Vec::with_capacity(raw_packet.len());
@@ -523,7 +650,11 @@ impl ChannelManager {
 		}
 	}
 
-	fn build_failure_packet(shared_secret: &SharedSecret, failure_type: u16, failure_data: &[u8]) -> msgs::DecodedOnionErrorPacket {
+	fn build_failure_packet(
+		shared_secret: &SharedSecret,
+		failure_type: u16,
+		failure_data: &[u8],
+	) -> msgs::DecodedOnionErrorPacket {
 		assert!(failure_data.len() <= 256 - 2);
 
 		let um = ChannelManager::gen_um_from_shared_secret(&shared_secret);
@@ -554,19 +685,31 @@ impl ChannelManager {
 	}
 
 	#[inline]
-	fn build_first_hop_failure_packet(shared_secret: &SharedSecret, failure_type: u16, failure_data: &[u8]) -> msgs::OnionErrorPacket {
-		let failure_packet = ChannelManager::build_failure_packet(shared_secret, failure_type, failure_data);
+	fn build_first_hop_failure_packet(
+		shared_secret: &SharedSecret,
+		failure_type: u16,
+		failure_data: &[u8],
+	) -> msgs::OnionErrorPacket {
+		let failure_packet =
+			ChannelManager::build_failure_packet(shared_secret, failure_type, failure_data);
 		ChannelManager::encrypt_failure_packet(shared_secret, &failure_packet.encode()[..])
 	}
 
 	/// only fails if the channel does not yet have an assigned short_id
 	fn get_channel_update(&self, chan: &Channel) -> Result<msgs::ChannelUpdate, HandleError> {
 		let short_channel_id = match chan.get_short_channel_id() {
-			None => return Err(HandleError{err: "Channel not yet established", msg: None}),
+			None => {
+				return Err(HandleError {
+					err: "Channel not yet established",
+					msg: None,
+				})
+			}
 			Some(id) => id,
 		};
 
-		let were_node_one = PublicKey::from_secret_key(&self.secp_ctx, &self.our_network_key).unwrap().serialize()[..] < chan.get_their_node_id().serialize()[..];
+		let were_node_one = PublicKey::from_secret_key(&self.secp_ctx, &self.our_network_key)
+			.unwrap()
+			.serialize()[..] < chan.get_their_node_id().serialize()[..];
 
 		let unsigned = msgs::UnsignedChannelUpdate {
 			chain_hash: self.genesis_hash,
@@ -580,11 +723,16 @@ impl ChannelManager {
 		};
 
 		let msg_hash = Sha256dHash::from_data(&unsigned.encode()[..]);
-		let sig = self.secp_ctx.sign(&Message::from_slice(&msg_hash[..]).unwrap(), &self.our_network_key).unwrap(); //TODO Can we unwrap here?
+		let sig = self.secp_ctx
+			.sign(
+				&Message::from_slice(&msg_hash[..]).unwrap(),
+				&self.our_network_key,
+			)
+			.unwrap(); //TODO Can we unwrap here?
 
 		Ok(msgs::ChannelUpdate {
 			signature: sig,
-			contents: unsigned
+			contents: unsigned,
 		})
 	}
 
@@ -595,12 +743,18 @@ impl ChannelManager {
 	/// May generate a SendHTLCs event on success, which should be relayed.
 	pub fn send_payment(&self, route: Route, payment_hash: [u8; 32]) -> Result<(), HandleError> {
 		if route.hops.len() < 1 || route.hops.len() > 20 {
-			return Err(HandleError{err: "Route didn't go anywhere/had bogus size", msg: None});
+			return Err(HandleError {
+				err: "Route didn't go anywhere/had bogus size",
+				msg: None,
+			});
 		}
 		let our_node_id = self.get_our_node_id();
 		for (idx, hop) in route.hops.iter().enumerate() {
 			if idx != route.hops.len() - 1 && hop.pubkey == our_node_id {
-				return Err(HandleError{err: "Route went through us but wasn't a simple rebalance loop to us", msg: None});
+				return Err(HandleError {
+					err: "Route went through us but wasn't a simple rebalance loop to us",
+					msg: None,
+				});
 			}
 		}
 
@@ -612,30 +766,50 @@ impl ChannelManager {
 
 		let associated_data = Vec::new(); //TODO: What to put here?
 
-		let onion_keys = ChannelManager::construct_onion_keys(&self.secp_ctx, &route, &session_priv)?;
+		let onion_keys =
+			ChannelManager::construct_onion_keys(&self.secp_ctx, &route, &session_priv)?;
 		let (onion_payloads, htlc_msat, htlc_cltv) = ChannelManager::build_onion_payloads(&route)?;
-		let onion_packet = ChannelManager::construct_onion_packet(onion_payloads, onion_keys, associated_data)?;
+		let onion_packet =
+			ChannelManager::construct_onion_packet(onion_payloads, onion_keys, associated_data)?;
 
 		let (first_hop_node_id, (update_add, commitment_signed, chan_monitor)) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
-			let id = match channel_state.short_to_id.get(&route.hops.first().unwrap().short_channel_id) {
-				None => return Err(HandleError{err: "No channel available with first hop!", msg: None}),
-				Some(id) => id.clone()
+			let id = match channel_state
+				.short_to_id
+				.get(&route.hops.first().unwrap().short_channel_id)
+			{
+				None => {
+					return Err(HandleError {
+						err: "No channel available with first hop!",
+						msg: None,
+					})
+				}
+				Some(id) => id.clone(),
 			};
 			let res = {
 				let chan = channel_state.by_id.get_mut(&id).unwrap();
 				if chan.get_their_node_id() != route.hops.first().unwrap().pubkey {
-					return Err(HandleError{err: "Node ID mismatch on first hop!", msg: None});
+					return Err(HandleError {
+						err: "Node ID mismatch on first hop!",
+						msg: None,
+					});
 				}
 				chan.send_htlc_and_commit(htlc_msat, payment_hash.clone(), htlc_cltv, onion_packet)?
 			};
 
 			let first_hop_node_id = route.hops.first().unwrap().pubkey;
 
-			if channel_state.claimable_htlcs.insert(payment_hash, PendingOutboundHTLC::OutboundRoute {
-				route,
-				session_priv,
-			}).is_some() {
+			if channel_state
+				.claimable_htlcs
+				.insert(
+					payment_hash,
+					PendingOutboundHTLC::OutboundRoute {
+						route,
+						session_priv,
+					},
+				)
+				.is_some()
+			{
 				// TODO: We need to track these better, we're not generating these, so a
 				// third-party might make this happen:
 				panic!("payment_hash was repeated! Don't let this happen");
@@ -647,7 +821,9 @@ impl ChannelManager {
 			}
 		};
 
-		if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
+		if let Err(_e) = self.monitor
+			.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor)
+		{
 			unimplemented!(); // maybe remove from claimable_htlcs?
 		}
 
@@ -662,25 +838,29 @@ impl ChannelManager {
 
 	/// Call this upon creation of a funding transaction for the given channel.
 	/// Panics if a funding transaction has already been provided for this channel.
-	pub fn funding_transaction_generated(&self, temporary_channel_id: &Uint256, funding_txo: OutPoint) {
+	pub fn funding_transaction_generated(
+		&self,
+		temporary_channel_id: &Uint256,
+		funding_txo: OutPoint,
+	) {
 		let (chan, msg, chan_monitor) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			match channel_state.by_id.remove(&temporary_channel_id) {
 				Some(mut chan) => {
 					match chan.get_outbound_funding_created(funding_txo) {
-						Ok(funding_msg) => {
-							(chan, funding_msg.0, funding_msg.1)
-						},
+						Ok(funding_msg) => (chan, funding_msg.0, funding_msg.1),
 						Err(_e) => {
 							//TODO: Push e to pendingevents
 							return;
 						}
 					}
-				},
-				None => return
+				}
+				None => return,
 			}
 		}; // Release channel lock for install_watch_outpoint call,
-		if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
+		if let Err(_e) = self.monitor
+			.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor)
+		{
 			unimplemented!(); // maybe remove from claimable_htlcs?
 		}
 		{
@@ -695,11 +875,18 @@ impl ChannelManager {
 		channel_state.by_id.insert(chan.channel_id(), chan);
 	}
 
-	fn get_announcement_sigs(&self, chan: &Channel) -> Result<Option<msgs::AnnouncementSignatures>, HandleError> {
-		if !chan.is_usable() { return Ok(None) }
+	fn get_announcement_sigs(
+		&self,
+		chan: &Channel,
+	) -> Result<Option<msgs::AnnouncementSignatures>, HandleError> {
+		if !chan.is_usable() {
+			return Ok(None);
+		}
 
-		let (announcement, our_bitcoin_sig) = chan.get_channel_announcement(self.get_our_node_id(), self.genesis_hash.clone())?;
-		let msghash = Message::from_slice(&Sha256dHash::from_data(&announcement.encode()[..])[..]).unwrap();
+		let (announcement, our_bitcoin_sig) =
+			chan.get_channel_announcement(self.get_our_node_id(), self.genesis_hash.clone())?;
+		let msghash =
+			Message::from_slice(&Sha256dHash::from_data(&announcement.encode()[..])[..]).unwrap();
 		let our_node_sig = secp_call!(self.secp_ctx.sign(&msghash, &self.our_network_key));
 
 		Ok(Some(msgs::AnnouncementSignatures {
@@ -728,7 +915,11 @@ impl ChannelManager {
 						None => {
 							failed_forwards.reserve(pending_forwards.len());
 							for forward_info in pending_forwards {
-								failed_forwards.push((forward_info.payment_hash, 0x4000 | 10, None));
+								failed_forwards.push((
+									forward_info.payment_hash,
+									0x4000 | 10,
+									None,
+								));
 							}
 							// TODO: Send a failure packet back on each pending_forward
 							continue;
@@ -738,15 +929,26 @@ impl ChannelManager {
 
 					let mut add_htlc_msgs = Vec::new();
 					for forward_info in pending_forwards {
-						match forward_chan.send_htlc(forward_info.amt_to_forward, forward_info.payment_hash, forward_info.outgoing_cltv_value, forward_info.onion_packet.unwrap()) {
+						match forward_chan.send_htlc(
+							forward_info.amt_to_forward,
+							forward_info.payment_hash,
+							forward_info.outgoing_cltv_value,
+							forward_info.onion_packet.unwrap(),
+						) {
 							Err(_e) => {
 								let chan_update = self.get_channel_update(forward_chan).unwrap();
-								failed_forwards.push((forward_info.payment_hash, 0x4000 | 7, Some(chan_update)));
+								failed_forwards.push((
+									forward_info.payment_hash,
+									0x4000 | 7,
+									Some(chan_update),
+								));
 								continue;
-							},
+							}
 							Ok(update_add) => {
 								match update_add {
-									Some(msg) => { add_htlc_msgs.push(msg); },
+									Some(msg) => {
+										add_htlc_msgs.push(msg);
+									}
 									None => {
 										// Nothing to do here...we're waiting on a remote
 										// revoke_and_ack before we can add anymore HTLCs. The Channel
@@ -767,20 +969,26 @@ impl ChannelManager {
 							Err(_) => {
 								//TODO: Handle...this is bad!
 								continue;
-							},
+							}
 						};
-						new_events.push((Some(monitor), events::Event::SendHTLCs {
-							node_id: forward_chan.get_their_node_id(),
-							msgs: add_htlc_msgs,
-							commitment_msg: commitment_msg,
-						}));
+						new_events.push((
+							Some(monitor),
+							events::Event::SendHTLCs {
+								node_id: forward_chan.get_their_node_id(),
+								msgs: add_htlc_msgs,
+								commitment_msg: commitment_msg,
+							},
+						));
 					}
 				} else {
 					for forward_info in pending_forwards {
-						new_events.push((None, events::Event::PaymentReceived {
-							payment_hash: forward_info.payment_hash,
-							amt: forward_info.amt_to_forward,
-						}));
+						new_events.push((
+							None,
+							events::Event::PaymentReceived {
+								payment_hash: forward_info.payment_hash,
+								amt: forward_info.amt_to_forward,
+							},
+						));
 					}
 				}
 			}
@@ -788,17 +996,35 @@ impl ChannelManager {
 
 		for failed_forward in failed_forwards.drain(..) {
 			match failed_forward.2 {
-				None => self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), &failed_forward.0, HTLCFailReason::Reason { failure_code: failed_forward.1, data: Vec::new() }),
-				Some(chan_update) => self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), &failed_forward.0, HTLCFailReason::Reason { failure_code: failed_forward.1, data: chan_update.encode_with_len() }),
+				None => self.fail_htlc_backwards_internal(
+					self.channel_state.lock().unwrap(),
+					&failed_forward.0,
+					HTLCFailReason::Reason {
+						failure_code: failed_forward.1,
+						data: Vec::new(),
+					},
+				),
+				Some(chan_update) => self.fail_htlc_backwards_internal(
+					self.channel_state.lock().unwrap(),
+					&failed_forward.0,
+					HTLCFailReason::Reason {
+						failure_code: failed_forward.1,
+						data: chan_update.encode_with_len(),
+					},
+				),
 			};
 		}
 
-		if new_events.is_empty() { return }
+		if new_events.is_empty() {
+			return;
+		}
 
 		new_events.retain(|event| {
 			if let &Some(ref monitor) = &event.0 {
-				if let Err(_e) = self.monitor.add_update_monitor(monitor.get_funding_txo().unwrap(), monitor.clone()) {
-					unimplemented!();// but def dont push the event...
+				if let Err(_e) = self.monitor
+					.add_update_monitor(monitor.get_funding_txo().unwrap(), monitor.clone())
+				{
+					unimplemented!(); // but def dont push the event...
 				}
 			}
 			true
@@ -813,10 +1039,22 @@ impl ChannelManager {
 
 	/// Indicates that the preimage for payment_hash is unknown after a PaymentReceived event.
 	pub fn fail_htlc_backwards(&self, payment_hash: &[u8; 32]) -> bool {
-		self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), payment_hash, HTLCFailReason::Reason { failure_code: 0x4000 | 15, data: Vec::new() })
+		self.fail_htlc_backwards_internal(
+			self.channel_state.lock().unwrap(),
+			payment_hash,
+			HTLCFailReason::Reason {
+				failure_code: 0x4000 | 15,
+				data: Vec::new(),
+			},
+		)
 	}
 
-	fn fail_htlc_backwards_internal(&self, mut channel_state: MutexGuard<ChannelHolder>, payment_hash: &[u8; 32], onion_error: HTLCFailReason) -> bool {
+	fn fail_htlc_backwards_internal(
+		&self,
+		mut channel_state: MutexGuard<ChannelHolder>,
+		payment_hash: &[u8; 32],
+		onion_error: HTLCFailReason,
+	) -> bool {
 		let mut pending_htlc = {
 			match channel_state.claimable_htlcs.remove(payment_hash) {
 				Some(pending_htlc) => pending_htlc,
@@ -825,42 +1063,66 @@ impl ChannelManager {
 		};
 
 		match pending_htlc {
-			PendingOutboundHTLC::CycledRoute { source_short_channel_id, incoming_packet_shared_secret, route, session_priv } => {
-				channel_state.claimable_htlcs.insert(payment_hash.clone(), PendingOutboundHTLC::OutboundRoute {
-					route,
-					session_priv,
-				});
-				pending_htlc = PendingOutboundHTLC::IntermediaryHopData { source_short_channel_id, incoming_packet_shared_secret };
-			},
+			PendingOutboundHTLC::CycledRoute {
+				source_short_channel_id,
+				incoming_packet_shared_secret,
+				route,
+				session_priv,
+			} => {
+				channel_state.claimable_htlcs.insert(
+					payment_hash.clone(),
+					PendingOutboundHTLC::OutboundRoute {
+						route,
+						session_priv,
+					},
+				);
+				pending_htlc = PendingOutboundHTLC::IntermediaryHopData {
+					source_short_channel_id,
+					incoming_packet_shared_secret,
+				};
+			}
 			_ => {}
 		}
 
 		match pending_htlc {
-			PendingOutboundHTLC::CycledRoute { .. } => { panic!("WAT"); },
+			PendingOutboundHTLC::CycledRoute { .. } => {
+				panic!("WAT");
+			}
 			PendingOutboundHTLC::OutboundRoute { .. } => {
 				mem::drop(channel_state);
 
 				let mut pending_events = self.pending_events.lock().unwrap();
 				pending_events.push(events::Event::PaymentFailed {
-					payment_hash: payment_hash.clone()
+					payment_hash: payment_hash.clone(),
 				});
 				false
-			},
-			PendingOutboundHTLC::IntermediaryHopData { source_short_channel_id, incoming_packet_shared_secret } => {
+			}
+			PendingOutboundHTLC::IntermediaryHopData {
+				source_short_channel_id,
+				incoming_packet_shared_secret,
+			} => {
 				let err_packet = match onion_error {
 					HTLCFailReason::Reason { failure_code, data } => {
-						let packet = ChannelManager::build_failure_packet(&incoming_packet_shared_secret, failure_code, &data[..]).encode();
-						ChannelManager::encrypt_failure_packet(&incoming_packet_shared_secret, &packet)
-					},
-					HTLCFailReason::ErrorPacket { err } => {
-						ChannelManager::encrypt_failure_packet(&incoming_packet_shared_secret, &err.data)
+						let packet = ChannelManager::build_failure_packet(
+							&incoming_packet_shared_secret,
+							failure_code,
+							&data[..],
+						).encode();
+						ChannelManager::encrypt_failure_packet(
+							&incoming_packet_shared_secret,
+							&packet,
+						)
 					}
+					HTLCFailReason::ErrorPacket { err } => ChannelManager::encrypt_failure_packet(
+						&incoming_packet_shared_secret,
+						&err.data,
+					),
 				};
 
 				let (node_id, fail_msgs) = {
 					let chan_id = match channel_state.short_to_id.get(&source_short_channel_id) {
 						Some(chan_id) => chan_id.clone(),
-						None => return false
+						None => return false,
 					};
 
 					let chan = channel_state.by_id.get_mut(&chan_id).unwrap();
@@ -869,7 +1131,7 @@ impl ChannelManager {
 						Err(_e) => {
 							//TODO: Do something with e?
 							return false;
-						},
+						}
 					}
 				};
 
@@ -877,8 +1139,11 @@ impl ChannelManager {
 					Some((msg, commitment_msg, chan_monitor)) => {
 						mem::drop(channel_state);
 
-						if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
-							unimplemented!();// but def dont push the event...
+						if let Err(_e) = self.monitor.add_update_monitor(
+							chan_monitor.get_funding_txo().unwrap(),
+							chan_monitor,
+						) {
+							unimplemented!(); // but def dont push the event...
 						}
 
 						let mut pending_events = self.pending_events.lock().unwrap();
@@ -887,12 +1152,12 @@ impl ChannelManager {
 							msg: msg,
 							commitment_msg: commitment_msg,
 						});
-					},
-					None => {},
+					}
+					None => {}
 				}
 
 				true
-			},
+			}
 		}
 	}
 
@@ -918,37 +1183,65 @@ impl ChannelManager {
 		};
 
 		match pending_htlc {
-			PendingOutboundHTLC::CycledRoute { source_short_channel_id, incoming_packet_shared_secret, route, session_priv } => {
-				if from_user { // This was the end hop back to us
-					pending_htlc = PendingOutboundHTLC::IntermediaryHopData { source_short_channel_id, incoming_packet_shared_secret };
-					channel_state.claimable_htlcs.insert(payment_hash, PendingOutboundHTLC::OutboundRoute { route, session_priv });
-				} else { // This came from the first upstream node
+			PendingOutboundHTLC::CycledRoute {
+				source_short_channel_id,
+				incoming_packet_shared_secret,
+				route,
+				session_priv,
+			} => {
+				if from_user {
+					// This was the end hop back to us
+					pending_htlc = PendingOutboundHTLC::IntermediaryHopData {
+						source_short_channel_id,
+						incoming_packet_shared_secret,
+					};
+					channel_state.claimable_htlcs.insert(
+						payment_hash,
+						PendingOutboundHTLC::OutboundRoute {
+							route,
+							session_priv,
+						},
+					);
+				} else {
+					// This came from the first upstream node
 					// Bank error in our favor! Maybe we should tell the user this somehow???
-					pending_htlc = PendingOutboundHTLC::OutboundRoute { route, session_priv };
-					channel_state.claimable_htlcs.insert(payment_hash, PendingOutboundHTLC::IntermediaryHopData { source_short_channel_id, incoming_packet_shared_secret });
+					pending_htlc = PendingOutboundHTLC::OutboundRoute {
+						route,
+						session_priv,
+					};
+					channel_state.claimable_htlcs.insert(
+						payment_hash,
+						PendingOutboundHTLC::IntermediaryHopData {
+							source_short_channel_id,
+							incoming_packet_shared_secret,
+						},
+					);
 				}
-			},
-			_ => {},
+			}
+			_ => {}
 		}
 
 		match pending_htlc {
-			PendingOutboundHTLC::CycledRoute { .. } => { panic!("WAT"); },
+			PendingOutboundHTLC::CycledRoute { .. } => {
+				panic!("WAT");
+			}
 			PendingOutboundHTLC::OutboundRoute { .. } => {
 				if from_user {
 					panic!("Called claim_funds with a preimage for an outgoing payment. There is nothing we can do with this, and something is seriously wrong if you knew this...");
 				}
 				mem::drop(channel_state);
 				let mut pending_events = self.pending_events.lock().unwrap();
-				pending_events.push(events::Event::PaymentSent {
-					payment_preimage
-				});
+				pending_events.push(events::Event::PaymentSent { payment_preimage });
 				false
-			},
-			PendingOutboundHTLC::IntermediaryHopData { source_short_channel_id, .. } => {
+			}
+			PendingOutboundHTLC::IntermediaryHopData {
+				source_short_channel_id,
+				..
+			} => {
 				let (node_id, fulfill_msgs) = {
 					let chan_id = match channel_state.short_to_id.get(&source_short_channel_id) {
 						Some(chan_id) => chan_id.clone(),
-						None => return false
+						None => return false,
 					};
 
 					let chan = channel_state.by_id.get_mut(&chan_id).unwrap();
@@ -957,15 +1250,18 @@ impl ChannelManager {
 						Err(_e) => {
 							//TODO: Do something with e?
 							return false;
-						},
+						}
 					}
 				};
 
 				mem::drop(channel_state);
 				match fulfill_msgs {
 					Some((msg, commitment_msg, chan_monitor)) => {
-						if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
-							unimplemented!();// but def dont push the event...
+						if let Err(_e) = self.monitor.add_update_monitor(
+							chan_monitor.get_funding_txo().unwrap(),
+							chan_monitor,
+						) {
+							unimplemented!(); // but def dont push the event...
 						}
 
 						let mut pending_events = self.pending_events.lock().unwrap();
@@ -974,11 +1270,11 @@ impl ChannelManager {
 							msg,
 							commitment_msg,
 						});
-					},
-					None => {},
+					}
+					None => {}
 				}
 				true
-			},
+			}
 		}
 	}
 
@@ -1005,14 +1301,22 @@ impl events::EventsProvider for ChannelManager {
 }
 
 impl ChainListener for ChannelManager {
-	fn block_connected(&self, header: &BlockHeader, height: u32, txn_matched: &[&Transaction], indexes_of_txn_matched: &[u32]) {
+	fn block_connected(
+		&self,
+		header: &BlockHeader,
+		height: u32,
+		txn_matched: &[&Transaction],
+		indexes_of_txn_matched: &[u32],
+	) {
 		let mut new_events = Vec::new();
 		{
 			let mut channel_state = self.channel_state.lock().unwrap();
 			let mut short_to_ids_to_insert = Vec::new();
 			let mut short_to_ids_to_remove = Vec::new();
 			channel_state.by_id.retain(|_, channel| {
-				if let Some(funding_locked) = channel.block_connected(header, height, txn_matched, indexes_of_txn_matched) {
+				if let Some(funding_locked) =
+					channel.block_connected(header, height, txn_matched, indexes_of_txn_matched)
+				{
 					let announcement_sigs = match self.get_announcement_sigs(channel) {
 						Ok(res) => res,
 						Err(_e) => {
@@ -1023,21 +1327,26 @@ impl ChainListener for ChannelManager {
 					new_events.push(events::Event::SendFundingLocked {
 						node_id: channel.get_their_node_id(),
 						msg: funding_locked,
-						announcement_sigs: announcement_sigs
+						announcement_sigs: announcement_sigs,
 					});
-					short_to_ids_to_insert.push((channel.get_short_channel_id().unwrap(), channel.channel_id()));
+					short_to_ids_to_insert.push((
+						channel.get_short_channel_id().unwrap(),
+						channel.channel_id(),
+					));
 				}
 				if let Some(funding_txo) = channel.get_funding_txo() {
 					for tx in txn_matched {
 						for inp in tx.input.iter() {
-							if inp.prev_hash == funding_txo.txid && inp.prev_index == funding_txo.index as u32 {
+							if inp.prev_hash == funding_txo.txid
+								&& inp.prev_index == funding_txo.index as u32
+							{
 								if let Some(short_id) = channel.get_short_channel_id() {
 									short_to_ids_to_remove.push(short_id);
 								}
 								channel.force_shutdown();
 								if let Ok(update) = self.get_channel_update(&channel) {
 									new_events.push(events::Event::BroadcastChannelUpdate {
-										msg: update
+										msg: update,
 									});
 								}
 								return false;
@@ -1051,9 +1360,7 @@ impl ChainListener for ChannelManager {
 					}
 					channel.force_shutdown();
 					if let Ok(update) = self.get_channel_update(&channel) {
-						new_events.push(events::Event::BroadcastChannelUpdate {
-							msg: update
-						});
+						new_events.push(events::Event::BroadcastChannelUpdate { msg: update });
 					}
 					return false;
 				}
@@ -1084,53 +1391,131 @@ impl ChainListener for ChannelManager {
 
 impl ChannelMessageHandler for ChannelManager {
 	//TODO: Handle errors and close channel (or so)
-	fn handle_open_channel(&self, their_node_id: &PublicKey, msg: &msgs::OpenChannel) -> Result<msgs::AcceptChannel, HandleError> {
+	fn handle_open_channel(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::OpenChannel,
+	) -> Result<msgs::AcceptChannel, HandleError> {
 		if msg.chain_hash != self.genesis_hash {
-			return Err(HandleError{err: "Unknown genesis block hash", msg: None});
+			return Err(HandleError {
+				err: "Unknown genesis block hash",
+				msg: None,
+			});
 		}
 		let mut channel_state = self.channel_state.lock().unwrap();
 		if channel_state.by_id.contains_key(&msg.temporary_channel_id) {
-			return Err(HandleError{err: "temporary_channel_id collision!", msg: None});
+			return Err(HandleError {
+				err: "temporary_channel_id collision!",
+				msg: None,
+			});
 		}
 
 		let chan_keys = if cfg!(feature = "fuzztarget") {
 			ChannelKeys {
-				funding_key:               SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				revocation_base_key:       SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				payment_base_key:          SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				delayed_payment_base_key:  SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				htlc_base_key:             SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				channel_close_key:         SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				channel_monitor_claim_key: SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).unwrap(),
-				commitment_seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+				funding_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				revocation_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				payment_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				delayed_payment_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				htlc_base_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				channel_close_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				channel_monitor_claim_key: SecretKey::from_slice(
+					&self.secp_ctx,
+					&[
+						0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+						0, 0, 0, 0, 0, 0, 0, 0,
+					],
+				).unwrap(),
+				commitment_seed: [
+					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+					0, 0, 0, 0, 0, 0,
+				],
 			}
 		} else {
 			let mut key_seed = [0u8; 32];
 			rng::fill_bytes(&mut key_seed);
 			match ChannelKeys::new_from_seed(&key_seed) {
 				Ok(key) => key,
-				Err(_) => panic!("RNG is busted!")
+				Err(_) => panic!("RNG is busted!"),
 			}
 		};
 
-		let channel = Channel::new_from_req(&*self.fee_estimator, chan_keys, their_node_id.clone(), msg, 0, self.announce_channels_publicly)?;
+		let channel = Channel::new_from_req(
+			&*self.fee_estimator,
+			chan_keys,
+			their_node_id.clone(),
+			msg,
+			0,
+			self.announce_channels_publicly,
+		)?;
 		let accept_msg = channel.get_accept_channel()?;
 		channel_state.by_id.insert(channel.channel_id(), channel);
 		Ok(accept_msg)
 	}
 
-	fn handle_accept_channel(&self, their_node_id: &PublicKey, msg: &msgs::AcceptChannel) -> Result<(), HandleError> {
+	fn handle_accept_channel(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::AcceptChannel,
+	) -> Result<(), HandleError> {
 		let (value, output_script, user_id) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			match channel_state.by_id.get_mut(&msg.temporary_channel_id) {
 				Some(chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					chan.accept_channel(&msg)?;
-					(chan.get_value_satoshis(), chan.get_funding_redeemscript().to_v0_p2wsh(), chan.get_user_id())
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+					(
+						chan.get_value_satoshis(),
+						chan.get_funding_redeemscript().to_v0_p2wsh(),
+						chan.get_user_id(),
+					)
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
 		let mut pending_events = self.pending_events.lock().unwrap();
@@ -1143,7 +1528,11 @@ impl ChannelMessageHandler for ChannelManager {
 		Ok(())
 	}
 
-	fn handle_funding_created(&self, their_node_id: &PublicKey, msg: &msgs::FundingCreated) -> Result<msgs::FundingSigned, HandleError> {
+	fn handle_funding_created(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::FundingCreated,
+	) -> Result<msgs::FundingSigned, HandleError> {
 		//TODO: broke this - a node shouldn't be able to get their channel removed by sending a
 		//funding_created a second time, or long after the first, or whatever (note this also
 		//leaves the short_to_id map in a busted state.
@@ -1152,24 +1541,32 @@ impl ChannelMessageHandler for ChannelManager {
 			match channel_state.by_id.remove(&msg.temporary_channel_id) {
 				Some(mut chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					match chan.funding_created(msg) {
-						Ok((funding_msg, monitor_update)) => {
-							(chan, funding_msg, monitor_update)
-						},
+						Ok((funding_msg, monitor_update)) => (chan, funding_msg, monitor_update),
 						Err(e) => {
 							return Err(e);
 						}
 					}
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		}; // Release channel lock for install_watch_outpoint call,
-		   // note that this means if the remote end is misbehaving and sends a message for the same
-		   // channel back-to-back with funding_created, we'll end up thinking they sent a message
-		   // for a bogus channel.
-		if let Err(_e) = self.monitor.add_update_monitor(monitor_update.get_funding_txo().unwrap(), monitor_update) {
+	 // note that this means if the remote end is misbehaving and sends a message for the same
+	 // channel back-to-back with funding_created, we'll end up thinking they sent a message
+	 // for a bogus channel.
+		if let Err(_e) = self.monitor
+			.add_update_monitor(monitor_update.get_funding_txo().unwrap(), monitor_update)
+		{
 			unimplemented!();
 		}
 		let mut channel_state = self.channel_state.lock().unwrap();
@@ -1177,21 +1574,39 @@ impl ChannelMessageHandler for ChannelManager {
 		Ok(funding_msg)
 	}
 
-	fn handle_funding_signed(&self, their_node_id: &PublicKey, msg: &msgs::FundingSigned) -> Result<(), HandleError> {
+	fn handle_funding_signed(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::FundingSigned,
+	) -> Result<(), HandleError> {
 		let (funding_txo, user_id, monitor) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			match channel_state.by_id.get_mut(&msg.channel_id) {
 				Some(chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					let chan_monitor = chan.funding_signed(&msg)?;
-					(chan.get_funding_txo().unwrap(), chan.get_user_id(), chan_monitor)
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+					(
+						chan.get_funding_txo().unwrap(),
+						chan.get_user_id(),
+						chan_monitor,
+					)
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
-		if let Err(_e) = self.monitor.add_update_monitor(monitor.get_funding_txo().unwrap(), monitor) {
+		if let Err(_e) = self.monitor
+			.add_update_monitor(monitor.get_funding_txo().unwrap(), monitor)
+		{
 			unimplemented!();
 		}
 		let mut pending_events = self.pending_events.lock().unwrap();
@@ -1202,21 +1617,37 @@ impl ChannelMessageHandler for ChannelManager {
 		Ok(())
 	}
 
-	fn handle_funding_locked(&self, their_node_id: &PublicKey, msg: &msgs::FundingLocked) -> Result<Option<msgs::AnnouncementSignatures>, HandleError> {
+	fn handle_funding_locked(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::FundingLocked,
+	) -> Result<Option<msgs::AnnouncementSignatures>, HandleError> {
 		let mut channel_state = self.channel_state.lock().unwrap();
 		match channel_state.by_id.get_mut(&msg.channel_id) {
 			Some(chan) => {
 				if chan.get_their_node_id() != *their_node_id {
-					return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+					return Err(HandleError {
+						err: "Got a message for a channel from the wrong node!",
+						msg: None,
+					});
 				}
 				chan.funding_locked(&msg)?;
 				return Ok(self.get_announcement_sigs(chan)?);
-			},
-			None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+			}
+			None => {
+				return Err(HandleError {
+					err: "Failed to find corresponding channel",
+					msg: None,
+				})
+			}
 		};
 	}
 
-	fn handle_shutdown(&self, their_node_id: &PublicKey, msg: &msgs::Shutdown) -> Result<(Option<msgs::Shutdown>, Option<msgs::ClosingSigned>), HandleError> {
+	fn handle_shutdown(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::Shutdown,
+	) -> Result<(Option<msgs::Shutdown>, Option<msgs::ClosingSigned>), HandleError> {
 		let (res, chan_option) = {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = channel_state_lock.borrow_parts();
@@ -1224,7 +1655,10 @@ impl ChannelMessageHandler for ChannelManager {
 			match channel_state.by_id.entry(msg.channel_id.clone()) {
 				hash_map::Entry::Occupied(mut chan_entry) => {
 					if chan_entry.get().get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					let res = chan_entry.get_mut().shutdown(&*self.fee_estimator, &msg)?;
 					if chan_entry.get().is_shutdown() {
@@ -1232,36 +1666,57 @@ impl ChannelMessageHandler for ChannelManager {
 							channel_state.short_to_id.remove(&short_id);
 						}
 						(res, Some(chan_entry.remove_entry().1))
-					} else { (res, None) }
-				},
-				hash_map::Entry::Vacant(_) => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+					} else {
+						(res, None)
+					}
+				}
+				hash_map::Entry::Vacant(_) => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
 		for payment_hash in res.2 {
 			// unknown_next_peer...I dunno who that is anymore....
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), &payment_hash, HTLCFailReason::Reason { failure_code: 0x4000 | 10, data: Vec::new() });
+			self.fail_htlc_backwards_internal(
+				self.channel_state.lock().unwrap(),
+				&payment_hash,
+				HTLCFailReason::Reason {
+					failure_code: 0x4000 | 10,
+					data: Vec::new(),
+				},
+			);
 		}
 		if let Some(chan) = chan_option {
 			if let Ok(update) = self.get_channel_update(&chan) {
 				let mut events = self.pending_events.lock().unwrap();
-				events.push(events::Event::BroadcastChannelUpdate {
-					msg: update
-				});
+				events.push(events::Event::BroadcastChannelUpdate { msg: update });
 			}
 		}
 		Ok((res.0, res.1))
 	}
 
-	fn handle_closing_signed(&self, their_node_id: &PublicKey, msg: &msgs::ClosingSigned) -> Result<Option<msgs::ClosingSigned>, HandleError> {
+	fn handle_closing_signed(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::ClosingSigned,
+	) -> Result<Option<msgs::ClosingSigned>, HandleError> {
 		let (res, chan_option) = {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = channel_state_lock.borrow_parts();
 			match channel_state.by_id.entry(msg.channel_id.clone()) {
 				hash_map::Entry::Occupied(mut chan_entry) => {
 					if chan_entry.get().get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
-					let res = chan_entry.get_mut().closing_signed(&*self.fee_estimator, &msg)?;
+					let res = chan_entry
+						.get_mut()
+						.closing_signed(&*self.fee_estimator, &msg)?;
 					if res.1.is_some() {
 						// We're done with this channel, we've got a signed closing transaction and
 						// will send the closing_signed back to the remote peer upon return. This
@@ -1272,9 +1727,16 @@ impl ChannelMessageHandler for ChannelManager {
 							channel_state.short_to_id.remove(&short_id);
 						}
 						(res, Some(chan_entry.remove_entry().1))
-					} else { (res, None) }
-				},
-				hash_map::Entry::Vacant(_) => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+					} else {
+						(res, None)
+					}
+				}
+				hash_map::Entry::Vacant(_) => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
 		if let Some(broadcast_tx) = res.1 {
@@ -1283,15 +1745,17 @@ impl ChannelMessageHandler for ChannelManager {
 		if let Some(chan) = chan_option {
 			if let Ok(update) = self.get_channel_update(&chan) {
 				let mut events = self.pending_events.lock().unwrap();
-				events.push(events::Event::BroadcastChannelUpdate {
-					msg: update
-				});
+				events.push(events::Event::BroadcastChannelUpdate { msg: update });
 			}
 		}
 		Ok(res.0)
 	}
 
-	fn handle_update_add_htlc(&self, their_node_id: &PublicKey, msg: &msgs::UpdateAddHTLC) -> Result<(), msgs::HandleError> {
+	fn handle_update_add_htlc(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::UpdateAddHTLC,
+	) -> Result<(), msgs::HandleError> {
 		//TODO: BOLT 4 points out a specific attack where a peer may re-send an onion packet and
 		//determine the state of the payment based on our response/if we forward anything/the time
 		//we take to respond. We should take care to avoid allowing such an attack.
@@ -1301,36 +1765,42 @@ impl ChannelMessageHandler for ChannelManager {
 		//encrypted with the same key. Its not immediately obvious how to usefully exploit that,
 		//but we should prevent it anyway.
 
-		let shared_secret = SharedSecret::new(&self.secp_ctx, &msg.onion_routing_packet.public_key, &self.our_network_key);
+		let shared_secret = SharedSecret::new(
+			&self.secp_ctx,
+			&msg.onion_routing_packet.public_key,
+			&self.our_network_key,
+		);
 		let (rho, mu) = ChannelManager::gen_rho_mu_from_shared_secret(&shared_secret);
 
 		let associated_data = Vec::new(); //TODO: What to put here?
 
 		macro_rules! get_onion_hash {
-			() => {
-				{
-					let mut sha = Sha256::new();
-					sha.input(&msg.onion_routing_packet.hop_data);
-					let mut onion_hash = [0; 32];
-					sha.result(&mut onion_hash);
-					onion_hash
-				}
-			}
+			() => {{
+				let mut sha = Sha256::new();
+				sha.input(&msg.onion_routing_packet.hop_data);
+				let mut onion_hash = [0; 32];
+				sha.result(&mut onion_hash);
+				onion_hash
+				}};
 		}
 
 		macro_rules! return_err {
-			($msg: expr, $err_code: expr, $data: expr) => {
+			($msg:expr, $err_code:expr, $data:expr) => {
 				return Err(msgs::HandleError {
 					err: $msg,
 					msg: Some(msgs::ErrorAction::UpdateFailHTLC {
 						msg: msgs::UpdateFailHTLC {
 							channel_id: msg.channel_id,
 							htlc_id: msg.htlc_id,
-							reason: ChannelManager::build_first_hop_failure_packet(&shared_secret, $err_code, $data),
-						}
+							reason: ChannelManager::build_first_hop_failure_packet(
+								&shared_secret,
+								$err_code,
+								$data,
+							),
+						},
 					}),
-				});
-			}
+					});
+			};
 		}
 
 		if msg.onion_routing_packet.version != 0 {
@@ -1340,7 +1810,11 @@ impl ChannelMessageHandler for ChannelManager {
 			//receiving node would have to brute force to figure out which version was put in the
 			//packet by the node that send us the message, in the case of hashing the hop_data, the
 			//node knows the HMAC matched, so they already know what is there...
-			return_err!("Unknown onion packet version", 0x8000 | 0x4000 | 4, &get_onion_hash!());
+			return_err!(
+				"Unknown onion packet version",
+				0x8000 | 0x4000 | 4,
+				&get_onion_hash!()
+			);
 		}
 
 		let mut hmac = Hmac::new(Sha256::new(), &mu);
@@ -1360,103 +1834,139 @@ impl ChannelMessageHandler for ChannelManager {
 						msgs::DecodeError::UnknownRealmByte => 0x4000 | 1,
 						_ => 0x2000 | 2, // Should never happen
 					};
-					return_err!("Unable to decode our hop data", error_code, &[0;0]);
-				},
-				Ok(msg) => msg
+					return_err!("Unable to decode our hop data", error_code, &[0; 0]);
+				}
+				Ok(msg) => msg,
 			}
 		};
 
 		let mut pending_forward_info = if next_hop_data.hmac == [0; 32] {
-				// OUR PAYMENT!
-				if next_hop_data.data.amt_to_forward != msg.amount_msat {
-					return_err!("Upstream node sent less than we were supposed to receive in payment", 19, &byte_utils::be64_to_array(msg.amount_msat));
-				}
-				if next_hop_data.data.outgoing_cltv_value != msg.cltv_expiry {
-					return_err!("Upstream node set CLTV to the wrong value", 18, &byte_utils::be32_to_array(msg.cltv_expiry));
-				}
+			// OUR PAYMENT!
+			if next_hop_data.data.amt_to_forward != msg.amount_msat {
+				return_err!(
+					"Upstream node sent less than we were supposed to receive in payment",
+					19,
+					&byte_utils::be64_to_array(msg.amount_msat)
+				);
+			}
+			if next_hop_data.data.outgoing_cltv_value != msg.cltv_expiry {
+				return_err!(
+					"Upstream node set CLTV to the wrong value",
+					18,
+					&byte_utils::be32_to_array(msg.cltv_expiry)
+				);
+			}
 
-				// Note that we could obviously respond immediately with an update_fulfill_htlc
-				// message, however that would leak that we are the recipient of this payment, so
-				// instead we stay symmetric with the forwarding case, only responding (after a
-				// delay) once they've send us a commitment_signed!
+			// Note that we could obviously respond immediately with an update_fulfill_htlc
+			// message, however that would leak that we are the recipient of this payment, so
+			// instead we stay symmetric with the forwarding case, only responding (after a
+			// delay) once they've send us a commitment_signed!
 
-				PendingForwardHTLCInfo {
-					onion_packet: None,
-					payment_hash: msg.payment_hash.clone(),
-					short_channel_id: 0,
-					prev_short_channel_id: 0,
-					amt_to_forward: next_hop_data.data.amt_to_forward,
-					outgoing_cltv_value: next_hop_data.data.outgoing_cltv_value,
-				}
-			} else {
-				let mut new_packet_data = [0; 20*65];
-				chacha.process(&msg.onion_routing_packet.hop_data[65..], &mut new_packet_data[0..19*65]);
-				chacha.process(&ChannelManager::ZERO[0..65], &mut new_packet_data[19*65..]);
+			PendingForwardHTLCInfo {
+				onion_packet: None,
+				payment_hash: msg.payment_hash.clone(),
+				short_channel_id: 0,
+				prev_short_channel_id: 0,
+				amt_to_forward: next_hop_data.data.amt_to_forward,
+				outgoing_cltv_value: next_hop_data.data.outgoing_cltv_value,
+			}
+		} else {
+			let mut new_packet_data = [0; 20 * 65];
+			chacha.process(
+				&msg.onion_routing_packet.hop_data[65..],
+				&mut new_packet_data[0..19 * 65],
+			);
+			chacha.process(
+				&ChannelManager::ZERO[0..65],
+				&mut new_packet_data[19 * 65..],
+			);
 
-				let mut new_pubkey = msg.onion_routing_packet.public_key.clone();
+			let mut new_pubkey = msg.onion_routing_packet.public_key.clone();
 
-				let blinding_factor = {
-					let mut sha = Sha256::new();
-					sha.input(&new_pubkey.serialize()[..]);
-					sha.input(&shared_secret[..]);
-					let mut res = [0u8; 32];
-					sha.result(&mut res);
-					match SecretKey::from_slice(&self.secp_ctx, &res) {
-						Err(_) => {
-							// Return temporary node failure as its technically our issue, not the
-							// channel's issue.
-							return_err!("Blinding factor is an invalid private key", 0x2000 | 2, &[0;0]);
-						},
-						Ok(key) => key
-					}
-				};
-
-				match new_pubkey.mul_assign(&self.secp_ctx, &blinding_factor) {
+			let blinding_factor = {
+				let mut sha = Sha256::new();
+				sha.input(&new_pubkey.serialize()[..]);
+				sha.input(&shared_secret[..]);
+				let mut res = [0u8; 32];
+				sha.result(&mut res);
+				match SecretKey::from_slice(&self.secp_ctx, &res) {
 					Err(_) => {
 						// Return temporary node failure as its technically our issue, not the
 						// channel's issue.
-						return_err!("New blinding factor is an invalid private key", 0x2000 | 2, &[0;0]);
-					},
-					Ok(_) => {}
-				};
-
-				let outgoing_packet = msgs::OnionPacket {
-					version: 0,
-					public_key: new_pubkey,
-					hop_data: new_packet_data,
-					hmac: next_hop_data.hmac.clone(),
-				};
-
-				//TODO: Check amt_to_forward and outgoing_cltv_value are within acceptable ranges!
-
-				PendingForwardHTLCInfo {
-					onion_packet: Some(outgoing_packet),
-					payment_hash: msg.payment_hash.clone(),
-					short_channel_id: next_hop_data.data.short_channel_id,
-					prev_short_channel_id: 0,
-					amt_to_forward: next_hop_data.data.amt_to_forward,
-					outgoing_cltv_value: next_hop_data.data.outgoing_cltv_value,
+						return_err!(
+							"Blinding factor is an invalid private key",
+							0x2000 | 2,
+							&[0; 0]
+						);
+					}
+					Ok(key) => key,
 				}
 			};
+
+			match new_pubkey.mul_assign(&self.secp_ctx, &blinding_factor) {
+				Err(_) => {
+					// Return temporary node failure as its technically our issue, not the
+					// channel's issue.
+					return_err!(
+						"New blinding factor is an invalid private key",
+						0x2000 | 2,
+						&[0; 0]
+					);
+				}
+				Ok(_) => {}
+			};
+
+			let outgoing_packet = msgs::OnionPacket {
+				version: 0,
+				public_key: new_pubkey,
+				hop_data: new_packet_data,
+				hmac: next_hop_data.hmac.clone(),
+			};
+
+			//TODO: Check amt_to_forward and outgoing_cltv_value are within acceptable ranges!
+
+			PendingForwardHTLCInfo {
+				onion_packet: Some(outgoing_packet),
+				payment_hash: msg.payment_hash.clone(),
+				short_channel_id: next_hop_data.data.short_channel_id,
+				prev_short_channel_id: 0,
+				amt_to_forward: next_hop_data.data.amt_to_forward,
+				outgoing_cltv_value: next_hop_data.data.outgoing_cltv_value,
+			}
+		};
 
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = channel_state_lock.borrow_parts();
 
-		if pending_forward_info.onion_packet.is_some() { // If short_channel_id is 0 here, we'll reject them in the body here
-			let forwarding_id = match channel_state.short_to_id.get(&pending_forward_info.short_channel_id) {
+		if pending_forward_info.onion_packet.is_some() {
+			// If short_channel_id is 0 here, we'll reject them in the body here
+			let forwarding_id = match channel_state
+				.short_to_id
+				.get(&pending_forward_info.short_channel_id)
+			{
 				None => {
-					return_err!("Don't have available channel for forwarding as requested.", 0x4000 | 10, &[0;0]);
-				},
+					return_err!(
+						"Don't have available channel for forwarding as requested.",
+						0x4000 | 10,
+						&[0; 0]
+					);
+				}
 				Some(id) => id.clone(),
 			};
 			let chan = channel_state.by_id.get_mut(&forwarding_id).unwrap();
 			if !chan.is_live() {
 				let chan_update = self.get_channel_update(chan).unwrap();
-				return_err!("Forwarding channel is not in a ready state.", 0x4000 | 7, &chan_update.encode_with_len()[..]);
+				return_err!(
+					"Forwarding channel is not in a ready state.",
+					0x4000 | 7,
+					&chan_update.encode_with_len()[..]
+				);
 			}
 		}
 
-		let claimable_htlcs_entry = channel_state.claimable_htlcs.entry(msg.payment_hash.clone());
+		let claimable_htlcs_entry = channel_state
+			.claimable_htlcs
+			.entry(msg.payment_hash.clone());
 
 		// We dont correctly handle payments that route through us twice on their way to their
 		// destination. That's OK since those nodes are probably busted or trying to do network
@@ -1468,39 +1978,58 @@ impl ChannelMessageHandler for ChannelManager {
 				match e.get() {
 					&PendingOutboundHTLC::OutboundRoute { .. } => {
 						acceptable_cycle = pending_forward_info.short_channel_id == 0;
-					},
-					_ => {},
+					}
+					_ => {}
 				}
 				if !acceptable_cycle {
-					return_err!("Payment looped through us twice", 0x4000 | 0x2000 | 2, &[0;0]);
+					return_err!(
+						"Payment looped through us twice",
+						0x4000 | 0x2000 | 2,
+						&[0; 0]
+					);
 				}
-			},
-			_ => {},
+			}
+			_ => {}
 		}
 
 		let (source_short_channel_id, res) = match channel_state.by_id.get_mut(&msg.channel_id) {
 			Some(chan) => {
 				if chan.get_their_node_id() != *their_node_id {
-					return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+					return Err(HandleError {
+						err: "Got a message for a channel from the wrong node!",
+						msg: None,
+					});
 				}
 				if !chan.is_usable() {
-					return Err(HandleError{err: "Channel not yet available for receiving HTLCs", msg: None});
+					return Err(HandleError {
+						err: "Channel not yet available for receiving HTLCs",
+						msg: None,
+					});
 				}
 				let short_channel_id = chan.get_short_channel_id().unwrap();
 				pending_forward_info.prev_short_channel_id = short_channel_id;
-				(short_channel_id, chan.update_add_htlc(&msg, pending_forward_info)?)
-			},
-			None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None}), //TODO: panic?
+				(
+					short_channel_id,
+					chan.update_add_htlc(&msg, pending_forward_info)?,
+				)
+			}
+			None => {
+				return Err(HandleError {
+					err: "Failed to find corresponding channel",
+					msg: None,
+				})
+			} //TODO: panic?
 		};
 
 		match claimable_htlcs_entry {
 			hash_map::Entry::Occupied(mut e) => {
 				let outbound_route = e.get_mut();
 				let (route, session_priv) = match outbound_route {
-					&mut PendingOutboundHTLC::OutboundRoute { ref route, ref session_priv } => {
-						(route.clone(), session_priv.clone())
-					},
-					_ => { panic!("WAT") },
+					&mut PendingOutboundHTLC::OutboundRoute {
+						ref route,
+						ref session_priv,
+					} => (route.clone(), session_priv.clone()),
+					_ => panic!("WAT"),
 				};
 				*outbound_route = PendingOutboundHTLC::CycledRoute {
 					source_short_channel_id,
@@ -1508,7 +2037,7 @@ impl ChannelMessageHandler for ChannelManager {
 					route,
 					session_priv,
 				};
-			},
+			}
 			hash_map::Entry::Vacant(e) => {
 				e.insert(PendingOutboundHTLC::IntermediaryHopData {
 					source_short_channel_id,
@@ -1520,7 +2049,11 @@ impl ChannelMessageHandler for ChannelManager {
 		Ok(res)
 	}
 
-	fn handle_update_fulfill_htlc(&self, their_node_id: &PublicKey, msg: &msgs::UpdateFulfillHTLC) -> Result<(), HandleError> {
+	fn handle_update_fulfill_htlc(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::UpdateFulfillHTLC,
+	) -> Result<(), HandleError> {
 		//TODO: Delay the claimed_funds relaying just like we do outbound relay!
 		// Claim funds first, cause we don't really care if the channel we received the message on
 		// is broken, we may have enough info to get our own money!
@@ -1531,161 +2064,273 @@ impl ChannelMessageHandler for ChannelManager {
 			match channel_state.by_id.get_mut(&msg.channel_id) {
 				Some(chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					chan.update_fulfill_htlc(&msg)?
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
-		if let Err(_e) = self.monitor.add_update_monitor(monitor.get_funding_txo().unwrap(), monitor) {
+		if let Err(_e) = self.monitor
+			.add_update_monitor(monitor.get_funding_txo().unwrap(), monitor)
+		{
 			unimplemented!();
 		}
 		Ok(())
 	}
 
-	fn handle_update_fail_htlc(&self, their_node_id: &PublicKey, msg: &msgs::UpdateFailHTLC) -> Result<Option<msgs::HTLCFailChannelUpdate>, HandleError> {
+	fn handle_update_fail_htlc(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::UpdateFailHTLC,
+	) -> Result<Option<msgs::HTLCFailChannelUpdate>, HandleError> {
 		let mut channel_state = self.channel_state.lock().unwrap();
 		let payment_hash = match channel_state.by_id.get_mut(&msg.channel_id) {
 			Some(chan) => {
 				if chan.get_their_node_id() != *their_node_id {
-					return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+					return Err(HandleError {
+						err: "Got a message for a channel from the wrong node!",
+						msg: None,
+					});
 				}
-				chan.update_fail_htlc(&msg, HTLCFailReason::ErrorPacket { err: msg.reason.clone() })
-			},
-			None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+				chan.update_fail_htlc(
+					&msg,
+					HTLCFailReason::ErrorPacket {
+						err: msg.reason.clone(),
+					},
+				)
+			}
+			None => {
+				return Err(HandleError {
+					err: "Failed to find corresponding channel",
+					msg: None,
+				})
+			}
 		}?;
 
 		if let Some(pending_htlc) = channel_state.claimable_htlcs.get(&payment_hash) {
 			match pending_htlc {
-				&PendingOutboundHTLC::OutboundRoute { ref route, ref session_priv } => {
+				&PendingOutboundHTLC::OutboundRoute {
+					ref route,
+					ref session_priv,
+				} => {
 					// Handle packed channel/node updates for passing back for the route handler
 					let mut packet_decrypted = msg.reason.data.clone();
 					let mut res = None;
-					Self::construct_onion_keys_callback(&self.secp_ctx, &route, &session_priv, |shared_secret, _, _, route_hop| {
-						if res.is_some() { return; }
+					Self::construct_onion_keys_callback(
+						&self.secp_ctx,
+						&route,
+						&session_priv,
+						|shared_secret, _, _, route_hop| {
+							if res.is_some() {
+								return;
+							}
 
-						let ammag = ChannelManager::gen_ammag_from_shared_secret(&shared_secret);
+							let ammag =
+								ChannelManager::gen_ammag_from_shared_secret(&shared_secret);
 
-						let mut decryption_tmp = Vec::with_capacity(packet_decrypted.len());
-						decryption_tmp.resize(packet_decrypted.len(), 0);
-						let mut chacha = ChaCha20::new(&ammag, &[0u8; 8]);
-						chacha.process(&packet_decrypted, &mut decryption_tmp[..]);
-						packet_decrypted = decryption_tmp;
+							let mut decryption_tmp = Vec::with_capacity(packet_decrypted.len());
+							decryption_tmp.resize(packet_decrypted.len(), 0);
+							let mut chacha = ChaCha20::new(&ammag, &[0u8; 8]);
+							chacha.process(&packet_decrypted, &mut decryption_tmp[..]);
+							packet_decrypted = decryption_tmp;
 
-						if let Ok(err_packet) = msgs::DecodedOnionErrorPacket::decode(&packet_decrypted) {
-							if err_packet.failuremsg.len() >= 2 {
-								let um = ChannelManager::gen_um_from_shared_secret(&shared_secret);
+							if let Ok(err_packet) =
+								msgs::DecodedOnionErrorPacket::decode(&packet_decrypted)
+							{
+								if err_packet.failuremsg.len() >= 2 {
+									let um =
+										ChannelManager::gen_um_from_shared_secret(&shared_secret);
 
-								let mut hmac = Hmac::new(Sha256::new(), &um);
-								hmac.input(&err_packet.encode()[32..]);
-								let mut calc_tag = [0u8; 32];
-								hmac.raw_result(&mut calc_tag);
-								if crypto::util::fixed_time_eq(&calc_tag, &err_packet.hmac) {
-									const UNKNOWN_CHAN: u16 = 0x4000|10;
-									const TEMP_CHAN_FAILURE: u16 = 0x4000|7;
-									match byte_utils::slice_to_be16(&err_packet.failuremsg[0..2]) {
-										TEMP_CHAN_FAILURE => {
-											if err_packet.failuremsg.len() >= 4 {
-												let update_len = byte_utils::slice_to_be16(&err_packet.failuremsg[2..4]) as usize;
-												if err_packet.failuremsg.len() >= 4 + update_len {
-													if let Ok(chan_update) = msgs::ChannelUpdate::decode(&err_packet.failuremsg[4..4 + update_len]) {
-														res = Some(msgs::HTLCFailChannelUpdate::ChannelUpdateMessage {
+									let mut hmac = Hmac::new(Sha256::new(), &um);
+									hmac.input(&err_packet.encode()[32..]);
+									let mut calc_tag = [0u8; 32];
+									hmac.raw_result(&mut calc_tag);
+									if crypto::util::fixed_time_eq(&calc_tag, &err_packet.hmac) {
+										const UNKNOWN_CHAN: u16 = 0x4000 | 10;
+										const TEMP_CHAN_FAILURE: u16 = 0x4000 | 7;
+										match byte_utils::slice_to_be16(
+											&err_packet.failuremsg[0..2],
+										) {
+											TEMP_CHAN_FAILURE => {
+												if err_packet.failuremsg.len() >= 4 {
+													let update_len = byte_utils::slice_to_be16(
+														&err_packet.failuremsg[2..4],
+													) as usize;
+													if err_packet.failuremsg.len() >= 4 + update_len
+													{
+														if let Ok(chan_update) =
+															msgs::ChannelUpdate::decode(
+																&err_packet.failuremsg
+																	[4..4 + update_len],
+															) {
+															res = Some(msgs::HTLCFailChannelUpdate::ChannelUpdateMessage {
 															msg: chan_update,
 														});
+														}
 													}
 												}
 											}
-										},
-										UNKNOWN_CHAN => {
-											// No such next-hop. We know this came from the
-											// current node as the HMAC validated.
-											res = Some(msgs::HTLCFailChannelUpdate::ChannelClosed {
-												short_channel_id: route_hop.short_channel_id
-											});
-										},
-										_ => {}, //TODO: Enumerate all of these!
+											UNKNOWN_CHAN => {
+												// No such next-hop. We know this came from the
+												// current node as the HMAC validated.
+												res = Some(
+													msgs::HTLCFailChannelUpdate::ChannelClosed {
+														short_channel_id: route_hop
+															.short_channel_id,
+													},
+												);
+											}
+											_ => {} //TODO: Enumerate all of these!
+										}
 									}
 								}
 							}
-						}
-					}).unwrap();
+						},
+					).unwrap();
 					Ok(res)
-				},
-				_ => { Ok(None) },
+				}
+				_ => Ok(None),
 			}
 		} else {
 			Ok(None)
 		}
 	}
 
-	fn handle_update_fail_malformed_htlc(&self, their_node_id: &PublicKey, msg: &msgs::UpdateFailMalformedHTLC) -> Result<(), HandleError> {
+	fn handle_update_fail_malformed_htlc(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::UpdateFailMalformedHTLC,
+	) -> Result<(), HandleError> {
 		let mut channel_state = self.channel_state.lock().unwrap();
 		match channel_state.by_id.get_mut(&msg.channel_id) {
 			Some(chan) => {
 				if chan.get_their_node_id() != *their_node_id {
-					return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+					return Err(HandleError {
+						err: "Got a message for a channel from the wrong node!",
+						msg: None,
+					});
 				}
-				chan.update_fail_malformed_htlc(&msg, HTLCFailReason::Reason { failure_code: msg.failure_code, data: Vec::new() })
-			},
-			None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+				chan.update_fail_malformed_htlc(
+					&msg,
+					HTLCFailReason::Reason {
+						failure_code: msg.failure_code,
+						data: Vec::new(),
+					},
+				)
+			}
+			None => {
+				return Err(HandleError {
+					err: "Failed to find corresponding channel",
+					msg: None,
+				})
+			}
 		}
 	}
 
-	fn handle_commitment_signed(&self, their_node_id: &PublicKey, msg: &msgs::CommitmentSigned) -> Result<(msgs::RevokeAndACK, Option<msgs::CommitmentSigned>), HandleError> {
+	fn handle_commitment_signed(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::CommitmentSigned,
+	) -> Result<(msgs::RevokeAndACK, Option<msgs::CommitmentSigned>), HandleError> {
 		let (revoke_and_ack, commitment_signed, chan_monitor) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			match channel_state.by_id.get_mut(&msg.channel_id) {
 				Some(chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					chan.commitment_signed(&msg)?
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
-		if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
+		if let Err(_e) = self.monitor
+			.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor)
+		{
 			unimplemented!();
 		}
 
 		Ok((revoke_and_ack, commitment_signed))
 	}
 
-	fn handle_revoke_and_ack(&self, their_node_id: &PublicKey, msg: &msgs::RevokeAndACK) -> Result<Option<msgs::CommitmentUpdate>, HandleError> {
+	fn handle_revoke_and_ack(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::RevokeAndACK,
+	) -> Result<Option<msgs::CommitmentUpdate>, HandleError> {
 		let (res, mut pending_forwards, mut pending_failures, chan_monitor) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			match channel_state.by_id.get_mut(&msg.channel_id) {
 				Some(chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					chan.revoke_and_ack(&msg)?
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
-		if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
+		if let Err(_e) = self.monitor
+			.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor)
+		{
 			unimplemented!();
 		}
 		for failure in pending_failures.drain(..) {
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), &failure.0, failure.1);
+			self.fail_htlc_backwards_internal(
+				self.channel_state.lock().unwrap(),
+				&failure.0,
+				failure.1,
+			);
 		}
 
 		let mut forward_event = None;
 		if !pending_forwards.is_empty() {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			if channel_state.forward_htlcs.is_empty() {
-				forward_event = Some(Instant::now() + Duration::from_millis(((rng::rand_f32() * 4.0 + 1.0) * MIN_HTLC_RELAY_HOLDING_CELL_MILLIS as f32) as u64));
+				forward_event = Some(
+					Instant::now()
+						+ Duration::from_millis(
+							((rng::rand_f32() * 4.0 + 1.0)
+								* MIN_HTLC_RELAY_HOLDING_CELL_MILLIS as f32) as u64,
+						),
+				);
 				channel_state.next_forward = forward_event.unwrap();
 			}
 			for forward_info in pending_forwards.drain(..) {
-				match channel_state.forward_htlcs.entry(forward_info.short_channel_id) {
+				match channel_state
+					.forward_htlcs
+					.entry(forward_info.short_channel_id)
+				{
 					hash_map::Entry::Occupied(mut entry) => {
 						entry.get_mut().push(forward_info);
-					},
+					}
 					hash_map::Entry::Vacant(entry) => {
-						entry.insert(vec!(forward_info));
+						entry.insert(vec![forward_info]);
 					}
 				}
 			}
@@ -1694,63 +2339,134 @@ impl ChannelMessageHandler for ChannelManager {
 			Some(time) => {
 				let mut pending_events = self.pending_events.lock().unwrap();
 				pending_events.push(events::Event::PendingHTLCsForwardable {
-					time_forwardable: time
+					time_forwardable: time,
 				});
 			}
-			None => {},
+			None => {}
 		}
 
 		Ok(res)
 	}
 
-	fn handle_update_fee(&self, their_node_id: &PublicKey, msg: &msgs::UpdateFee) -> Result<(), HandleError> {
+	fn handle_update_fee(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::UpdateFee,
+	) -> Result<(), HandleError> {
 		let mut channel_state = self.channel_state.lock().unwrap();
 		match channel_state.by_id.get_mut(&msg.channel_id) {
 			Some(chan) => {
 				if chan.get_their_node_id() != *their_node_id {
-					return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+					return Err(HandleError {
+						err: "Got a message for a channel from the wrong node!",
+						msg: None,
+					});
 				}
 				chan.update_fee(&*self.fee_estimator, &msg)
-			},
-			None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+			}
+			None => {
+				return Err(HandleError {
+					err: "Failed to find corresponding channel",
+					msg: None,
+				})
+			}
 		}
 	}
 
-	fn handle_announcement_signatures(&self, their_node_id: &PublicKey, msg: &msgs::AnnouncementSignatures) -> Result<(), HandleError> {
+	fn handle_announcement_signatures(
+		&self,
+		their_node_id: &PublicKey,
+		msg: &msgs::AnnouncementSignatures,
+	) -> Result<(), HandleError> {
 		let (chan_announcement, chan_update) = {
 			let mut channel_state = self.channel_state.lock().unwrap();
 			match channel_state.by_id.get_mut(&msg.channel_id) {
 				Some(chan) => {
 					if chan.get_their_node_id() != *their_node_id {
-						return Err(HandleError{err: "Got a message for a channel from the wrong node!", msg: None})
+						return Err(HandleError {
+							err: "Got a message for a channel from the wrong node!",
+							msg: None,
+						});
 					}
 					if !chan.is_usable() {
-						return Err(HandleError{err: "Got an announcement_signatures before we were ready for it", msg: None });
+						return Err(HandleError {
+							err: "Got an announcement_signatures before we were ready for it",
+							msg: None,
+						});
 					}
 
 					let our_node_id = self.get_our_node_id();
-					let (announcement, our_bitcoin_sig) = chan.get_channel_announcement(our_node_id.clone(), self.genesis_hash.clone())?;
+					let (announcement, our_bitcoin_sig) = chan.get_channel_announcement(
+						our_node_id.clone(),
+						self.genesis_hash.clone(),
+					)?;
 
 					let were_node_one = announcement.node_id_1 == our_node_id;
-					let msghash = Message::from_slice(&Sha256dHash::from_data(&announcement.encode()[..])[..]).unwrap();
-					secp_call!(self.secp_ctx.verify(&msghash, &msg.node_signature, if were_node_one { &announcement.node_id_2 } else { &announcement.node_id_1 }));
-					secp_call!(self.secp_ctx.verify(&msghash, &msg.bitcoin_signature, if were_node_one { &announcement.bitcoin_key_2 } else { &announcement.bitcoin_key_1 }));
+					let msghash = Message::from_slice(
+						&Sha256dHash::from_data(&announcement.encode()[..])[..],
+					).unwrap();
+					secp_call!(self.secp_ctx.verify(
+						&msghash,
+						&msg.node_signature,
+						if were_node_one {
+							&announcement.node_id_2
+						} else {
+							&announcement.node_id_1
+						}
+					));
+					secp_call!(self.secp_ctx.verify(
+						&msghash,
+						&msg.bitcoin_signature,
+						if were_node_one {
+							&announcement.bitcoin_key_2
+						} else {
+							&announcement.bitcoin_key_1
+						}
+					));
 
-					let our_node_sig = secp_call!(self.secp_ctx.sign(&msghash, &self.our_network_key));
+					let our_node_sig =
+						secp_call!(self.secp_ctx.sign(&msghash, &self.our_network_key));
 
-					(msgs::ChannelAnnouncement {
-						node_signature_1: if were_node_one { our_node_sig } else { msg.node_signature },
-						node_signature_2: if were_node_one { msg.node_signature } else { our_node_sig },
-						bitcoin_signature_1: if were_node_one { our_bitcoin_sig } else { msg.bitcoin_signature },
-						bitcoin_signature_2: if were_node_one { msg.bitcoin_signature } else { our_bitcoin_sig },
-						contents: announcement,
-					}, self.get_channel_update(chan).unwrap()) // can only fail if we're not in a ready state
-				},
-				None => return Err(HandleError{err: "Failed to find corresponding channel", msg: None})
+					(
+						msgs::ChannelAnnouncement {
+							node_signature_1: if were_node_one {
+								our_node_sig
+							} else {
+								msg.node_signature
+							},
+							node_signature_2: if were_node_one {
+								msg.node_signature
+							} else {
+								our_node_sig
+							},
+							bitcoin_signature_1: if were_node_one {
+								our_bitcoin_sig
+							} else {
+								msg.bitcoin_signature
+							},
+							bitcoin_signature_2: if were_node_one {
+								msg.bitcoin_signature
+							} else {
+								our_bitcoin_sig
+							},
+							contents: announcement,
+						},
+						self.get_channel_update(chan).unwrap(),
+					) // can only fail if we're not in a ready state
+				}
+				None => {
+					return Err(HandleError {
+						err: "Failed to find corresponding channel",
+						msg: None,
+					})
+				}
 			}
 		};
 		let mut pending_events = self.pending_events.lock().unwrap();
-		pending_events.push(events::Event::BroadcastChannelAnnouncement { msg: chan_announcement, update_msg: chan_update });
+		pending_events.push(events::Event::BroadcastChannelAnnouncement {
+			msg: chan_announcement,
+			update_msg: chan_update,
+		});
 		Ok(())
 	}
 
@@ -1771,9 +2487,7 @@ impl ChannelMessageHandler for ChannelManager {
 							self.tx_broadcaster.broadcast_transaction(&tx);
 						}
 						if let Ok(update) = self.get_channel_update(&chan) {
-							new_events.push(events::Event::BroadcastChannelUpdate {
-								msg: update
-							});
+							new_events.push(events::Event::BroadcastChannelUpdate { msg: update });
 						}
 						false
 					} else {
@@ -1803,68 +2517,108 @@ impl ChannelMessageHandler for ChannelManager {
 mod tests {
 	use chain::chaininterface;
 	use chain::transaction::OutPoint;
-	use ln::channelmanager::{ChannelManager,OnionKeys};
-	use ln::router::{Route, RouteHop, Router};
+	use ln::channelmanager::{ChannelManager, OnionKeys};
 	use ln::msgs;
-	use ln::msgs::{MsgEncodable,ChannelMessageHandler,RoutingMessageHandler};
-	use util::test_utils;
+	use ln::msgs::{ChannelMessageHandler, MsgEncodable, RoutingMessageHandler};
+	use ln::router::{Route, RouteHop, Router};
 	use util::events::{Event, EventsProvider};
+	use util::test_utils;
 
-	use bitcoin::util::misc::hex_bytes;
-	use bitcoin::util::hash::Sha256dHash;
-	use bitcoin::util::uint::Uint256;
 	use bitcoin::blockdata::block::BlockHeader;
 	use bitcoin::blockdata::transaction::{Transaction, TxOut};
 	use bitcoin::network::constants::Network;
 	use bitcoin::network::serialize::serialize;
 	use bitcoin::network::serialize::BitcoinHash;
+	use bitcoin::util::hash::Sha256dHash;
+	use bitcoin::util::misc::hex_bytes;
+	use bitcoin::util::uint::Uint256;
 
+	use secp256k1::key::{PublicKey, SecretKey};
 	use secp256k1::Secp256k1;
-	use secp256k1::key::{PublicKey,SecretKey};
 
-	use crypto::sha2::Sha256;
 	use crypto::digest::Digest;
+	use crypto::sha2::Sha256;
 
-	use rand::{thread_rng,Rng};
+	use rand::{thread_rng, Rng};
 
 	use std::collections::HashMap;
 	use std::default::Default;
+	use std::mem;
 	use std::sync::{Arc, Mutex};
 	use std::time::Instant;
-	use std::mem;
 
 	fn build_test_onion_keys() -> Vec<OnionKeys> {
 		// Keys from BOLT 4, used in both test vector tests
 		let secp_ctx = Secp256k1::new();
 
 		let route = Route {
-			hops: vec!(
-					RouteHop {
-						pubkey: PublicKey::from_slice(&secp_ctx, &hex_bytes("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
-					},
-					RouteHop {
-						pubkey: PublicKey::from_slice(&secp_ctx, &hex_bytes("0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
-					},
-					RouteHop {
-						pubkey: PublicKey::from_slice(&secp_ctx, &hex_bytes("027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
-					},
-					RouteHop {
-						pubkey: PublicKey::from_slice(&secp_ctx, &hex_bytes("032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
-					},
-					RouteHop {
-						pubkey: PublicKey::from_slice(&secp_ctx, &hex_bytes("02edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
-					},
-			),
+			hops: vec![
+				RouteHop {
+					pubkey: PublicKey::from_slice(
+						&secp_ctx,
+						&hex_bytes(
+							"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619",
+						).unwrap()[..],
+					).unwrap(),
+					short_channel_id: 0,
+					fee_msat: 0,
+					cltv_expiry_delta: 0, // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+				},
+				RouteHop {
+					pubkey: PublicKey::from_slice(
+						&secp_ctx,
+						&hex_bytes(
+							"0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c",
+						).unwrap()[..],
+					).unwrap(),
+					short_channel_id: 0,
+					fee_msat: 0,
+					cltv_expiry_delta: 0, // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+				},
+				RouteHop {
+					pubkey: PublicKey::from_slice(
+						&secp_ctx,
+						&hex_bytes(
+							"027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007",
+						).unwrap()[..],
+					).unwrap(),
+					short_channel_id: 0,
+					fee_msat: 0,
+					cltv_expiry_delta: 0, // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+				},
+				RouteHop {
+					pubkey: PublicKey::from_slice(
+						&secp_ctx,
+						&hex_bytes(
+							"032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991",
+						).unwrap()[..],
+					).unwrap(),
+					short_channel_id: 0,
+					fee_msat: 0,
+					cltv_expiry_delta: 0, // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+				},
+				RouteHop {
+					pubkey: PublicKey::from_slice(
+						&secp_ctx,
+						&hex_bytes(
+							"02edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145",
+						).unwrap()[..],
+					).unwrap(),
+					short_channel_id: 0,
+					fee_msat: 0,
+					cltv_expiry_delta: 0, // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+				},
+			],
 		};
 
-		let session_priv = SecretKey::from_slice(&secp_ctx, &hex_bytes("4141414141414141414141414141414141414141414141414141414141414141").unwrap()[..]).unwrap();
+		let session_priv = SecretKey::from_slice(
+			&secp_ctx,
+			&hex_bytes("4141414141414141414141414141414141414141414141414141414141414141").unwrap()
+				[..],
+		).unwrap();
 
-		let onion_keys = ChannelManager::construct_onion_keys(&secp_ctx, &route, &session_priv).unwrap();
+		let onion_keys =
+			ChannelManager::construct_onion_keys(&secp_ctx, &route, &session_priv).unwrap();
 		assert_eq!(onion_keys.len(), route.hops.len());
 		onion_keys
 	}
@@ -1874,38 +2628,138 @@ mod tests {
 		// Packet creation test vectors from BOLT 4
 		let onion_keys = build_test_onion_keys();
 
-		assert_eq!(onion_keys[0].shared_secret[..], hex_bytes("53eb63ea8a3fec3b3cd433b85cd62a4b145e1dda09391b348c4e1cd36a03ea66").unwrap()[..]);
-		assert_eq!(onion_keys[0].blinding_factor[..], hex_bytes("2ec2e5da605776054187180343287683aa6a51b4b1c04d6dd49c45d8cffb3c36").unwrap()[..]);
-		assert_eq!(onion_keys[0].ephemeral_pubkey.serialize()[..], hex_bytes("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619").unwrap()[..]);
-		assert_eq!(onion_keys[0].rho, hex_bytes("ce496ec94def95aadd4bec15cdb41a740c9f2b62347c4917325fcc6fb0453986").unwrap()[..]);
-		assert_eq!(onion_keys[0].mu, hex_bytes("b57061dc6d0a2b9f261ac410c8b26d64ac5506cbba30267a649c28c179400eba").unwrap()[..]);
+		assert_eq!(
+			onion_keys[0].shared_secret[..],
+			hex_bytes("53eb63ea8a3fec3b3cd433b85cd62a4b145e1dda09391b348c4e1cd36a03ea66").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[0].blinding_factor[..],
+			hex_bytes("2ec2e5da605776054187180343287683aa6a51b4b1c04d6dd49c45d8cffb3c36").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[0].ephemeral_pubkey.serialize()[..],
+			hex_bytes("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")
+				.unwrap()[..]
+		);
+		assert_eq!(
+			onion_keys[0].rho,
+			hex_bytes("ce496ec94def95aadd4bec15cdb41a740c9f2b62347c4917325fcc6fb0453986").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[0].mu,
+			hex_bytes("b57061dc6d0a2b9f261ac410c8b26d64ac5506cbba30267a649c28c179400eba").unwrap()
+				[..]
+		);
 
-		assert_eq!(onion_keys[1].shared_secret[..], hex_bytes("a6519e98832a0b179f62123b3567c106db99ee37bef036e783263602f3488fae").unwrap()[..]);
-		assert_eq!(onion_keys[1].blinding_factor[..], hex_bytes("bf66c28bc22e598cfd574a1931a2bafbca09163df2261e6d0056b2610dab938f").unwrap()[..]);
-		assert_eq!(onion_keys[1].ephemeral_pubkey.serialize()[..], hex_bytes("028f9438bfbf7feac2e108d677e3a82da596be706cc1cf342b75c7b7e22bf4e6e2").unwrap()[..]);
-		assert_eq!(onion_keys[1].rho, hex_bytes("450ffcabc6449094918ebe13d4f03e433d20a3d28a768203337bc40b6e4b2c59").unwrap()[..]);
-		assert_eq!(onion_keys[1].mu, hex_bytes("05ed2b4a3fb023c2ff5dd6ed4b9b6ea7383f5cfe9d59c11d121ec2c81ca2eea9").unwrap()[..]);
+		assert_eq!(
+			onion_keys[1].shared_secret[..],
+			hex_bytes("a6519e98832a0b179f62123b3567c106db99ee37bef036e783263602f3488fae").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[1].blinding_factor[..],
+			hex_bytes("bf66c28bc22e598cfd574a1931a2bafbca09163df2261e6d0056b2610dab938f").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[1].ephemeral_pubkey.serialize()[..],
+			hex_bytes("028f9438bfbf7feac2e108d677e3a82da596be706cc1cf342b75c7b7e22bf4e6e2")
+				.unwrap()[..]
+		);
+		assert_eq!(
+			onion_keys[1].rho,
+			hex_bytes("450ffcabc6449094918ebe13d4f03e433d20a3d28a768203337bc40b6e4b2c59").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[1].mu,
+			hex_bytes("05ed2b4a3fb023c2ff5dd6ed4b9b6ea7383f5cfe9d59c11d121ec2c81ca2eea9").unwrap()
+				[..]
+		);
 
-		assert_eq!(onion_keys[2].shared_secret[..], hex_bytes("3a6b412548762f0dbccce5c7ae7bb8147d1caf9b5471c34120b30bc9c04891cc").unwrap()[..]);
-		assert_eq!(onion_keys[2].blinding_factor[..], hex_bytes("a1f2dadd184eb1627049673f18c6325814384facdee5bfd935d9cb031a1698a5").unwrap()[..]);
-		assert_eq!(onion_keys[2].ephemeral_pubkey.serialize()[..], hex_bytes("03bfd8225241ea71cd0843db7709f4c222f62ff2d4516fd38b39914ab6b83e0da0").unwrap()[..]);
-		assert_eq!(onion_keys[2].rho, hex_bytes("11bf5c4f960239cb37833936aa3d02cea82c0f39fd35f566109c41f9eac8deea").unwrap()[..]);
-		assert_eq!(onion_keys[2].mu, hex_bytes("caafe2820fa00eb2eeb78695ae452eba38f5a53ed6d53518c5c6edf76f3f5b78").unwrap()[..]);
+		assert_eq!(
+			onion_keys[2].shared_secret[..],
+			hex_bytes("3a6b412548762f0dbccce5c7ae7bb8147d1caf9b5471c34120b30bc9c04891cc").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[2].blinding_factor[..],
+			hex_bytes("a1f2dadd184eb1627049673f18c6325814384facdee5bfd935d9cb031a1698a5").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[2].ephemeral_pubkey.serialize()[..],
+			hex_bytes("03bfd8225241ea71cd0843db7709f4c222f62ff2d4516fd38b39914ab6b83e0da0")
+				.unwrap()[..]
+		);
+		assert_eq!(
+			onion_keys[2].rho,
+			hex_bytes("11bf5c4f960239cb37833936aa3d02cea82c0f39fd35f566109c41f9eac8deea").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[2].mu,
+			hex_bytes("caafe2820fa00eb2eeb78695ae452eba38f5a53ed6d53518c5c6edf76f3f5b78").unwrap()
+				[..]
+		);
 
-		assert_eq!(onion_keys[3].shared_secret[..], hex_bytes("21e13c2d7cfe7e18836df50872466117a295783ab8aab0e7ecc8c725503ad02d").unwrap()[..]);
-		assert_eq!(onion_keys[3].blinding_factor[..], hex_bytes("7cfe0b699f35525029ae0fa437c69d0f20f7ed4e3916133f9cacbb13c82ff262").unwrap()[..]);
-		assert_eq!(onion_keys[3].ephemeral_pubkey.serialize()[..], hex_bytes("031dde6926381289671300239ea8e57ffaf9bebd05b9a5b95beaf07af05cd43595").unwrap()[..]);
-		assert_eq!(onion_keys[3].rho, hex_bytes("cbe784ab745c13ff5cffc2fbe3e84424aa0fd669b8ead4ee562901a4a4e89e9e").unwrap()[..]);
-		assert_eq!(onion_keys[3].mu, hex_bytes("5052aa1b3d9f0655a0932e50d42f0c9ba0705142c25d225515c45f47c0036ee9").unwrap()[..]);
+		assert_eq!(
+			onion_keys[3].shared_secret[..],
+			hex_bytes("21e13c2d7cfe7e18836df50872466117a295783ab8aab0e7ecc8c725503ad02d").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[3].blinding_factor[..],
+			hex_bytes("7cfe0b699f35525029ae0fa437c69d0f20f7ed4e3916133f9cacbb13c82ff262").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[3].ephemeral_pubkey.serialize()[..],
+			hex_bytes("031dde6926381289671300239ea8e57ffaf9bebd05b9a5b95beaf07af05cd43595")
+				.unwrap()[..]
+		);
+		assert_eq!(
+			onion_keys[3].rho,
+			hex_bytes("cbe784ab745c13ff5cffc2fbe3e84424aa0fd669b8ead4ee562901a4a4e89e9e").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[3].mu,
+			hex_bytes("5052aa1b3d9f0655a0932e50d42f0c9ba0705142c25d225515c45f47c0036ee9").unwrap()
+				[..]
+		);
 
-		assert_eq!(onion_keys[4].shared_secret[..], hex_bytes("b5756b9b542727dbafc6765a49488b023a725d631af688fc031217e90770c328").unwrap()[..]);
-		assert_eq!(onion_keys[4].blinding_factor[..], hex_bytes("c96e00dddaf57e7edcd4fb5954be5b65b09f17cb6d20651b4e90315be5779205").unwrap()[..]);
-		assert_eq!(onion_keys[4].ephemeral_pubkey.serialize()[..], hex_bytes("03a214ebd875aab6ddfd77f22c5e7311d7f77f17a169e599f157bbcdae8bf071f4").unwrap()[..]);
-		assert_eq!(onion_keys[4].rho, hex_bytes("034e18b8cc718e8af6339106e706c52d8df89e2b1f7e9142d996acf88df8799b").unwrap()[..]);
-		assert_eq!(onion_keys[4].mu, hex_bytes("8e45e5c61c2b24cb6382444db6698727afb063adecd72aada233d4bf273d975a").unwrap()[..]);
+		assert_eq!(
+			onion_keys[4].shared_secret[..],
+			hex_bytes("b5756b9b542727dbafc6765a49488b023a725d631af688fc031217e90770c328").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[4].blinding_factor[..],
+			hex_bytes("c96e00dddaf57e7edcd4fb5954be5b65b09f17cb6d20651b4e90315be5779205").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[4].ephemeral_pubkey.serialize()[..],
+			hex_bytes("03a214ebd875aab6ddfd77f22c5e7311d7f77f17a169e599f157bbcdae8bf071f4")
+				.unwrap()[..]
+		);
+		assert_eq!(
+			onion_keys[4].rho,
+			hex_bytes("034e18b8cc718e8af6339106e706c52d8df89e2b1f7e9142d996acf88df8799b").unwrap()
+				[..]
+		);
+		assert_eq!(
+			onion_keys[4].mu,
+			hex_bytes("8e45e5c61c2b24cb6382444db6698727afb063adecd72aada233d4bf273d975a").unwrap()
+				[..]
+		);
 
 		// Test vectors below are flat-out wrong: they claim to set outgoing_cltv_value to non-0 :/
-		let payloads = vec!(
+		let payloads = vec![
 			msgs::OnionHopData {
 				realm: 0,
 				data: msgs::OnionRealm0HopData {
@@ -1951,9 +2805,13 @@ mod tests {
 				},
 				hmac: [0; 32],
 			},
-		);
+		];
 
-		let packet = ChannelManager::construct_onion_packet(payloads, onion_keys, hex_bytes("4242424242424242424242424242424242424242424242424242424242424242").unwrap()).unwrap();
+		let packet = ChannelManager::construct_onion_packet(
+			payloads,
+			onion_keys,
+			hex_bytes("4242424242424242424242424242424242424242424242424242424242424242").unwrap(),
+		).unwrap();
 		// Just check the final packet encoding, as it includes all the per-hop vectors in it
 		// anyway...
 		assert_eq!(packet.encode(), hex_bytes("0002eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619e5f14350c2a76fc232b5e46d421e9615471ab9e0bc887beff8c95fdb878f7b3a716a996c7845c93d90e4ecbb9bde4ece2f69425c99e4bc820e44485455f135edc0d10f7d61ab590531cf08000179a333a347f8b4072f216400406bdf3bf038659793d4a1fd7b246979e3150a0a4cb052c9ec69acf0f48c3d39cd55675fe717cb7d80ce721caad69320c3a469a202f1e468c67eaf7a7cd8226d0fd32f7b48084dca885d56047694762b67021713ca673929c163ec36e04e40ca8e1c6d17569419d3039d9a1ec866abe044a9ad635778b961fc0776dc832b3a451bd5d35072d2269cf9b040f6b7a7dad84fb114ed413b1426cb96ceaf83825665ed5a1d002c1687f92465b49ed4c7f0218ff8c6c7dd7221d589c65b3b9aaa71a41484b122846c7c7b57e02e679ea8469b70e14fe4f70fee4d87b910cf144be6fe48eef24da475c0b0bcc6565ae82cd3f4e3b24c76eaa5616c6111343306ab35c1fe5ca4a77c0e314ed7dba39d6f1e0de791719c241a939cc493bea2bae1c1e932679ea94d29084278513c77b899cc98059d06a27d171b0dbdf6bee13ddc4fc17a0c4d2827d488436b57baa167544138ca2e64a11b43ac8a06cd0c2fba2d4d900ed2d9205305e2d7383cc98dacb078133de5f6fb6bed2ef26ba92cea28aafc3b9948dd9ae5559e8bd6920b8cea462aa445ca6a95e0e7ba52961b181c79e73bd581821df2b10173727a810c92b83b5ba4a0403eb710d2ca10689a35bec6c3a708e9e92f7d78ff3c5d9989574b00c6736f84c199256e76e19e78f0c98a9d580b4a658c84fc8f2096c2fbea8f5f8c59d0fdacb3be2802ef802abbecb3aba4acaac69a0e965abd8981e9896b1f6ef9d60f7a164b371af869fd0e48073742825e9434fc54da837e120266d53302954843538ea7c6c3dbfb4ff3b2fdbe244437f2a153ccf7bdb4c92aa08102d4f3cff2ae5ef86fab4653595e6a5837fa2f3e29f27a9cde5966843fb847a4a61f1e76c281fe8bb2b0a181d096100db5a1a5ce7a910238251a43ca556712eaadea167fb4d7d75825e440f3ecd782036d7574df8bceacb397abefc5f5254d2722215c53ff54af8299aaaad642c6d72a14d27882d9bbd539e1cc7a527526ba89b8c037ad09120e98ab042d3e8652b31ae0e478516bfaf88efca9f3676ffe99d2819dcaeb7610a626695f53117665d267d3f7abebd6bbd6733f645c72c389f03855bdf1e4b8075b516569b118233a0f0971d24b83113c0b096f5216a207ca99a7cddc81c130923fe3d91e7508c9ac5f2e914ff5dccab9e558566fa14efb34ac98d878580814b94b73acbfde9072f30b881f7f0fff42d4045d1ace6322d86a97d164aa84d93a60498065cc7c20e636f5862dc81531a88c60305a2e59a985be327a6902e4bed986dbf4a0b50c217af0ea7fdf9ab37f9ea1a1aaa72f54cf40154ea9b269f1a7c09f9f43245109431a175d50e2db0132337baa0ef97eed0fcf20489da36b79a1172faccc2f7ded7c60e00694282d93359c4682135642bc81f433574aa8ef0c97b4ade7ca372c5ffc23c7eddd839bab4e0f14d6df15c9dbeab176bec8b5701cf054eb3072f6dadc98f88819042bf10c407516ee58bce33fbe3b3d86a54255e577db4598e30a135361528c101683a5fcde7e8ba53f3456254be8f45fe3a56120ae96ea3773631fcb3873aa3abd91bcff00bd38bd43697a2e789e00da6077482e7b1b1a677b5afae4c54e6cbdf7377b694eb7d7a5b913476a5be923322d3de06060fd5e819635232a2cf4f0731da13b8546d1d6d4f8d75b9fce6c2341a71b0ea6f780df54bfdb0dd5cd9855179f602f9172307c7268724c3618e6817abd793adc214a0dc0bc616816632f27ea336fb56dfd").unwrap());
@@ -1964,30 +2822,64 @@ mod tests {
 		// Returning Errors test vectors from BOLT 4
 
 		let onion_keys = build_test_onion_keys();
-		let onion_error = ChannelManager::build_failure_packet(&onion_keys[4].shared_secret, 0x2002, &[0; 0]);
+		let onion_error =
+			ChannelManager::build_failure_packet(&onion_keys[4].shared_secret, 0x2002, &[0; 0]);
 		assert_eq!(onion_error.encode(), hex_bytes("4c2fc8bc08510334b6833ad9c3e79cd1b52ae59dfe5c2a4b23ead50f09f7ee0b0002200200fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap());
 
-		let onion_packet_1 = ChannelManager::encrypt_failure_packet(&onion_keys[4].shared_secret, &onion_error.encode()[..]);
+		let onion_packet_1 = ChannelManager::encrypt_failure_packet(
+			&onion_keys[4].shared_secret,
+			&onion_error.encode()[..],
+		);
 		assert_eq!(onion_packet_1.data, hex_bytes("a5e6bd0c74cb347f10cce367f949098f2457d14c046fd8a22cb96efb30b0fdcda8cb9168b50f2fd45edd73c1b0c8b33002df376801ff58aaa94000bf8a86f92620f343baef38a580102395ae3abf9128d1047a0736ff9b83d456740ebbb4aeb3aa9737f18fb4afb4aa074fb26c4d702f42968888550a3bded8c05247e045b866baef0499f079fdaeef6538f31d44deafffdfd3afa2fb4ca9082b8f1c465371a9894dd8c243fb4847e004f5256b3e90e2edde4c9fb3082ddfe4d1e734cacd96ef0706bf63c9984e22dc98851bcccd1c3494351feb458c9c6af41c0044bea3c47552b1d992ae542b17a2d0bba1a096c78d169034ecb55b6e3a7263c26017f033031228833c1daefc0dedb8cf7c3e37c9c37ebfe42f3225c326e8bcfd338804c145b16e34e4").unwrap());
 
-		let onion_packet_2 = ChannelManager::encrypt_failure_packet(&onion_keys[3].shared_secret, &onion_packet_1.data[..]);
+		let onion_packet_2 = ChannelManager::encrypt_failure_packet(
+			&onion_keys[3].shared_secret,
+			&onion_packet_1.data[..],
+		);
 		assert_eq!(onion_packet_2.data, hex_bytes("c49a1ce81680f78f5f2000cda36268de34a3f0a0662f55b4e837c83a8773c22aa081bab1616a0011585323930fa5b9fae0c85770a2279ff59ec427ad1bbff9001c0cd1497004bd2a0f68b50704cf6d6a4bf3c8b6a0833399a24b3456961ba00736785112594f65b6b2d44d9f5ea4e49b5e1ec2af978cbe31c67114440ac51a62081df0ed46d4a3df295da0b0fe25c0115019f03f15ec86fabb4c852f83449e812f141a9395b3f70b766ebbd4ec2fae2b6955bd8f32684c15abfe8fd3a6261e52650e8807a92158d9f1463261a925e4bfba44bd20b166d532f0017185c3a6ac7957adefe45559e3072c8dc35abeba835a8cb01a71a15c736911126f27d46a36168ca5ef7dccd4e2886212602b181463e0dd30185c96348f9743a02aca8ec27c0b90dca270").unwrap());
 
-		let onion_packet_3 = ChannelManager::encrypt_failure_packet(&onion_keys[2].shared_secret, &onion_packet_2.data[..]);
+		let onion_packet_3 = ChannelManager::encrypt_failure_packet(
+			&onion_keys[2].shared_secret,
+			&onion_packet_2.data[..],
+		);
 		assert_eq!(onion_packet_3.data, hex_bytes("a5d3e8634cfe78b2307d87c6d90be6fe7855b4f2cc9b1dfb19e92e4b79103f61ff9ac25f412ddfb7466e74f81b3e545563cdd8f5524dae873de61d7bdfccd496af2584930d2b566b4f8d3881f8c043df92224f38cf094cfc09d92655989531524593ec6d6caec1863bdfaa79229b5020acc034cd6deeea1021c50586947b9b8e6faa83b81fbfa6133c0af5d6b07c017f7158fa94f0d206baf12dda6b68f785b773b360fd0497e16cc402d779c8d48d0fa6315536ef0660f3f4e1865f5b38ea49c7da4fd959de4e83ff3ab686f059a45c65ba2af4a6a79166aa0f496bf04d06987b6d2ea205bdb0d347718b9aeff5b61dfff344993a275b79717cd815b6ad4c0beb568c4ac9c36ff1c315ec1119a1993c4b61e6eaa0375e0aaf738ac691abd3263bf937e3").unwrap());
 
-		let onion_packet_4 = ChannelManager::encrypt_failure_packet(&onion_keys[1].shared_secret, &onion_packet_3.data[..]);
+		let onion_packet_4 = ChannelManager::encrypt_failure_packet(
+			&onion_keys[1].shared_secret,
+			&onion_packet_3.data[..],
+		);
 		assert_eq!(onion_packet_4.data, hex_bytes("aac3200c4968f56b21f53e5e374e3a2383ad2b1b6501bbcc45abc31e59b26881b7dfadbb56ec8dae8857add94e6702fb4c3a4de22e2e669e1ed926b04447fc73034bb730f4932acd62727b75348a648a1128744657ca6a4e713b9b646c3ca66cac02cdab44dd3439890ef3aaf61708714f7375349b8da541b2548d452d84de7084bb95b3ac2345201d624d31f4d52078aa0fa05a88b4e20202bd2b86ac5b52919ea305a8949de95e935eed0319cf3cf19ebea61d76ba92532497fcdc9411d06bcd4275094d0a4a3c5d3a945e43305a5a9256e333e1f64dbca5fcd4e03a39b9012d197506e06f29339dfee3331995b21615337ae060233d39befea925cc262873e0530408e6990f1cbd233a150ef7b004ff6166c70c68d9f8c853c1abca640b8660db2921").unwrap());
 
-		let onion_packet_5 = ChannelManager::encrypt_failure_packet(&onion_keys[0].shared_secret, &onion_packet_4.data[..]);
+		let onion_packet_5 = ChannelManager::encrypt_failure_packet(
+			&onion_keys[0].shared_secret,
+			&onion_packet_4.data[..],
+		);
 		assert_eq!(onion_packet_5.data, hex_bytes("9c5add3963fc7f6ed7f148623c84134b5647e1306419dbe2174e523fa9e2fbed3a06a19f899145610741c83ad40b7712aefaddec8c6baf7325d92ea4ca4d1df8bce517f7e54554608bf2bd8071a4f52a7a2f7ffbb1413edad81eeea5785aa9d990f2865dc23b4bc3c301a94eec4eabebca66be5cf638f693ec256aec514620cc28ee4a94bd9565bc4d4962b9d3641d4278fb319ed2b84de5b665f307a2db0f7fbb757366067d88c50f7e829138fde4f78d39b5b5802f1b92a8a820865af5cc79f9f30bc3f461c66af95d13e5e1f0381c184572a91dee1c849048a647a1158cf884064deddbf1b0b88dfe2f791428d0ba0f6fb2f04e14081f69165ae66d9297c118f0907705c9c4954a199bae0bb96fad763d690e7daa6cfda59ba7f2c8d11448b604d12d").unwrap());
 	}
 
-	fn confirm_transaction(chain: &chaininterface::ChainWatchInterfaceUtil, tx: &Transaction, chan_id: u32) {
-		let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	fn confirm_transaction(
+		chain: &chaininterface::ChainWatchInterfaceUtil,
+		tx: &Transaction,
+		chan_id: u32,
+	) {
+		let mut header = BlockHeader {
+			version: 0x20000000,
+			prev_blockhash: Default::default(),
+			merkle_root: Default::default(),
+			time: 42,
+			bits: 42,
+			nonce: 42,
+		};
 		chain.block_connected_checked(&header, 1, &[tx; 1], &[chan_id; 1]);
 		for i in 2..100 {
-			header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+			header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: header.bitcoin_hash(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
 			chain.block_connected_checked(&header, i, &[tx; 0], &[0; 0]);
 		}
 	}
@@ -2003,10 +2895,28 @@ mod tests {
 	}
 
 	static mut CHAN_COUNT: u32 = 0;
-	fn create_chan_between_nodes(node_a: &Node, node_b: &Node) -> (msgs::ChannelAnnouncement, msgs::ChannelUpdate, msgs::ChannelUpdate, Uint256, Transaction) {
-		let open_chan = node_a.node.create_channel(node_b.node.get_our_node_id(), 100000, 42).unwrap();
-		let accept_chan = node_b.node.handle_open_channel(&node_a.node.get_our_node_id(), &open_chan).unwrap();
-		node_a.node.handle_accept_channel(&node_b.node.get_our_node_id(), &accept_chan).unwrap();
+	fn create_chan_between_nodes(
+		node_a: &Node,
+		node_b: &Node,
+	) -> (
+		msgs::ChannelAnnouncement,
+		msgs::ChannelUpdate,
+		msgs::ChannelUpdate,
+		Uint256,
+		Transaction,
+	) {
+		let open_chan = node_a
+			.node
+			.create_channel(node_b.node.get_our_node_id(), 100000, 42)
+			.unwrap();
+		let accept_chan = node_b
+			.node
+			.handle_open_channel(&node_a.node.get_our_node_id(), &open_chan)
+			.unwrap();
+		node_a
+			.node
+			.handle_accept_channel(&node_b.node.get_our_node_id(), &accept_chan)
+			.unwrap();
 
 		let chan_id = unsafe { CHAN_COUNT };
 		let tx;
@@ -2015,40 +2925,63 @@ mod tests {
 		let events_1 = node_a.node.get_and_clear_pending_events();
 		assert_eq!(events_1.len(), 1);
 		match events_1[0] {
-			Event::FundingGenerationReady { ref temporary_channel_id, ref channel_value_satoshis, ref output_script, user_channel_id } => {
+			Event::FundingGenerationReady {
+				ref temporary_channel_id,
+				ref channel_value_satoshis,
+				ref output_script,
+				user_channel_id,
+			} => {
 				assert_eq!(*channel_value_satoshis, 100000);
 				assert_eq!(user_channel_id, 42);
 
-				tx = Transaction { version: chan_id as u32, lock_time: 0, input: Vec::new(), output: vec![TxOut {
-					value: *channel_value_satoshis, script_pubkey: output_script.clone(),
-				}]};
-				funding_output = OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);
+				tx = Transaction {
+					version: chan_id as u32,
+					lock_time: 0,
+					input: Vec::new(),
+					output: vec![TxOut {
+						value: *channel_value_satoshis,
+						script_pubkey: output_script.clone(),
+					}],
+				};
+				funding_output =
+					OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);
 
-				node_a.node.funding_transaction_generated(&temporary_channel_id, funding_output);
+				node_a
+					.node
+					.funding_transaction_generated(&temporary_channel_id, funding_output);
 				let mut added_monitors = node_a.chan_monitor.added_monitors.lock().unwrap();
 				assert_eq!(added_monitors.len(), 1);
 				assert_eq!(added_monitors[0].0, funding_output);
 				added_monitors.clear();
-			},
+			}
 			_ => panic!("Unexpected event"),
 		}
 
 		let events_2 = node_a.node.get_and_clear_pending_events();
 		assert_eq!(events_2.len(), 1);
 		let funding_signed = match events_2[0] {
-			Event::SendFundingCreated { ref node_id, ref msg } => {
+			Event::SendFundingCreated {
+				ref node_id,
+				ref msg,
+			} => {
 				assert_eq!(*node_id, node_b.node.get_our_node_id());
-				let res = node_b.node.handle_funding_created(&node_a.node.get_our_node_id(), msg).unwrap();
+				let res = node_b
+					.node
+					.handle_funding_created(&node_a.node.get_our_node_id(), msg)
+					.unwrap();
 				let mut added_monitors = node_b.chan_monitor.added_monitors.lock().unwrap();
 				assert_eq!(added_monitors.len(), 1);
 				assert_eq!(added_monitors[0].0, funding_output);
 				added_monitors.clear();
 				res
-			},
+			}
 			_ => panic!("Unexpected event"),
 		};
 
-		node_a.node.handle_funding_signed(&node_b.node.get_our_node_id(), &funding_signed).unwrap();
+		node_a
+			.node
+			.handle_funding_signed(&node_b.node.get_our_node_id(), &funding_signed)
+			.unwrap();
 		{
 			let mut added_monitors = node_a.chan_monitor.added_monitors.lock().unwrap();
 			assert_eq!(added_monitors.len(), 1);
@@ -2059,10 +2992,13 @@ mod tests {
 		let events_3 = node_a.node.get_and_clear_pending_events();
 		assert_eq!(events_3.len(), 1);
 		match events_3[0] {
-			Event::FundingBroadcastSafe { ref funding_txo, user_channel_id } => {
+			Event::FundingBroadcastSafe {
+				ref funding_txo,
+				user_channel_id,
+			} => {
 				assert_eq!(user_channel_id, 42);
 				assert_eq!(*funding_txo, funding_output);
-			},
+			}
 			_ => panic!("Unexpected event"),
 		};
 
@@ -2070,11 +3006,18 @@ mod tests {
 		let events_4 = node_a.node.get_and_clear_pending_events();
 		assert_eq!(events_4.len(), 1);
 		match events_4[0] {
-			Event::SendFundingLocked { ref node_id, ref msg, ref announcement_sigs } => {
+			Event::SendFundingLocked {
+				ref node_id,
+				ref msg,
+				ref announcement_sigs,
+			} => {
 				assert_eq!(*node_id, node_b.node.get_our_node_id());
 				assert!(announcement_sigs.is_none());
-				node_b.node.handle_funding_locked(&node_a.node.get_our_node_id(), msg).unwrap()
-			},
+				node_b
+					.node
+					.handle_funding_locked(&node_a.node.get_our_node_id(), msg)
+					.unwrap()
+			}
 			_ => panic!("Unexpected event"),
 		};
 
@@ -2084,33 +3027,54 @@ mod tests {
 		let events_5 = node_b.node.get_and_clear_pending_events();
 		assert_eq!(events_5.len(), 1);
 		let as_announcement_sigs = match events_5[0] {
-			Event::SendFundingLocked { ref node_id, ref msg, ref announcement_sigs } => {
+			Event::SendFundingLocked {
+				ref node_id,
+				ref msg,
+				ref announcement_sigs,
+			} => {
 				assert_eq!(*node_id, node_a.node.get_our_node_id());
 				channel_id = msg.channel_id.clone();
-				let as_announcement_sigs = node_a.node.handle_funding_locked(&node_b.node.get_our_node_id(), msg).unwrap().unwrap();
-				node_a.node.handle_announcement_signatures(&node_b.node.get_our_node_id(), &(*announcement_sigs).clone().unwrap()).unwrap();
+				let as_announcement_sigs = node_a
+					.node
+					.handle_funding_locked(&node_b.node.get_our_node_id(), msg)
+					.unwrap()
+					.unwrap();
+				node_a
+					.node
+					.handle_announcement_signatures(
+						&node_b.node.get_our_node_id(),
+						&(*announcement_sigs).clone().unwrap(),
+					)
+					.unwrap();
 				as_announcement_sigs
-			},
+			}
 			_ => panic!("Unexpected event"),
 		};
 
 		let events_6 = node_a.node.get_and_clear_pending_events();
 		assert_eq!(events_6.len(), 1);
 		let (announcement, as_update) = match events_6[0] {
-			Event::BroadcastChannelAnnouncement { ref msg, ref update_msg } => {
-				(msg, update_msg)
-			},
+			Event::BroadcastChannelAnnouncement {
+				ref msg,
+				ref update_msg,
+			} => (msg, update_msg),
 			_ => panic!("Unexpected event"),
 		};
 
-		node_b.node.handle_announcement_signatures(&node_a.node.get_our_node_id(), &as_announcement_sigs).unwrap();
+		node_b
+			.node
+			.handle_announcement_signatures(&node_a.node.get_our_node_id(), &as_announcement_sigs)
+			.unwrap();
 		let events_7 = node_b.node.get_and_clear_pending_events();
 		assert_eq!(events_7.len(), 1);
 		let bs_update = match events_7[0] {
-			Event::BroadcastChannelAnnouncement { ref msg, ref update_msg } => {
+			Event::BroadcastChannelAnnouncement {
+				ref msg,
+				ref update_msg,
+			} => {
 				assert!(*announcement == *msg);
 				update_msg
-			},
+			}
 			_ => panic!("Unexpected event"),
 		};
 
@@ -2118,47 +3082,101 @@ mod tests {
 			CHAN_COUNT += 1;
 		}
 
-		((*announcement).clone(), (*as_update).clone(), (*bs_update).clone(), channel_id, tx)
+		(
+			(*announcement).clone(),
+			(*as_update).clone(),
+			(*bs_update).clone(),
+			channel_id,
+			tx,
+		)
 	}
 
-	fn create_announced_chan_between_nodes(nodes: &Vec<Node>, a: usize, b: usize) -> (msgs::ChannelUpdate, msgs::ChannelUpdate, Uint256, Transaction) {
+	fn create_announced_chan_between_nodes(
+		nodes: &Vec<Node>,
+		a: usize,
+		b: usize,
+	) -> (
+		msgs::ChannelUpdate,
+		msgs::ChannelUpdate,
+		Uint256,
+		Transaction,
+	) {
 		let chan_announcement = create_chan_between_nodes(&nodes[a], &nodes[b]);
 		for node in nodes {
-			assert!(node.router.handle_channel_announcement(&chan_announcement.0).unwrap());
-			node.router.handle_channel_update(&chan_announcement.1).unwrap();
-			node.router.handle_channel_update(&chan_announcement.2).unwrap();
+			assert!(
+				node.router
+					.handle_channel_announcement(&chan_announcement.0)
+					.unwrap()
+			);
+			node.router
+				.handle_channel_update(&chan_announcement.1)
+				.unwrap();
+			node.router
+				.handle_channel_update(&chan_announcement.2)
+				.unwrap();
 		}
-		(chan_announcement.1, chan_announcement.2, chan_announcement.3, chan_announcement.4)
+		(
+			chan_announcement.1,
+			chan_announcement.2,
+			chan_announcement.3,
+			chan_announcement.4,
+		)
 	}
 
-	fn close_channel(outbound_node: &Node, inbound_node: &Node, channel_id: &Uint256, funding_tx: Transaction, close_inbound_first: bool) -> (msgs::ChannelUpdate, msgs::ChannelUpdate) {
-		let (node_a, broadcaster_a) = if close_inbound_first { (&inbound_node.node, &inbound_node.tx_broadcaster) } else { (&outbound_node.node, &outbound_node.tx_broadcaster) };
-		let (node_b, broadcaster_b) = if close_inbound_first { (&outbound_node.node, &outbound_node.tx_broadcaster) } else { (&inbound_node.node, &inbound_node.tx_broadcaster) };
+	fn close_channel(
+		outbound_node: &Node,
+		inbound_node: &Node,
+		channel_id: &Uint256,
+		funding_tx: Transaction,
+		close_inbound_first: bool,
+	) -> (msgs::ChannelUpdate, msgs::ChannelUpdate) {
+		let (node_a, broadcaster_a) = if close_inbound_first {
+			(&inbound_node.node, &inbound_node.tx_broadcaster)
+		} else {
+			(&outbound_node.node, &outbound_node.tx_broadcaster)
+		};
+		let (node_b, broadcaster_b) = if close_inbound_first {
+			(&outbound_node.node, &outbound_node.tx_broadcaster)
+		} else {
+			(&inbound_node.node, &inbound_node.tx_broadcaster)
+		};
 		let (tx_a, tx_b);
 
 		let shutdown_a = node_a.close_channel(channel_id).unwrap();
-		let (shutdown_b, mut closing_signed_b) = node_b.handle_shutdown(&node_a.get_our_node_id(), &shutdown_a).unwrap();
+		let (shutdown_b, mut closing_signed_b) = node_b
+			.handle_shutdown(&node_a.get_our_node_id(), &shutdown_a)
+			.unwrap();
 		if !close_inbound_first {
 			assert!(closing_signed_b.is_none());
 		}
-		let (empty_a, mut closing_signed_a) = node_a.handle_shutdown(&node_b.get_our_node_id(), &shutdown_b.unwrap()).unwrap();
+		let (empty_a, mut closing_signed_a) = node_a
+			.handle_shutdown(&node_b.get_our_node_id(), &shutdown_b.unwrap())
+			.unwrap();
 		assert!(empty_a.is_none());
 		if close_inbound_first {
 			assert!(closing_signed_a.is_none());
-			closing_signed_a = node_a.handle_closing_signed(&node_b.get_our_node_id(), &closing_signed_b.unwrap()).unwrap();
+			closing_signed_a = node_a
+				.handle_closing_signed(&node_b.get_our_node_id(), &closing_signed_b.unwrap())
+				.unwrap();
 			assert_eq!(broadcaster_a.txn_broadcasted.lock().unwrap().len(), 1);
 			tx_a = broadcaster_a.txn_broadcasted.lock().unwrap().remove(0);
 
-			let empty_b = node_b.handle_closing_signed(&node_a.get_our_node_id(), &closing_signed_a.unwrap()).unwrap();
+			let empty_b = node_b
+				.handle_closing_signed(&node_a.get_our_node_id(), &closing_signed_a.unwrap())
+				.unwrap();
 			assert!(empty_b.is_none());
 			assert_eq!(broadcaster_b.txn_broadcasted.lock().unwrap().len(), 1);
 			tx_b = broadcaster_b.txn_broadcasted.lock().unwrap().remove(0);
 		} else {
-			closing_signed_b = node_b.handle_closing_signed(&node_a.get_our_node_id(), &closing_signed_a.unwrap()).unwrap();
+			closing_signed_b = node_b
+				.handle_closing_signed(&node_a.get_our_node_id(), &closing_signed_a.unwrap())
+				.unwrap();
 			assert_eq!(broadcaster_b.txn_broadcasted.lock().unwrap().len(), 1);
 			tx_b = broadcaster_b.txn_broadcasted.lock().unwrap().remove(0);
 
-			let empty_a2 = node_a.handle_closing_signed(&node_b.get_our_node_id(), &closing_signed_b.unwrap()).unwrap();
+			let empty_a2 = node_a
+				.handle_closing_signed(&node_b.get_our_node_id(), &closing_signed_b.unwrap())
+				.unwrap();
 			assert!(empty_a2.is_none());
 			assert_eq!(broadcaster_a.txn_broadcasted.lock().unwrap().len(), 1);
 			tx_a = broadcaster_a.txn_broadcasted.lock().unwrap().remove(0);
@@ -2171,18 +3189,14 @@ mod tests {
 		let events_1 = node_a.get_and_clear_pending_events();
 		assert_eq!(events_1.len(), 1);
 		let as_update = match events_1[0] {
-			Event::BroadcastChannelUpdate { ref msg } => {
-				msg.clone()
-			},
+			Event::BroadcastChannelUpdate { ref msg } => msg.clone(),
 			_ => panic!("Unexpected event"),
 		};
 
 		let events_2 = node_b.get_and_clear_pending_events();
 		assert_eq!(events_2.len(), 1);
 		let bs_update = match events_2[0] {
-			Event::BroadcastChannelUpdate { ref msg } => {
-				msg.clone()
-			},
+			Event::BroadcastChannelUpdate { ref msg } => msg.clone(),
 			_ => panic!("Unexpected event"),
 		};
 
@@ -2197,8 +3211,14 @@ mod tests {
 	impl SendEvent {
 		fn from_event(event: Event) -> SendEvent {
 			match event {
-				Event::SendHTLCs { node_id, msgs, commitment_msg } => {
-					SendEvent { node_id: node_id, msgs: msgs, commitment_msg: commitment_msg }
+				Event::SendHTLCs {
+					node_id,
+					msgs,
+					commitment_msg,
+				} => SendEvent {
+					node_id: node_id,
+					msgs: msgs,
+					commitment_msg: commitment_msg,
 				},
 				_ => panic!("Unexpected event type!"),
 			}
@@ -2206,7 +3226,12 @@ mod tests {
 	}
 
 	static mut PAYMENT_COUNT: u8 = 0;
-	fn send_along_route(origin_node: &Node, route: Route, expected_route: &[&Node], recv_value: u64) -> ([u8; 32], [u8; 32]) {
+	fn send_along_route(
+		origin_node: &Node,
+		route: Route,
+		expected_route: &[&Node],
+		recv_value: u64,
+	) -> ([u8; 32], [u8; 32]) {
 		let our_payment_preimage = unsafe { [PAYMENT_COUNT; 32] };
 		unsafe { PAYMENT_COUNT += 1 };
 		let our_payment_hash = {
@@ -2218,7 +3243,10 @@ mod tests {
 		};
 
 		let mut payment_event = {
-			origin_node.node.send_payment(route, our_payment_hash).unwrap();
+			origin_node
+				.node
+				.send_payment(route, our_payment_hash)
+				.unwrap();
 			{
 				let mut added_monitors = origin_node.chan_monitor.added_monitors.lock().unwrap();
 				assert_eq!(added_monitors.len(), 1);
@@ -2234,26 +3262,50 @@ mod tests {
 		for (idx, &node) in expected_route.iter().enumerate() {
 			assert_eq!(node.node.get_our_node_id(), payment_event.node_id);
 
-			node.node.handle_update_add_htlc(&prev_node.node.get_our_node_id(), &payment_event.msgs[0]).unwrap();
+			node.node
+				.handle_update_add_htlc(&prev_node.node.get_our_node_id(), &payment_event.msgs[0])
+				.unwrap();
 			{
 				let added_monitors = node.chan_monitor.added_monitors.lock().unwrap();
 				assert_eq!(added_monitors.len(), 0);
 			}
 
-			let revoke_and_ack = node.node.handle_commitment_signed(&prev_node.node.get_our_node_id(), &payment_event.commitment_msg).unwrap();
+			let revoke_and_ack = node.node
+				.handle_commitment_signed(
+					&prev_node.node.get_our_node_id(),
+					&payment_event.commitment_msg,
+				)
+				.unwrap();
 			{
 				let mut added_monitors = node.chan_monitor.added_monitors.lock().unwrap();
 				assert_eq!(added_monitors.len(), 1);
 				added_monitors.clear();
 			}
-			assert!(prev_node.node.handle_revoke_and_ack(&node.node.get_our_node_id(), &revoke_and_ack.0).unwrap().is_none());
-			let prev_revoke_and_ack = prev_node.node.handle_commitment_signed(&node.node.get_our_node_id(), &revoke_and_ack.1.unwrap()).unwrap();
+			assert!(
+				prev_node
+					.node
+					.handle_revoke_and_ack(&node.node.get_our_node_id(), &revoke_and_ack.0)
+					.unwrap()
+					.is_none()
+			);
+			let prev_revoke_and_ack = prev_node
+				.node
+				.handle_commitment_signed(&node.node.get_our_node_id(), &revoke_and_ack.1.unwrap())
+				.unwrap();
 			{
 				let mut added_monitors = prev_node.chan_monitor.added_monitors.lock().unwrap();
 				assert_eq!(added_monitors.len(), 2);
 				added_monitors.clear();
 			}
-			assert!(node.node.handle_revoke_and_ack(&prev_node.node.get_our_node_id(), &prev_revoke_and_ack.0).unwrap().is_none());
+			assert!(
+				node.node
+					.handle_revoke_and_ack(
+						&prev_node.node.get_our_node_id(),
+						&prev_revoke_and_ack.0
+					)
+					.unwrap()
+					.is_none()
+			);
 			assert!(prev_revoke_and_ack.1.is_none());
 			{
 				let mut added_monitors = node.chan_monitor.added_monitors.lock().unwrap();
@@ -2264,7 +3316,7 @@ mod tests {
 			let events_1 = node.node.get_and_clear_pending_events();
 			assert_eq!(events_1.len(), 1);
 			match events_1[0] {
-				Event::PendingHTLCsForwardable { .. } => { },
+				Event::PendingHTLCsForwardable { .. } => {}
 				_ => panic!("Unexpected event"),
 			};
 
@@ -2275,10 +3327,13 @@ mod tests {
 			assert_eq!(events_2.len(), 1);
 			if idx == expected_route.len() - 1 {
 				match events_2[0] {
-					Event::PaymentReceived { ref payment_hash, amt } => {
+					Event::PaymentReceived {
+						ref payment_hash,
+						amt,
+					} => {
 						assert_eq!(our_payment_hash, *payment_hash);
 						assert_eq!(amt, recv_value);
-					},
+					}
 					_ => panic!("Unexpected event"),
 				}
 			} else {
@@ -2298,50 +3353,87 @@ mod tests {
 	}
 
 	fn claim_payment(origin_node: &Node, expected_route: &[&Node], our_payment_preimage: [u8; 32]) {
-		assert!(expected_route.last().unwrap().node.claim_funds(our_payment_preimage));
+		assert!(
+			expected_route
+				.last()
+				.unwrap()
+				.node
+				.claim_funds(our_payment_preimage)
+		);
 		{
-			let mut added_monitors = expected_route.last().unwrap().chan_monitor.added_monitors.lock().unwrap();
+			let mut added_monitors = expected_route
+				.last()
+				.unwrap()
+				.chan_monitor
+				.added_monitors
+				.lock()
+				.unwrap();
 			assert_eq!(added_monitors.len(), 1);
 			added_monitors.clear();
 		}
 
 		let mut next_msgs: Option<(msgs::UpdateFulfillHTLC, msgs::CommitmentSigned)> = None;
 		macro_rules! update_fulfill_dance {
-			($node: expr, $prev_node: expr, $last_node: expr) => {
-				{
-					$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0).unwrap();
+			($node:expr, $prev_node:expr, $last_node:expr) => {{
+				$node
+					.node
+					.handle_update_fulfill_htlc(
+						&$prev_node.node.get_our_node_id(),
+						&next_msgs.as_ref().unwrap().0,
+						)
+					.unwrap();
 					{
-						let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
-						if $last_node {
-							assert_eq!(added_monitors.len(), 1);
-						} else {
-							assert_eq!(added_monitors.len(), 2);
-							assert!(added_monitors[0].0 != added_monitors[1].0);
-						}
-						added_monitors.clear();
-					}
-					let revoke_and_commit = $node.node.handle_commitment_signed(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().1).unwrap();
-					{
-						let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					if $last_node {
 						assert_eq!(added_monitors.len(), 1);
-						added_monitors.clear();
-					}
-					assert!($prev_node.node.handle_revoke_and_ack(&$node.node.get_our_node_id(), &revoke_and_commit.0).unwrap().is_none());
-					let revoke_and_ack = $prev_node.node.handle_commitment_signed(&$node.node.get_our_node_id(), &revoke_and_commit.1.unwrap()).unwrap();
-					assert!(revoke_and_ack.1.is_none());
-					{
-						let mut added_monitors = $prev_node.chan_monitor.added_monitors.lock().unwrap();
+					} else {
 						assert_eq!(added_monitors.len(), 2);
-						added_monitors.clear();
+						assert!(added_monitors[0].0 != added_monitors[1].0);
+						}
+					added_monitors.clear();
 					}
-					assert!($node.node.handle_revoke_and_ack(&$prev_node.node.get_our_node_id(), &revoke_and_ack.0).unwrap().is_none());
+				let revoke_and_commit = $node
+					.node
+					.handle_commitment_signed(
+						&$prev_node.node.get_our_node_id(),
+						&next_msgs.as_ref().unwrap().1,
+						)
+					.unwrap();
 					{
-						let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
-						assert_eq!(added_monitors.len(), 1);
-						added_monitors.clear();
+					let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 1);
+					added_monitors.clear();
 					}
-				}
-			}
+				assert!(
+					$prev_node
+						.node
+						.handle_revoke_and_ack(&$node.node.get_our_node_id(), &revoke_and_commit.0)
+						.unwrap()
+						.is_none()
+					);
+				let revoke_and_ack = $prev_node
+					.node
+					.handle_commitment_signed(&$node.node.get_our_node_id(), &revoke_and_commit.1.unwrap())
+					.unwrap();
+				assert!(revoke_and_ack.1.is_none());
+					{
+					let mut added_monitors = $prev_node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 2);
+					added_monitors.clear();
+					}
+				assert!(
+					$node
+						.node
+						.handle_revoke_and_ack(&$prev_node.node.get_our_node_id(), &revoke_and_ack.0)
+						.unwrap()
+						.is_none()
+					);
+					{
+					let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 1);
+					added_monitors.clear();
+					}
+				}};
 		}
 
 		let mut expected_next_node = expected_route.last().unwrap().node.get_our_node_id();
@@ -2355,10 +3447,14 @@ mod tests {
 			let events = node.node.get_and_clear_pending_events();
 			assert_eq!(events.len(), 1);
 			match events[0] {
-				Event::SendFulfillHTLC { ref node_id, ref msg, ref commitment_msg } => {
+				Event::SendFulfillHTLC {
+					ref node_id,
+					ref msg,
+					ref commitment_msg,
+				} => {
 					expected_next_node = node_id.clone();
 					next_msgs = Some((msg.clone(), commitment_msg.clone()));
-				},
+				}
 				_ => panic!("Unexpected event"),
 			};
 
@@ -2373,15 +3469,27 @@ mod tests {
 		match events[0] {
 			Event::PaymentSent { payment_preimage } => {
 				assert_eq!(payment_preimage, our_payment_preimage);
-			},
+			}
 			_ => panic!("Unexpected event"),
 		}
 	}
 
 	const TEST_FINAL_CLTV: u32 = 32;
 
-	fn route_payment(origin_node: &Node, expected_route: &[&Node], recv_value: u64) -> ([u8; 32], [u8; 32]) {
-		let route = origin_node.router.get_route(&expected_route.last().unwrap().node.get_our_node_id(), &Vec::new(), recv_value, TEST_FINAL_CLTV).unwrap();
+	fn route_payment(
+		origin_node: &Node,
+		expected_route: &[&Node],
+		recv_value: u64,
+	) -> ([u8; 32], [u8; 32]) {
+		let route = origin_node
+			.router
+			.get_route(
+				&expected_route.last().unwrap().node.get_our_node_id(),
+				&Vec::new(),
+				recv_value,
+				TEST_FINAL_CLTV,
+			)
+			.unwrap();
 		assert_eq!(route.hops.len(), expected_route.len());
 		for (node, hop) in expected_route.iter().zip(route.hops.iter()) {
 			assert_eq!(hop.pubkey, node.node.get_our_node_id());
@@ -2391,7 +3499,15 @@ mod tests {
 	}
 
 	fn route_over_limit(origin_node: &Node, expected_route: &[&Node], recv_value: u64) {
-		let route = origin_node.router.get_route(&expected_route.last().unwrap().node.get_our_node_id(), &Vec::new(), recv_value, TEST_FINAL_CLTV).unwrap();
+		let route = origin_node
+			.router
+			.get_route(
+				&expected_route.last().unwrap().node.get_our_node_id(),
+				&Vec::new(),
+				recv_value,
+				TEST_FINAL_CLTV,
+			)
+			.unwrap();
 		assert_eq!(route.hops.len(), expected_route.len());
 		for (node, hop) in expected_route.iter().zip(route.hops.iter()) {
 			assert_eq!(hop.pubkey, node.node.get_our_node_id());
@@ -2407,8 +3523,15 @@ mod tests {
 			ret
 		};
 
-		let err = origin_node.node.send_payment(route, our_payment_hash).err().unwrap();
-		assert_eq!(err.err, "Cannot send value that would put us over our max HTLC value in flight");
+		let err = origin_node
+			.node
+			.send_payment(route, our_payment_hash)
+			.err()
+			.unwrap();
+		assert_eq!(
+			err.err,
+			"Cannot send value that would put us over our max HTLC value in flight"
+		);
 	}
 
 	fn send_payment(origin: &Node, expected_route: &[&Node], recv_value: u64) {
@@ -2417,52 +3540,89 @@ mod tests {
 	}
 
 	fn fail_payment(origin_node: &Node, expected_route: &[&Node], our_payment_hash: [u8; 32]) {
-		assert!(expected_route.last().unwrap().node.fail_htlc_backwards(&our_payment_hash));
+		assert!(
+			expected_route
+				.last()
+				.unwrap()
+				.node
+				.fail_htlc_backwards(&our_payment_hash)
+		);
 		{
-			let mut added_monitors = expected_route.last().unwrap().chan_monitor.added_monitors.lock().unwrap();
+			let mut added_monitors = expected_route
+				.last()
+				.unwrap()
+				.chan_monitor
+				.added_monitors
+				.lock()
+				.unwrap();
 			assert_eq!(added_monitors.len(), 1);
 			added_monitors.clear();
 		}
 
 		let mut next_msgs: Option<(msgs::UpdateFailHTLC, msgs::CommitmentSigned)> = None;
 		macro_rules! update_fail_dance {
-			($node: expr, $prev_node: expr, $last_node: expr) => {
-				{
-					$node.node.handle_update_fail_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0).unwrap();
-					let revoke_and_commit = $node.node.handle_commitment_signed(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().1).unwrap();
+			($node:expr, $prev_node:expr, $last_node:expr) => {{
+				$node
+					.node
+					.handle_update_fail_htlc(
+						&$prev_node.node.get_our_node_id(),
+						&next_msgs.as_ref().unwrap().0,
+						)
+					.unwrap();
+				let revoke_and_commit = $node
+					.node
+					.handle_commitment_signed(
+						&$prev_node.node.get_our_node_id(),
+						&next_msgs.as_ref().unwrap().1,
+						)
+					.unwrap();
 
 					{
-						let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
-						assert_eq!(added_monitors.len(), 1);
-						added_monitors.clear();
+					let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 1);
+					added_monitors.clear();
 					}
-					assert!($prev_node.node.handle_revoke_and_ack(&$node.node.get_our_node_id(), &revoke_and_commit.0).unwrap().is_none());
+				assert!(
+					$prev_node
+						.node
+						.handle_revoke_and_ack(&$node.node.get_our_node_id(), &revoke_and_commit.0)
+						.unwrap()
+						.is_none()
+					);
 					{
-						let mut added_monitors = $prev_node.chan_monitor.added_monitors.lock().unwrap();
-						assert_eq!(added_monitors.len(), 1);
-						added_monitors.clear();
+					let mut added_monitors = $prev_node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 1);
+					added_monitors.clear();
 					}
-					let revoke_and_ack = $prev_node.node.handle_commitment_signed(&$node.node.get_our_node_id(), &revoke_and_commit.1.unwrap()).unwrap();
+				let revoke_and_ack = $prev_node
+					.node
+					.handle_commitment_signed(&$node.node.get_our_node_id(), &revoke_and_commit.1.unwrap())
+					.unwrap();
 					{
-						let mut added_monitors = $prev_node.chan_monitor.added_monitors.lock().unwrap();
-						assert_eq!(added_monitors.len(), 1);
-						added_monitors.clear();
+					let mut added_monitors = $prev_node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 1);
+					added_monitors.clear();
 					}
-					assert!(revoke_and_ack.1.is_none());
-					assert!($node.node.get_and_clear_pending_events().is_empty());
-					assert!($node.node.handle_revoke_and_ack(&$prev_node.node.get_our_node_id(), &revoke_and_ack.0).unwrap().is_none());
+				assert!(revoke_and_ack.1.is_none());
+				assert!($node.node.get_and_clear_pending_events().is_empty());
+				assert!(
+					$node
+						.node
+						.handle_revoke_and_ack(&$prev_node.node.get_our_node_id(), &revoke_and_ack.0)
+						.unwrap()
+						.is_none()
+					);
 					{
-						let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
-						if $last_node {
-							assert_eq!(added_monitors.len(), 1);
-						} else {
-							assert_eq!(added_monitors.len(), 2);
-							assert!(added_monitors[0].0 != added_monitors[1].0);
+					let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					if $last_node {
+						assert_eq!(added_monitors.len(), 1);
+					} else {
+						assert_eq!(added_monitors.len(), 2);
+						assert!(added_monitors[0].0 != added_monitors[1].0);
 						}
-						added_monitors.clear();
+					added_monitors.clear();
 					}
-				}
-			}
+				}};
 		}
 
 		let mut expected_next_node = expected_route.last().unwrap().node.get_our_node_id();
@@ -2476,10 +3636,14 @@ mod tests {
 			let events = node.node.get_and_clear_pending_events();
 			assert_eq!(events.len(), 1);
 			match events[0] {
-				Event::SendFailHTLC { ref node_id, ref msg, ref commitment_msg } => {
+				Event::SendFailHTLC {
+					ref node_id,
+					ref msg,
+					ref commitment_msg,
+				} => {
 					expected_next_node = node_id.clone();
 					next_msgs = Some((msg.clone(), commitment_msg.clone()));
-				},
+				}
 				_ => panic!("Unexpected event"),
 			};
 
@@ -2494,7 +3658,7 @@ mod tests {
 		match events[0] {
 			Event::PaymentFailed { payment_hash } => {
 				assert_eq!(payment_hash, our_payment_hash);
-			},
+			}
 			_ => panic!("Unexpected event"),
 		}
 	}
@@ -2507,16 +3671,38 @@ mod tests {
 		for _ in 0..node_count {
 			let feeest = Arc::new(test_utils::TestFeeEstimator { sat_per_vbyte: 1 });
 			let chain_monitor = Arc::new(chaininterface::ChainWatchInterfaceUtil::new());
-			let tx_broadcaster = Arc::new(test_utils::TestBroadcaster{txn_broadcasted: Mutex::new(Vec::new())});
-			let chan_monitor = Arc::new(test_utils::TestChannelMonitor::new(chain_monitor.clone(), tx_broadcaster.clone()));
+			let tx_broadcaster = Arc::new(test_utils::TestBroadcaster {
+				txn_broadcasted: Mutex::new(Vec::new()),
+			});
+			let chan_monitor = Arc::new(test_utils::TestChannelMonitor::new(
+				chain_monitor.clone(),
+				tx_broadcaster.clone(),
+			));
 			let node_id = {
 				let mut key_slice = [0; 32];
 				rng.fill_bytes(&mut key_slice);
 				SecretKey::from_slice(&secp_ctx, &key_slice).unwrap()
 			};
-			let node = ChannelManager::new(node_id.clone(), 0, true, Network::Testnet, feeest.clone(), chan_monitor.clone(), chain_monitor.clone(), tx_broadcaster.clone()).unwrap();
+			let node = ChannelManager::new(
+				node_id.clone(),
+				0,
+				true,
+				Network::Testnet,
+				feeest.clone(),
+				chan_monitor.clone(),
+				chain_monitor.clone(),
+				tx_broadcaster.clone(),
+			).unwrap();
 			let router = Router::new(PublicKey::from_secret_key(&secp_ctx, &node_id).unwrap());
-			nodes.push(Node { feeest, chain_monitor, tx_broadcaster, chan_monitor, node_id, node, router });
+			nodes.push(Node {
+				feeest,
+				chain_monitor,
+				tx_broadcaster,
+				chan_monitor,
+				node_id,
+				node,
+				router,
+			});
 		}
 
 		nodes
@@ -2534,30 +3720,58 @@ mod tests {
 		let chan_3 = create_announced_chan_between_nodes(&nodes, 2, 3);
 
 		// Rebalance the network a bit by relaying one payment through all the channels...
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], 8000000);
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], 8000000);
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], 8000000);
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], 8000000);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3]][..],
+			8000000,
+		);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3]][..],
+			8000000,
+		);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3]][..],
+			8000000,
+		);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3]][..],
+			8000000,
+		);
 
 		// Send some more payments
-		send_payment(&nodes[1], &vec!(&nodes[2], &nodes[3])[..], 1000000);
-		send_payment(&nodes[3], &vec!(&nodes[2], &nodes[1], &nodes[0])[..], 1000000);
-		send_payment(&nodes[3], &vec!(&nodes[2], &nodes[1])[..], 1000000);
+		send_payment(&nodes[1], &vec![&nodes[2], &nodes[3]][..], 1000000);
+		send_payment(
+			&nodes[3],
+			&vec![&nodes[2], &nodes[1], &nodes[0]][..],
+			1000000,
+		);
+		send_payment(&nodes[3], &vec![&nodes[2], &nodes[1]][..], 1000000);
 
 		// Test failure packets
-		let payment_hash_1 = route_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], 1000000).1;
-		fail_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], payment_hash_1);
+		let payment_hash_1 = route_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3]][..],
+			1000000,
+		).1;
+		fail_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3]][..],
+			payment_hash_1,
+		);
 
 		// Add a new channel that skips 3
 		let chan_4 = create_announced_chan_between_nodes(&nodes, 1, 3);
 
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 1000000);
-		send_payment(&nodes[2], &vec!(&nodes[3])[..], 1000000);
-		send_payment(&nodes[1], &vec!(&nodes[3])[..], 8000000);
-		send_payment(&nodes[1], &vec!(&nodes[3])[..], 8000000);
-		send_payment(&nodes[1], &vec!(&nodes[3])[..], 8000000);
-		send_payment(&nodes[1], &vec!(&nodes[3])[..], 8000000);
-		send_payment(&nodes[1], &vec!(&nodes[3])[..], 8000000);
+		send_payment(&nodes[0], &vec![&nodes[1], &nodes[3]][..], 1000000);
+		send_payment(&nodes[2], &vec![&nodes[3]][..], 1000000);
+		send_payment(&nodes[1], &vec![&nodes[3]][..], 8000000);
+		send_payment(&nodes[1], &vec![&nodes[3]][..], 8000000);
+		send_payment(&nodes[1], &vec![&nodes[3]][..], 8000000);
+		send_payment(&nodes[1], &vec![&nodes[3]][..], 8000000);
+		send_payment(&nodes[1], &vec![&nodes[3]][..], 8000000);
 
 		// Do some rebalance loop payments, simultaneously
 		let mut hops = Vec::with_capacity(3);
@@ -2565,13 +3779,13 @@ mod tests {
 			pubkey: nodes[2].node.get_our_node_id(),
 			short_channel_id: chan_2.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_3.0.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_3.0.contents.cltv_expiry_delta as u32,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[3].node.get_our_node_id(),
 			short_channel_id: chan_3.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_4.1.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_4.1.contents.cltv_expiry_delta as u32,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[1].node.get_our_node_id(),
@@ -2579,22 +3793,31 @@ mod tests {
 			fee_msat: 1000000,
 			cltv_expiry_delta: TEST_FINAL_CLTV,
 		});
-		hops[1].fee_msat = chan_4.1.contents.fee_base_msat as u64 + chan_4.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64 / 1000000;
-		hops[0].fee_msat = chan_3.0.contents.fee_base_msat as u64 + chan_3.0.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64 / 1000000;
-		let payment_preimage_1 = send_along_route(&nodes[1], Route { hops }, &vec!(&nodes[2], &nodes[3], &nodes[1])[..], 1000000).0;
+		hops[1].fee_msat = chan_4.1.contents.fee_base_msat as u64
+			+ chan_4.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64
+				/ 1000000;
+		hops[0].fee_msat = chan_3.0.contents.fee_base_msat as u64
+			+ chan_3.0.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64
+				/ 1000000;
+		let payment_preimage_1 = send_along_route(
+			&nodes[1],
+			Route { hops },
+			&vec![&nodes[2], &nodes[3], &nodes[1]][..],
+			1000000,
+		).0;
 
 		let mut hops = Vec::with_capacity(3);
 		hops.push(RouteHop {
 			pubkey: nodes[3].node.get_our_node_id(),
 			short_channel_id: chan_4.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_3.1.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_3.1.contents.cltv_expiry_delta as u32,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[2].node.get_our_node_id(),
 			short_channel_id: chan_3.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_2.1.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_2.1.contents.cltv_expiry_delta as u32,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[1].node.get_our_node_id(),
@@ -2602,29 +3825,61 @@ mod tests {
 			fee_msat: 1000000,
 			cltv_expiry_delta: TEST_FINAL_CLTV,
 		});
-		hops[1].fee_msat = chan_2.1.contents.fee_base_msat as u64 + chan_2.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64 / 1000000;
-		hops[0].fee_msat = chan_3.1.contents.fee_base_msat as u64 + chan_3.1.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64 / 1000000;
-		let payment_hash_2 = send_along_route(&nodes[1], Route { hops }, &vec!(&nodes[3], &nodes[2], &nodes[1])[..], 1000000).1;
+		hops[1].fee_msat = chan_2.1.contents.fee_base_msat as u64
+			+ chan_2.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64
+				/ 1000000;
+		hops[0].fee_msat = chan_3.1.contents.fee_base_msat as u64
+			+ chan_3.1.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64
+				/ 1000000;
+		let payment_hash_2 = send_along_route(
+			&nodes[1],
+			Route { hops },
+			&vec![&nodes[3], &nodes[2], &nodes[1]][..],
+			1000000,
+		).1;
 
 		// Claim the rebalances...
-		fail_payment(&nodes[1], &vec!(&nodes[3], &nodes[2], &nodes[1])[..], payment_hash_2);
-		claim_payment(&nodes[1], &vec!(&nodes[2], &nodes[3], &nodes[1])[..], payment_preimage_1);
+		fail_payment(
+			&nodes[1],
+			&vec![&nodes[3], &nodes[2], &nodes[1]][..],
+			payment_hash_2,
+		);
+		claim_payment(
+			&nodes[1],
+			&vec![&nodes[2], &nodes[3], &nodes[1]][..],
+			payment_preimage_1,
+		);
 
 		// Add a duplicate new channel from 2 to 4
 		let chan_5 = create_announced_chan_between_nodes(&nodes, 1, 3);
 
 		// Send some payments across both channels
-		let payment_preimage_3 = route_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 3000000).0;
-		let payment_preimage_4 = route_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 3000000).0;
-		let payment_preimage_5 = route_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 3000000).0;
+		let payment_preimage_3 =
+			route_payment(&nodes[0], &vec![&nodes[1], &nodes[3]][..], 3000000).0;
+		let payment_preimage_4 =
+			route_payment(&nodes[0], &vec![&nodes[1], &nodes[3]][..], 3000000).0;
+		let payment_preimage_5 =
+			route_payment(&nodes[0], &vec![&nodes[1], &nodes[3]][..], 3000000).0;
 
-		route_over_limit(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 3000000);
+		route_over_limit(&nodes[0], &vec![&nodes[1], &nodes[3]][..], 3000000);
 
 		//TODO: Test that routes work again here as we've been notified that the channel is full
 
-		claim_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], payment_preimage_3);
-		claim_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], payment_preimage_4);
-		claim_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], payment_preimage_5);
+		claim_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[3]][..],
+			payment_preimage_3,
+		);
+		claim_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[3]][..],
+			payment_preimage_4,
+		);
+		claim_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[3]][..],
+			payment_preimage_5,
+		);
 
 		// Close down the channels...
 		close_channel(&nodes[0], &nodes[1], &chan_1.2, chan_1.3, true);
@@ -2641,10 +3896,28 @@ mod tests {
 	}
 
 	#[derive(PartialEq)]
-	enum HTLCType { NONE, TIMEOUT, SUCCESS }
-	fn test_txn_broadcast(node: &Node, chan: &(msgs::ChannelUpdate, msgs::ChannelUpdate, Uint256, Transaction), commitment_tx: Option<Transaction>, has_htlc_tx: HTLCType) -> Vec<Transaction> {
+	enum HTLCType {
+		NONE,
+		TIMEOUT,
+		SUCCESS,
+	}
+	fn test_txn_broadcast(
+		node: &Node,
+		chan: &(
+			msgs::ChannelUpdate,
+			msgs::ChannelUpdate,
+			Uint256,
+			Transaction,
+		),
+		commitment_tx: Option<Transaction>,
+		has_htlc_tx: HTLCType,
+	) -> Vec<Transaction> {
 		let mut node_txn = node.tx_broadcaster.txn_broadcasted.lock().unwrap();
-		assert!(node_txn.len() >= if commitment_tx.is_some() { 0 } else { 1 } + if has_htlc_tx == HTLCType::NONE { 0 } else { 1 });
+		assert!(
+			node_txn.len()
+				>= if commitment_tx.is_some() { 0 } else { 1 }
+					+ if has_htlc_tx == HTLCType::NONE { 0 } else { 1 }
+		);
 
 		let mut res = Vec::with_capacity(2);
 
@@ -2714,18 +3987,14 @@ mod tests {
 		let events_1 = nodes[a].node.get_and_clear_pending_events();
 		assert_eq!(events_1.len(), 1);
 		let as_update = match events_1[0] {
-			Event::BroadcastChannelUpdate { ref msg } => {
-				msg.clone()
-			},
+			Event::BroadcastChannelUpdate { ref msg } => msg.clone(),
 			_ => panic!("Unexpected event"),
 		};
 
 		let events_2 = nodes[b].node.get_and_clear_pending_events();
 		assert_eq!(events_2.len(), 1);
 		let bs_update = match events_2[0] {
-			Event::BroadcastChannelUpdate { ref msg } => {
-				msg.clone()
-			},
+			Event::BroadcastChannelUpdate { ref msg } => msg.clone(),
 			_ => panic!("Unexpected event"),
 		};
 
@@ -2748,71 +4017,135 @@ mod tests {
 		let chan_4 = create_announced_chan_between_nodes(&nodes, 3, 4);
 
 		// Rebalance the network a bit by relaying one payment through all the channels...
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3], &nodes[4])[..], 8000000);
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3], &nodes[4])[..], 8000000);
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3], &nodes[4])[..], 8000000);
-		send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3], &nodes[4])[..], 8000000);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3], &nodes[4]][..],
+			8000000,
+		);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3], &nodes[4]][..],
+			8000000,
+		);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3], &nodes[4]][..],
+			8000000,
+		);
+		send_payment(
+			&nodes[0],
+			&vec![&nodes[1], &nodes[2], &nodes[3], &nodes[4]][..],
+			8000000,
+		);
 
 		// Simple case with no pending HTLCs:
-		nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), true);
+		nodes[1]
+			.node
+			.peer_disconnected(&nodes[0].node.get_our_node_id(), true);
 		{
 			let node_txn = test_txn_broadcast(&nodes[1], &chan_1, None, HTLCType::NONE);
-			let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[0].chain_monitor.block_connected_checked(&header, 1, &[&node_txn[0]; 1], &[4; 1]);
-			assert_eq!(nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap().len(), 0);
+			let header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: Default::default(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[0]
+				.chain_monitor
+				.block_connected_checked(&header, 1, &[&node_txn[0]; 1], &[4; 1]);
+			assert_eq!(
+				nodes[0]
+					.tx_broadcaster
+					.txn_broadcasted
+					.lock()
+					.unwrap()
+					.len(),
+				0
+			);
 		}
 		get_announce_close_broadcast_events(&nodes, 0, 1);
 		assert_eq!(nodes[0].node.list_channels().len(), 0);
 		assert_eq!(nodes[1].node.list_channels().len(), 1);
 
 		// One pending HTLC is discarded by the force-close:
-		let payment_preimage_1 = route_payment(&nodes[1], &vec!(&nodes[2], &nodes[3])[..], 3000000).0;
+		let payment_preimage_1 =
+			route_payment(&nodes[1], &vec![&nodes[2], &nodes[3]][..], 3000000).0;
 
 		// Simple case of one pending HTLC to HTLC-Timeout
-		nodes[1].node.peer_disconnected(&nodes[2].node.get_our_node_id(), true);
+		nodes[1]
+			.node
+			.peer_disconnected(&nodes[2].node.get_our_node_id(), true);
 		{
 			let node_txn = test_txn_broadcast(&nodes[1], &chan_2, None, HTLCType::TIMEOUT);
-			let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[2].chain_monitor.block_connected_checked(&header, 1, &[&node_txn[0]; 1], &[4; 1]);
-			assert_eq!(nodes[2].tx_broadcaster.txn_broadcasted.lock().unwrap().len(), 0);
+			let header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: Default::default(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[2]
+				.chain_monitor
+				.block_connected_checked(&header, 1, &[&node_txn[0]; 1], &[4; 1]);
+			assert_eq!(
+				nodes[2]
+					.tx_broadcaster
+					.txn_broadcasted
+					.lock()
+					.unwrap()
+					.len(),
+				0
+			);
 		}
 		get_announce_close_broadcast_events(&nodes, 1, 2);
 		assert_eq!(nodes[1].node.list_channels().len(), 0);
 		assert_eq!(nodes[2].node.list_channels().len(), 1);
 
 		macro_rules! claim_funds {
-			($node: expr, $prev_node: expr, $preimage: expr) => {
-				{
-					assert!($node.node.claim_funds($preimage));
+			($node:expr, $prev_node:expr, $preimage:expr) => {{
+				assert!($node.node.claim_funds($preimage));
 					{
-						let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
-						assert_eq!(added_monitors.len(), 1);
-						added_monitors.clear();
+					let mut added_monitors = $node.chan_monitor.added_monitors.lock().unwrap();
+					assert_eq!(added_monitors.len(), 1);
+					added_monitors.clear();
 					}
 
-					let events = $node.node.get_and_clear_pending_events();
-					assert_eq!(events.len(), 1);
-					match events[0] {
-						Event::SendFulfillHTLC { ref node_id, .. } => {
-							assert_eq!(*node_id, $prev_node.node.get_our_node_id());
-						},
-						_ => panic!("Unexpected event"),
+				let events = $node.node.get_and_clear_pending_events();
+				assert_eq!(events.len(), 1);
+				match events[0] {
+					Event::SendFulfillHTLC { ref node_id, .. } => {
+						assert_eq!(*node_id, $prev_node.node.get_our_node_id());
+						}
+					_ => panic!("Unexpected event"),
 					};
-				}
-			}
+				}};
 		}
 
 		// nodes[3] gets the preimage, but nodes[2] already disconnected, resulting in a nodes[2]
 		// HTLC-Timeout and a nodes[3] claim against it (+ its own announces)
-		nodes[2].node.peer_disconnected(&nodes[3].node.get_our_node_id(), true);
+		nodes[2]
+			.node
+			.peer_disconnected(&nodes[3].node.get_our_node_id(), true);
 		{
 			let node_txn = test_txn_broadcast(&nodes[2], &chan_3, None, HTLCType::TIMEOUT);
 
 			// Claim the payment on nodes[3], giving it knowledge of the preimage
 			claim_funds!(nodes[3], nodes[2], payment_preimage_1);
 
-			let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[3].chain_monitor.block_connected_checked(&header, 1, &[&node_txn[0]; 1], &[4; 1]);
+			let header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: Default::default(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[3]
+				.chain_monitor
+				.block_connected_checked(&header, 1, &[&node_txn[0]; 1], &[4; 1]);
 
 			check_preimage_claim(&nodes[3], &node_txn);
 		}
@@ -2821,14 +4154,35 @@ mod tests {
 		assert_eq!(nodes[3].node.list_channels().len(), 1);
 
 		// One pending HTLC to time out:
-		let payment_preimage_2 = route_payment(&nodes[3], &vec!(&nodes[4])[..], 3000000).0;
+		let payment_preimage_2 = route_payment(&nodes[3], &vec![&nodes[4]][..], 3000000).0;
 
 		{
-			let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[3].chain_monitor.block_connected_checked(&header, 1, &Vec::new()[..], &[0; 0]);
+			let mut header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: Default::default(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[3]
+				.chain_monitor
+				.block_connected_checked(&header, 1, &Vec::new()[..], &[0; 0]);
 			for i in 2..TEST_FINAL_CLTV - 5 {
-				header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-				nodes[3].chain_monitor.block_connected_checked(&header, i, &Vec::new()[..], &[0; 0]);
+				header = BlockHeader {
+					version: 0x20000000,
+					prev_blockhash: header.bitcoin_hash(),
+					merkle_root: Default::default(),
+					time: 42,
+					bits: 42,
+					nonce: 42,
+				};
+				nodes[3].chain_monitor.block_connected_checked(
+					&header,
+					i,
+					&Vec::new()[..],
+					&[0; 0],
+				);
 			}
 
 			let node_txn = test_txn_broadcast(&nodes[3], &chan_4, None, HTLCType::TIMEOUT);
@@ -2836,17 +4190,50 @@ mod tests {
 			// Claim the payment on nodes[3], giving it knowledge of the preimage
 			claim_funds!(nodes[4], nodes[3], payment_preimage_2);
 
-			header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[4].chain_monitor.block_connected_checked(&header, 1, &Vec::new()[..], &[0; 0]);
+			header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: Default::default(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[4]
+				.chain_monitor
+				.block_connected_checked(&header, 1, &Vec::new()[..], &[0; 0]);
 			for i in 2..TEST_FINAL_CLTV - 5 {
-				header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-				nodes[4].chain_monitor.block_connected_checked(&header, i, &Vec::new()[..], &[0; 0]);
+				header = BlockHeader {
+					version: 0x20000000,
+					prev_blockhash: header.bitcoin_hash(),
+					merkle_root: Default::default(),
+					time: 42,
+					bits: 42,
+					nonce: 42,
+				};
+				nodes[4].chain_monitor.block_connected_checked(
+					&header,
+					i,
+					&Vec::new()[..],
+					&[0; 0],
+				);
 			}
 
 			test_txn_broadcast(&nodes[4], &chan_4, None, HTLCType::SUCCESS);
 
-			header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[4].chain_monitor.block_connected_checked(&header, TEST_FINAL_CLTV - 5, &[&node_txn[0]; 1], &[4; 1]);
+			header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: header.bitcoin_hash(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[4].chain_monitor.block_connected_checked(
+				&header,
+				TEST_FINAL_CLTV - 5,
+				&[&node_txn[0]; 1],
+				&[4; 1],
+			);
 
 			check_preimage_claim(&nodes[4], &node_txn);
 		}
@@ -2858,15 +4245,38 @@ mod tests {
 		let chan_5 = create_announced_chan_between_nodes(&nodes, 0, 1);
 
 		// A pending HTLC which will be revoked:
-		let payment_preimage_3 = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
+		let payment_preimage_3 = route_payment(&nodes[0], &vec![&nodes[1]][..], 3000000).0;
 		// Get the will-be-revoked local txn from nodes[0]
-		let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.iter().next().unwrap().1.last_local_commitment_txn.clone();
+		let revoked_local_txn = nodes[0]
+			.node
+			.channel_state
+			.lock()
+			.unwrap()
+			.by_id
+			.iter()
+			.next()
+			.unwrap()
+			.1
+			.last_local_commitment_txn
+			.clone();
 		// Revoke the old state
-		claim_payment(&nodes[0], &vec!(&nodes[1])[..], payment_preimage_3);
+		claim_payment(&nodes[0], &vec![&nodes[1]][..], payment_preimage_3);
 
 		{
-			let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[1].chain_monitor.block_connected_checked(&header, 1, &vec![&revoked_local_txn[0]; 1], &[4; 1]);
+			let mut header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: Default::default(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[1].chain_monitor.block_connected_checked(
+				&header,
+				1,
+				&vec![&revoked_local_txn[0]; 1],
+				&[4; 1],
+			);
 			{
 				let mut node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
 				assert_eq!(node_txn.len(), 1);
@@ -2878,10 +4288,29 @@ mod tests {
 				node_txn.clear();
 			}
 
-			nodes[0].chain_monitor.block_connected_checked(&header, 1, &vec![&revoked_local_txn[0]; 1], &[4; 0]);
-			let node_txn = test_txn_broadcast(&nodes[0], &chan_5, Some(revoked_local_txn[0].clone()), HTLCType::TIMEOUT);
-			header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[1].chain_monitor.block_connected_checked(&header, 1, &[&node_txn[1]; 1], &[4; 1]);
+			nodes[0].chain_monitor.block_connected_checked(
+				&header,
+				1,
+				&vec![&revoked_local_txn[0]; 1],
+				&[4; 0],
+			);
+			let node_txn = test_txn_broadcast(
+				&nodes[0],
+				&chan_5,
+				Some(revoked_local_txn[0].clone()),
+				HTLCType::TIMEOUT,
+			);
+			header = BlockHeader {
+				version: 0x20000000,
+				prev_blockhash: header.bitcoin_hash(),
+				merkle_root: Default::default(),
+				time: 42,
+				bits: 42,
+				nonce: 42,
+			};
+			nodes[1]
+				.chain_monitor
+				.block_connected_checked(&header, 1, &[&node_txn[1]; 1], &[4; 1]);
 
 			//TODO: At this point nodes[1] should claim the revoked HTLC-Timeout output, but that's
 			//not yet implemented in ChannelMonitor

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -1,24 +1,24 @@
 use bitcoin::blockdata::block::BlockHeader;
-use bitcoin::blockdata::transaction::{TxIn,TxOut,SigHashType,Transaction};
 use bitcoin::blockdata::script::Script;
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin::blockdata::transaction::{SigHashType, Transaction, TxIn, TxOut};
 use bitcoin::util::bip143;
+use bitcoin::util::hash::Sha256dHash;
 
 use crypto::digest::Digest;
 
-use secp256k1::{Secp256k1,Message,Signature};
-use secp256k1::key::{SecretKey,PublicKey};
+use secp256k1::key::{PublicKey, SecretKey};
+use secp256k1::{Message, Secp256k1, Signature};
 
-use ln::msgs::HandleError;
+use chain::chaininterface::{BroadcasterInterface, ChainListener, ChainWatchInterface};
+use chain::transaction::OutPoint;
 use ln::chan_utils;
 use ln::chan_utils::HTLCOutputInCommitment;
-use chain::chaininterface::{ChainListener, ChainWatchInterface, BroadcasterInterface};
-use chain::transaction::OutPoint;
+use ln::msgs::HandleError;
 use util::sha2::Sha256;
 
 use std::collections::HashMap;
-use std::sync::{Arc,Mutex};
-use std::{hash,cmp};
+use std::sync::{Arc, Mutex};
+use std::{cmp, hash};
 
 pub enum ChannelMonitorUpdateErr {
 	/// Used to indicate a temporary failure (eg connection to a watchtower failed, but is expected
@@ -44,7 +44,11 @@ pub enum ChannelMonitorUpdateErr {
 /// which we have revoked, allowing our counterparty to claim all funds in the channel!
 pub trait ManyChannelMonitor: Send + Sync {
 	/// Adds or updates a monitor for the given `funding_txo`.
-	fn add_update_monitor(&self, funding_txo: OutPoint, monitor: ChannelMonitor) -> Result<(), ChannelMonitorUpdateErr>;
+	fn add_update_monitor(
+		&self,
+		funding_txo: OutPoint,
+		monitor: ChannelMonitor,
+	) -> Result<(), ChannelMonitorUpdateErr>;
 }
 
 /// A simple implementation of a ManyChannelMonitor and ChainListener. Can be used to create a
@@ -58,33 +62,46 @@ pub trait ManyChannelMonitor: Send + Sync {
 pub struct SimpleManyChannelMonitor<Key> {
 	monitors: Mutex<HashMap<Key, ChannelMonitor>>,
 	chain_monitor: Arc<ChainWatchInterface>,
-	broadcaster: Arc<BroadcasterInterface>
+	broadcaster: Arc<BroadcasterInterface>,
 }
 
-impl<Key : Send + cmp::Eq + hash::Hash> ChainListener for SimpleManyChannelMonitor<Key> {
-	fn block_connected(&self, _header: &BlockHeader, height: u32, txn_matched: &[&Transaction], _indexes_of_txn_matched: &[u32]) {
+impl<Key: Send + cmp::Eq + hash::Hash> ChainListener for SimpleManyChannelMonitor<Key> {
+	fn block_connected(
+		&self,
+		_header: &BlockHeader,
+		height: u32,
+		txn_matched: &[&Transaction],
+		_indexes_of_txn_matched: &[u32],
+	) {
 		let monitors = self.monitors.lock().unwrap();
 		for monitor in monitors.values() {
 			monitor.block_connected(txn_matched, height, &*self.broadcaster);
 		}
 	}
 
-	fn block_disconnected(&self, _: &BlockHeader) { }
+	fn block_disconnected(&self, _: &BlockHeader) {}
 }
 
-impl<Key : Send + cmp::Eq + hash::Hash + 'static> SimpleManyChannelMonitor<Key> {
-	pub fn new(chain_monitor: Arc<ChainWatchInterface>, broadcaster: Arc<BroadcasterInterface>) -> Arc<SimpleManyChannelMonitor<Key>> {
+impl<Key: Send + cmp::Eq + hash::Hash + 'static> SimpleManyChannelMonitor<Key> {
+	pub fn new(
+		chain_monitor: Arc<ChainWatchInterface>,
+		broadcaster: Arc<BroadcasterInterface>,
+	) -> Arc<SimpleManyChannelMonitor<Key>> {
 		let res = Arc::new(SimpleManyChannelMonitor {
 			monitors: Mutex::new(HashMap::new()),
 			chain_monitor,
-			broadcaster
+			broadcaster,
 		});
 		let weak_res = Arc::downgrade(&res);
 		res.chain_monitor.register_listener(weak_res);
 		res
 	}
 
-	pub fn add_update_monitor_by_key(&self, key: Key, monitor: ChannelMonitor) -> Result<(), HandleError> {
+	pub fn add_update_monitor_by_key(
+		&self,
+		key: Key,
+		monitor: ChannelMonitor,
+	) -> Result<(), HandleError> {
 		let mut monitors = self.monitors.lock().unwrap();
 		match monitors.get_mut(&key) {
 			Some(orig_monitor) => return orig_monitor.insert_combine(monitor),
@@ -92,7 +109,8 @@ impl<Key : Send + cmp::Eq + hash::Hash + 'static> SimpleManyChannelMonitor<Key> 
 		};
 		match monitor.funding_txo {
 			None => self.chain_monitor.watch_all_txn(),
-			Some(outpoint) => self.chain_monitor.install_watch_outpoint((outpoint.txid, outpoint.index as u32)),
+			Some(outpoint) => self.chain_monitor
+				.install_watch_outpoint((outpoint.txid, outpoint.index as u32)),
 		}
 		monitors.insert(key, monitor);
 		Ok(())
@@ -100,7 +118,11 @@ impl<Key : Send + cmp::Eq + hash::Hash + 'static> SimpleManyChannelMonitor<Key> 
 }
 
 impl ManyChannelMonitor for SimpleManyChannelMonitor<OutPoint> {
-	fn add_update_monitor(&self, funding_txo: OutPoint, monitor: ChannelMonitor) -> Result<(), ChannelMonitorUpdateErr> {
+	fn add_update_monitor(
+		&self,
+		funding_txo: OutPoint,
+		monitor: ChannelMonitor,
+	) -> Result<(), ChannelMonitorUpdateErr> {
 		match self.add_update_monitor_by_key(funding_txo, monitor) {
 			Ok(_) => Ok(()),
 			Err(_) => Err(ChannelMonitorUpdateErr::PermanentFailure),
@@ -125,7 +147,7 @@ enum KeyStorage {
 		revocation_base_key: PublicKey,
 		htlc_base_key: PublicKey,
 		sigs: HashMap<Sha256dHash, Signature>,
-	}
+	},
 }
 
 #[derive(Clone)]
@@ -176,7 +198,8 @@ impl Clone for ChannelMonitor {
 	fn clone(&self) -> Self {
 		ChannelMonitor {
 			funding_txo: self.funding_txo.clone(),
-			commitment_transaction_number_obscure_factor: self.commitment_transaction_number_obscure_factor.clone(),
+			commitment_transaction_number_obscure_factor:
+				self.commitment_transaction_number_obscure_factor.clone(),
 
 			key_storage: self.key_storage.clone(),
 			delayed_payment_base_key: self.delayed_payment_base_key.clone(),
@@ -188,7 +211,9 @@ impl Clone for ChannelMonitor {
 
 			old_secrets: self.old_secrets.clone(),
 			remote_claimable_outpoints: self.remote_claimable_outpoints.clone(),
-			remote_htlc_outputs_on_chain: Mutex::new((*self.remote_htlc_outputs_on_chain.lock().unwrap()).clone()),
+			remote_htlc_outputs_on_chain: Mutex::new(
+				(*self.remote_htlc_outputs_on_chain.lock().unwrap()).clone(),
+			),
 			remote_hash_commitment_number: self.remote_hash_commitment_number.clone(),
 
 			prev_local_signed_commitment_tx: self.prev_local_signed_commitment_tx.clone(),
@@ -203,7 +228,13 @@ impl Clone for ChannelMonitor {
 }
 
 impl ChannelMonitor {
-	pub fn new(revocation_base_key: &SecretKey, delayed_payment_base_key: &PublicKey, htlc_base_key: &SecretKey, our_to_self_delay: u16, destination_script: Script) -> ChannelMonitor {
+	pub fn new(
+		revocation_base_key: &SecretKey,
+		delayed_payment_base_key: &PublicKey,
+		htlc_base_key: &SecretKey,
+		our_to_self_delay: u16,
+		destination_script: Script,
+	) -> ChannelMonitor {
 		ChannelMonitor {
 			funding_txo: None,
 			commitment_transaction_number_obscure_factor: 0,
@@ -238,7 +269,7 @@ impl ChannelMonitor {
 	fn place_secret(idx: u64) -> u8 {
 		for i in 0..48 {
 			if idx & (1 << i) == (1 << i) {
-				return i
+				return i;
 			}
 		}
 		48
@@ -264,12 +295,20 @@ impl ChannelMonitor {
 	/// in case the remote end force-closes using their latest state. Prunes old preimages if neither
 	/// needed by local commitment transactions HTCLs nor by remote ones. Unless we haven't already seen remote
 	/// commitment transaction's secret, they are de facto pruned (we can use revocation key).
-	pub fn provide_secret(&mut self, idx: u64, secret: [u8; 32], their_next_revocation_point: Option<(u64, PublicKey)>) -> Result<(), HandleError> {
+	pub fn provide_secret(
+		&mut self,
+		idx: u64,
+		secret: [u8; 32],
+		their_next_revocation_point: Option<(u64, PublicKey)>,
+	) -> Result<(), HandleError> {
 		let pos = ChannelMonitor::place_secret(idx);
 		for i in 0..pos {
 			let (old_secret, old_idx) = self.old_secrets[i as usize];
 			if ChannelMonitor::derive_secret(secret, pos, old_idx) != old_secret {
-				return Err(HandleError{err: "Previous secret did not match new one", msg: None})
+				return Err(HandleError {
+					err: "Previous secret did not match new one",
+					msg: None,
+				});
 			}
 		}
 		self.old_secrets[pos as usize] = (secret, idx);
@@ -278,25 +317,35 @@ impl ChannelMonitor {
 			match self.their_cur_revocation_points {
 				Some(old_points) => {
 					if old_points.0 == new_revocation_point.0 + 1 {
-						self.their_cur_revocation_points = Some((old_points.0, old_points.1, Some(new_revocation_point.1)));
+						self.their_cur_revocation_points =
+							Some((old_points.0, old_points.1, Some(new_revocation_point.1)));
 					} else if old_points.0 == new_revocation_point.0 + 2 {
 						if let Some(old_second_point) = old_points.2 {
-							self.their_cur_revocation_points = Some((old_points.0 - 1, old_second_point, Some(new_revocation_point.1)));
+							self.their_cur_revocation_points = Some((
+								old_points.0 - 1,
+								old_second_point,
+								Some(new_revocation_point.1),
+							));
 						} else {
-							self.their_cur_revocation_points = Some((new_revocation_point.0, new_revocation_point.1, None));
+							self.their_cur_revocation_points =
+								Some((new_revocation_point.0, new_revocation_point.1, None));
 						}
 					} else {
-						self.their_cur_revocation_points = Some((new_revocation_point.0, new_revocation_point.1, None));
+						self.their_cur_revocation_points =
+							Some((new_revocation_point.0, new_revocation_point.1, None));
 					}
-				},
+				}
 				None => {
-					self.their_cur_revocation_points = Some((new_revocation_point.0, new_revocation_point.1, None));
+					self.their_cur_revocation_points =
+						Some((new_revocation_point.0, new_revocation_point.1, None));
 				}
 			}
 		}
 
 		if !self.payment_preimages.is_empty() {
-			let local_signed_commitment_tx = self.current_local_signed_commitment_tx.as_ref().expect("Channel needs at least an initial commitment tx !");
+			let local_signed_commitment_tx = self.current_local_signed_commitment_tx
+				.as_ref()
+				.expect("Channel needs at least an initial commitment tx !");
 			let prev_local_signed_commitment_tx = self.prev_local_signed_commitment_tx.as_ref();
 			let min_idx = self.get_min_seen_secret();
 			let remote_hash_commitment_number = &mut self.remote_hash_commitment_number;
@@ -304,22 +353,24 @@ impl ChannelMonitor {
 			self.payment_preimages.retain(|&k, _| {
 				for &(ref htlc, _, _) in &local_signed_commitment_tx.htlc_outputs {
 					if k == htlc.payment_hash {
-						return true
+						return true;
 					}
 				}
 				if let Some(prev_local_commitment_tx) = prev_local_signed_commitment_tx {
 					for &(ref htlc, _, _) in prev_local_commitment_tx.htlc_outputs.iter() {
 						if k == htlc.payment_hash {
-							return true
+							return true;
 						}
 					}
 				}
 				let contains = if let Some(cn) = remote_hash_commitment_number.get(&k) {
 					if *cn < min_idx {
-						return true
+						return true;
 					}
 					true
-				} else { false };
+				} else {
+					false
+				};
 				if contains {
 					remote_hash_commitment_number.remove(&k);
 				}
@@ -334,15 +385,22 @@ impl ChannelMonitor {
 	/// The monitor watches for it to be broadcasted and then uses the HTLC information (and
 	/// possibly future revocation/preimage information) to claim outputs where possible.
 	/// We cache also the mapping hash:commitment number to lighten pruning of old preimages by watchtowers.
-	pub fn provide_latest_remote_commitment_tx_info(&mut self, unsigned_commitment_tx: &Transaction, htlc_outputs: Vec<HTLCOutputInCommitment>, commitment_number: u64) {
+	pub fn provide_latest_remote_commitment_tx_info(
+		&mut self,
+		unsigned_commitment_tx: &Transaction,
+		htlc_outputs: Vec<HTLCOutputInCommitment>,
+		commitment_number: u64,
+	) {
 		// TODO: Encrypt the htlc_outputs data with the single-hash of the commitment transaction
 		// so that a remote monitor doesn't learn anything unless there is a malicious close.
 		// (only maybe, sadly we cant do the same for local info, as we need to be aware of
 		// timeouts)
 		for htlc in &htlc_outputs {
-			self.remote_hash_commitment_number.insert(htlc.payment_hash, commitment_number);
+			self.remote_hash_commitment_number
+				.insert(htlc.payment_hash, commitment_number);
 		}
-		self.remote_claimable_outpoints.insert(unsigned_commitment_tx.txid(), htlc_outputs);
+		self.remote_claimable_outpoints
+			.insert(unsigned_commitment_tx.txid(), htlc_outputs);
 	}
 
 	/// Informs this monitor of the latest local (ie broadcastable) commitment transaction. The
@@ -350,7 +408,13 @@ impl ChannelMonitor {
 	/// is important that any clones of this channel monitor (including remote clones) by kept
 	/// up-to-date as our local commitment transaction is updated.
 	/// Panics if set_their_to_self_delay has never been called.
-	pub fn provide_latest_local_commitment_tx_info(&mut self, signed_commitment_tx: Transaction, local_keys: chan_utils::TxCreationKeys, feerate_per_kw: u64, htlc_outputs: Vec<(HTLCOutputInCommitment, Signature, Signature)>) {
+	pub fn provide_latest_local_commitment_tx_info(
+		&mut self,
+		signed_commitment_tx: Transaction,
+		local_keys: chan_utils::TxCreationKeys,
+		feerate_per_kw: u64,
+		htlc_outputs: Vec<(HTLCOutputInCommitment, Signature, Signature)>,
+	) {
 		assert!(self.their_to_self_delay.is_some());
 		self.prev_local_signed_commitment_tx = self.current_local_signed_commitment_tx.take();
 		self.current_local_signed_commitment_tx = Some(LocalSignedTx {
@@ -367,23 +431,35 @@ impl ChannelMonitor {
 
 	/// Provides a payment_hash->payment_preimage mapping. Will be automatically pruned when all
 	/// commitment_tx_infos which contain the payment hash have been revoked.
-	pub fn provide_payment_preimage(&mut self, payment_hash: &[u8; 32], payment_preimage: &[u8; 32]) {
-		self.payment_preimages.insert(payment_hash.clone(), payment_preimage.clone());
+	pub fn provide_payment_preimage(
+		&mut self,
+		payment_hash: &[u8; 32],
+		payment_preimage: &[u8; 32],
+	) {
+		self.payment_preimages
+			.insert(payment_hash.clone(), payment_preimage.clone());
 	}
 
 	pub fn insert_combine(&mut self, mut other: ChannelMonitor) -> Result<(), HandleError> {
 		match self.funding_txo {
 			Some(txo) => if other.funding_txo.is_some() && other.funding_txo.unwrap() != txo {
-				return Err(HandleError{err: "Funding transaction outputs are not identical!", msg: None});
+				return Err(HandleError {
+					err: "Funding transaction outputs are not identical!",
+					msg: None,
+				});
 			},
 			None => if other.funding_txo.is_some() {
 				self.funding_txo = other.funding_txo;
-			}
+			},
 		}
 		let other_min_secret = other.get_min_seen_secret();
 		let our_min_secret = self.get_min_seen_secret();
 		if our_min_secret > other_min_secret {
-			self.provide_secret(other_min_secret, other.get_secret(other_min_secret).unwrap(), None)?;
+			self.provide_secret(
+				other_min_secret,
+				other.get_secret(other_min_secret).unwrap(),
+				None,
+			)?;
 		}
 		if our_min_secret >= other_min_secret {
 			self.their_cur_revocation_points = other.their_cur_revocation_points;
@@ -402,9 +478,13 @@ impl ChannelMonitor {
 	}
 
 	/// Panics if commitment_transaction_number_obscure_factor doesn't fit in 48 bits
-	pub fn set_commitment_obscure_factor(&mut self, commitment_transaction_number_obscure_factor: u64) {
+	pub fn set_commitment_obscure_factor(
+		&mut self,
+		commitment_transaction_number_obscure_factor: u64,
+	) {
 		assert!(commitment_transaction_number_obscure_factor < (1 << 48));
-		self.commitment_transaction_number_obscure_factor = commitment_transaction_number_obscure_factor;
+		self.commitment_transaction_number_obscure_factor =
+			commitment_transaction_number_obscure_factor;
 	}
 
 	/// Allows this monitor to scan only for transactions which are applicable. Note that this is
@@ -438,11 +518,18 @@ impl ChannelMonitor {
 	pub fn get_secret(&self, idx: u64) -> Result<[u8; 32], HandleError> {
 		for i in 0..self.old_secrets.len() {
 			if (idx & (!((1 << i) - 1))) == self.old_secrets[i].1 {
-				return Ok(ChannelMonitor::derive_secret(self.old_secrets[i].0, i as u8, idx))
+				return Ok(ChannelMonitor::derive_secret(
+					self.old_secrets[i].0,
+					i as u8,
+					idx,
+				));
 			}
 		}
 		assert!(idx < self.get_min_seen_secret());
-		Err(HandleError{err: "idx too low", msg: None})
+		Err(HandleError {
+			err: "idx too low",
+			msg: None,
+		})
 	}
 
 	pub fn get_min_seen_secret(&self) -> u64 {
@@ -466,40 +553,99 @@ impl ChannelMonitor {
 		// a spend transaction...so we return no transactions to broadcast
 		let mut txn_to_broadcast = Vec::new();
 		macro_rules! ignore_error {
-			( $thing : expr ) => {
+			($thing:expr) => {
 				match $thing {
 					Ok(a) => a,
-					Err(_) => return txn_to_broadcast
-				}
+					Err(_) => return txn_to_broadcast,
+					}
 			};
 		}
 
 		let commitment_txid = tx.txid(); //TODO: This is gonna be a performance bottleneck for watchtowers!
 		let per_commitment_option = self.remote_claimable_outpoints.get(&commitment_txid);
 
-		let commitment_number = (((tx.input[0].sequence as u64 & 0xffffff) << 3*8) | (tx.lock_time as u64 & 0xffffff)) ^ self.commitment_transaction_number_obscure_factor;
+		let commitment_number = (((tx.input[0].sequence as u64 & 0xffffff) << 3 * 8)
+			| (tx.lock_time as u64 & 0xffffff))
+			^ self.commitment_transaction_number_obscure_factor;
 		if commitment_number >= self.get_min_seen_secret() {
 			let secret = self.get_secret(commitment_number).unwrap();
 			let per_commitment_key = ignore_error!(SecretKey::from_slice(&self.secp_ctx, &secret));
 			let (revocation_pubkey, b_htlc_key) = match self.key_storage {
-				KeyStorage::PrivMode { ref revocation_base_key, ref htlc_base_key } => {
-					let per_commitment_point = ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key));
-					(ignore_error!(chan_utils::derive_public_revocation_key(&self.secp_ctx, &per_commitment_point, &ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &revocation_base_key)))),
-					ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &per_commitment_point, &ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &htlc_base_key)))))
-				},
-				KeyStorage::SigsMode { ref revocation_base_key, ref htlc_base_key, .. } => {
-					let per_commitment_point = ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key));
-					(ignore_error!(chan_utils::derive_public_revocation_key(&self.secp_ctx, &per_commitment_point, &revocation_base_key)),
-					ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &per_commitment_point, &htlc_base_key)))
-				},
+				KeyStorage::PrivMode {
+					ref revocation_base_key,
+					ref htlc_base_key,
+				} => {
+					let per_commitment_point = ignore_error!(PublicKey::from_secret_key(
+						&self.secp_ctx,
+						&per_commitment_key
+					));
+					(
+						ignore_error!(chan_utils::derive_public_revocation_key(
+							&self.secp_ctx,
+							&per_commitment_point,
+							&ignore_error!(PublicKey::from_secret_key(
+								&self.secp_ctx,
+								&revocation_base_key
+							))
+						)),
+						ignore_error!(chan_utils::derive_public_key(
+							&self.secp_ctx,
+							&per_commitment_point,
+							&ignore_error!(PublicKey::from_secret_key(
+								&self.secp_ctx,
+								&htlc_base_key
+							))
+						)),
+					)
+				}
+				KeyStorage::SigsMode {
+					ref revocation_base_key,
+					ref htlc_base_key,
+					..
+				} => {
+					let per_commitment_point = ignore_error!(PublicKey::from_secret_key(
+						&self.secp_ctx,
+						&per_commitment_key
+					));
+					(
+						ignore_error!(chan_utils::derive_public_revocation_key(
+							&self.secp_ctx,
+							&per_commitment_point,
+							&revocation_base_key
+						)),
+						ignore_error!(chan_utils::derive_public_key(
+							&self.secp_ctx,
+							&per_commitment_point,
+							&htlc_base_key
+						)),
+					)
+				}
 			};
-			let delayed_key = ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key)), &self.delayed_payment_base_key));
+			let delayed_key = ignore_error!(chan_utils::derive_public_key(
+				&self.secp_ctx,
+				&ignore_error!(PublicKey::from_secret_key(
+					&self.secp_ctx,
+					&per_commitment_key
+				)),
+				&self.delayed_payment_base_key
+			));
 			let a_htlc_key = match self.their_htlc_base_key {
 				None => return txn_to_broadcast,
-				Some(their_htlc_base_key) => ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key)), &their_htlc_base_key)),
+				Some(their_htlc_base_key) => ignore_error!(chan_utils::derive_public_key(
+					&self.secp_ctx,
+					&ignore_error!(PublicKey::from_secret_key(
+						&self.secp_ctx,
+						&per_commitment_key
+					)),
+					&their_htlc_base_key
+				)),
 			};
 
-			let revokeable_redeemscript = chan_utils::get_revokeable_redeemscript(&revocation_pubkey, self.our_to_self_delay, &delayed_key);
+			let revokeable_redeemscript = chan_utils::get_revokeable_redeemscript(
+				&revocation_pubkey,
+				self.our_to_self_delay,
+				&delayed_key,
+			);
 			let revokeable_p2wsh = revokeable_redeemscript.to_v0_p2wsh();
 
 			let mut total_value = 0;
@@ -524,42 +670,69 @@ impl ChannelMonitor {
 			}
 
 			macro_rules! sign_input {
-				($sighash_parts: expr, $input: expr, $htlc_idx: expr, $amount: expr) => {
-					{
-						let (sig, redeemscript) = match self.key_storage {
-							KeyStorage::PrivMode { ref revocation_base_key, .. } => {
-								let redeemscript = if $htlc_idx.is_none() { revokeable_redeemscript.clone() } else {
-									let htlc = &per_commitment_option.unwrap()[$htlc_idx.unwrap()];
-									chan_utils::get_htlc_redeemscript_with_explicit_keys(htlc, &a_htlc_key, &b_htlc_key, &revocation_pubkey)
-								};
-								let sighash = ignore_error!(Message::from_slice(&$sighash_parts.sighash_all(&$input, &redeemscript, $amount)[..]));
-								let revocation_key = ignore_error!(chan_utils::derive_private_revocation_key(&self.secp_ctx, &per_commitment_key, &revocation_base_key));
-								(ignore_error!(self.secp_ctx.sign(&sighash, &revocation_key)), redeemscript)
-							},
-							KeyStorage::SigsMode { .. } => {
-								unimplemented!();
+				($sighash_parts:expr, $input:expr, $htlc_idx:expr, $amount:expr) => {{
+					let (sig, redeemscript) = match self.key_storage {
+						KeyStorage::PrivMode {
+							ref revocation_base_key,
+							..
+						} => {
+							let redeemscript = if $htlc_idx.is_none() {
+								revokeable_redeemscript.clone()
+							} else {
+								let htlc = &per_commitment_option.unwrap()[$htlc_idx.unwrap()];
+								chan_utils::get_htlc_redeemscript_with_explicit_keys(
+									htlc,
+									&a_htlc_key,
+									&b_htlc_key,
+									&revocation_pubkey,
+								)
+							};
+							let sighash = ignore_error!(Message::from_slice(
+								&$sighash_parts.sighash_all(&$input, &redeemscript, $amount)[..]
+							));
+							let revocation_key = ignore_error!(chan_utils::derive_private_revocation_key(
+								&self.secp_ctx,
+								&per_commitment_key,
+								&revocation_base_key
+							));
+							(
+								ignore_error!(self.secp_ctx.sign(&sighash, &revocation_key)),
+								redeemscript,
+							)
+							}
+						KeyStorage::SigsMode { .. } => {
+							unimplemented!();
 							}
 						};
-						$input.witness.push(sig.serialize_der(&self.secp_ctx).to_vec());
-						$input.witness[0].push(SigHashType::All as u8);
-						if $htlc_idx.is_none() {
-							$input.witness.push(vec!(1));
-						} else {
-							$input.witness.push(revocation_pubkey.serialize().to_vec());
+					$input
+						.witness
+						.push(sig.serialize_der(&self.secp_ctx).to_vec());
+					$input.witness[0].push(SigHashType::All as u8);
+					if $htlc_idx.is_none() {
+						$input.witness.push(vec![1]);
+					} else {
+						$input.witness.push(revocation_pubkey.serialize().to_vec());
 						}
-						$input.witness.push(redeemscript.into_vec());
-					}
-				}
+					$input.witness.push(redeemscript.into_vec());
+					}};
 			}
 
 			if let Some(per_commitment_data) = per_commitment_option {
 				inputs.reserve_exact(per_commitment_data.len());
 
 				for (idx, htlc) in per_commitment_data.iter().enumerate() {
-					let expected_script = chan_utils::get_htlc_redeemscript_with_explicit_keys(&htlc, &a_htlc_key, &b_htlc_key, &revocation_pubkey);
-					if htlc.transaction_output_index as usize >= tx.output.len() ||
-							tx.output[htlc.transaction_output_index as usize].value != htlc.amount_msat / 1000 ||
-							tx.output[htlc.transaction_output_index as usize].script_pubkey != expected_script.to_v0_p2wsh() {
+					let expected_script = chan_utils::get_htlc_redeemscript_with_explicit_keys(
+						&htlc,
+						&a_htlc_key,
+						&b_htlc_key,
+						&revocation_pubkey,
+					);
+					if htlc.transaction_output_index as usize >= tx.output.len()
+						|| tx.output[htlc.transaction_output_index as usize].value
+							!= htlc.amount_msat / 1000
+						|| tx.output[htlc.transaction_output_index as usize].script_pubkey
+							!= expected_script.to_v0_p2wsh()
+					{
 						return txn_to_broadcast; // Corrupted per_commitment_data, fuck this user
 					}
 					let input = TxIn {
@@ -579,13 +752,18 @@ impl ChannelMonitor {
 							version: 2,
 							lock_time: 0,
 							input: vec![input],
-							output: vec!(TxOut {
+							output: vec![TxOut {
 								script_pubkey: self.destination_script.clone(),
 								value: htlc.amount_msat / 1000, //TODO: - fee
-							}),
+							}],
 						};
 						let sighash_parts = bip143::SighashComponents::new(&single_htlc_tx);
-						sign_input!(sighash_parts, single_htlc_tx.input[0], Some(idx), htlc.amount_msat / 1000);
+						sign_input!(
+							sighash_parts,
+							single_htlc_tx.input[0],
+							Some(idx),
+							htlc.amount_msat / 1000
+						);
 						txn_to_broadcast.push(single_htlc_tx); // TODO: This is not yet tested in ChannelManager!
 					}
 				}
@@ -594,14 +772,19 @@ impl ChannelMonitor {
 			if !inputs.is_empty() || !txn_to_broadcast.is_empty() {
 				// We're definitely a remote commitment transaction!
 				// TODO: Register commitment_txid with the ChainWatchInterface!
-				self.remote_htlc_outputs_on_chain.lock().unwrap().insert(commitment_txid, commitment_number);
+				self.remote_htlc_outputs_on_chain
+					.lock()
+					.unwrap()
+					.insert(commitment_txid, commitment_number);
 			}
-			if inputs.is_empty() { return txn_to_broadcast; } // Nothing to be done...probably a false positive/local tx
+			if inputs.is_empty() {
+				return txn_to_broadcast;
+			} // Nothing to be done...probably a false positive/local tx
 
-			let outputs = vec!(TxOut {
+			let outputs = vec![TxOut {
 				script_pubkey: self.destination_script.clone(),
 				value: total_value, //TODO: - fee
-			});
+			}];
 			let mut spend_tx = Transaction {
 				version: 2,
 				lock_time: 0,
@@ -620,25 +803,64 @@ impl ChannelMonitor {
 			txn_to_broadcast.push(spend_tx);
 		} else if let Some(per_commitment_data) = per_commitment_option {
 			if let Some(revocation_points) = self.their_cur_revocation_points {
-				let revocation_point_option =
-					if revocation_points.0 == commitment_number { Some(&revocation_points.1) }
-					else if let Some(point) = revocation_points.2.as_ref() {
-						if revocation_points.0 == commitment_number + 1 { Some(point) } else { None }
-					} else { None };
+				let revocation_point_option = if revocation_points.0 == commitment_number {
+					Some(&revocation_points.1)
+				} else if let Some(point) = revocation_points.2.as_ref() {
+					if revocation_points.0 == commitment_number + 1 {
+						Some(point)
+					} else {
+						None
+					}
+				} else {
+					None
+				};
 				if let Some(revocation_point) = revocation_point_option {
 					let (revocation_pubkey, b_htlc_key) = match self.key_storage {
-						KeyStorage::PrivMode { ref revocation_base_key, ref htlc_base_key } => {
-							(ignore_error!(chan_utils::derive_public_revocation_key(&self.secp_ctx, revocation_point, &ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &revocation_base_key)))),
-							ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, revocation_point, &ignore_error!(PublicKey::from_secret_key(&self.secp_ctx, &htlc_base_key)))))
-						},
-						KeyStorage::SigsMode { ref revocation_base_key, ref htlc_base_key, .. } => {
-							(ignore_error!(chan_utils::derive_public_revocation_key(&self.secp_ctx, revocation_point, &revocation_base_key)),
-							ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, revocation_point, &htlc_base_key)))
-						},
+						KeyStorage::PrivMode {
+							ref revocation_base_key,
+							ref htlc_base_key,
+						} => (
+							ignore_error!(chan_utils::derive_public_revocation_key(
+								&self.secp_ctx,
+								revocation_point,
+								&ignore_error!(PublicKey::from_secret_key(
+									&self.secp_ctx,
+									&revocation_base_key
+								))
+							)),
+							ignore_error!(chan_utils::derive_public_key(
+								&self.secp_ctx,
+								revocation_point,
+								&ignore_error!(PublicKey::from_secret_key(
+									&self.secp_ctx,
+									&htlc_base_key
+								))
+							)),
+						),
+						KeyStorage::SigsMode {
+							ref revocation_base_key,
+							ref htlc_base_key,
+							..
+						} => (
+							ignore_error!(chan_utils::derive_public_revocation_key(
+								&self.secp_ctx,
+								revocation_point,
+								&revocation_base_key
+							)),
+							ignore_error!(chan_utils::derive_public_key(
+								&self.secp_ctx,
+								revocation_point,
+								&htlc_base_key
+							)),
+						),
 					};
 					let a_htlc_key = match self.their_htlc_base_key {
 						None => return txn_to_broadcast,
-						Some(their_htlc_base_key) => ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, revocation_point, &their_htlc_base_key)),
+						Some(their_htlc_base_key) => ignore_error!(chan_utils::derive_public_key(
+							&self.secp_ctx,
+							revocation_point,
+							&their_htlc_base_key
+						)),
 					};
 
 					let mut total_value = 0;
@@ -646,30 +868,48 @@ impl ChannelMonitor {
 					let mut inputs = Vec::new();
 
 					macro_rules! sign_input {
-						($sighash_parts: expr, $input: expr, $amount: expr, $preimage: expr) => {
-							{
-								let (sig, redeemscript) = match self.key_storage {
-									KeyStorage::PrivMode { ref htlc_base_key, .. } => {
-										let htlc = &per_commitment_option.unwrap()[$input.sequence as usize];
-										let redeemscript = chan_utils::get_htlc_redeemscript_with_explicit_keys(htlc, &a_htlc_key, &b_htlc_key, &revocation_pubkey);
-										let sighash = ignore_error!(Message::from_slice(&$sighash_parts.sighash_all(&$input, &redeemscript, $amount)[..]));
-										let htlc_key = ignore_error!(chan_utils::derive_private_key(&self.secp_ctx, revocation_point, &htlc_base_key));
-										(ignore_error!(self.secp_ctx.sign(&sighash, &htlc_key)), redeemscript)
-									},
-									KeyStorage::SigsMode { .. } => {
-										unimplemented!();
+						($sighash_parts:expr, $input:expr, $amount:expr, $preimage:expr) => {{
+							let (sig, redeemscript) = match self.key_storage {
+								KeyStorage::PrivMode {
+									ref htlc_base_key, ..
+								} => {
+									let htlc = &per_commitment_option.unwrap()[$input.sequence as usize];
+									let redeemscript = chan_utils::get_htlc_redeemscript_with_explicit_keys(
+										htlc,
+										&a_htlc_key,
+										&b_htlc_key,
+										&revocation_pubkey,
+									);
+									let sighash = ignore_error!(Message::from_slice(
+										&$sighash_parts.sighash_all(&$input, &redeemscript, $amount)[..]
+									));
+									let htlc_key = ignore_error!(chan_utils::derive_private_key(
+										&self.secp_ctx,
+										revocation_point,
+										&htlc_base_key
+									));
+									(
+										ignore_error!(self.secp_ctx.sign(&sighash, &htlc_key)),
+										redeemscript,
+									)
+									}
+								KeyStorage::SigsMode { .. } => {
+									unimplemented!();
 									}
 								};
-								$input.witness.push(sig.serialize_der(&self.secp_ctx).to_vec());
-								$input.witness[0].push(SigHashType::All as u8);
-								$input.witness.push($preimage);
-								$input.witness.push(redeemscript.into_vec());
-							}
-						}
+							$input
+								.witness
+								.push(sig.serialize_der(&self.secp_ctx).to_vec());
+							$input.witness[0].push(SigHashType::All as u8);
+							$input.witness.push($preimage);
+							$input.witness.push(redeemscript.into_vec());
+							}};
 					}
 
 					for (idx, htlc) in per_commitment_data.iter().enumerate() {
-						if let Some(payment_preimage) = self.payment_preimages.get(&htlc.payment_hash) {
+						if let Some(payment_preimage) =
+							self.payment_preimages.get(&htlc.payment_hash)
+						{
 							let input = TxIn {
 								prev_hash: commitment_txid,
 								prev_index: htlc.transaction_output_index,
@@ -679,31 +919,41 @@ impl ChannelMonitor {
 							};
 							if htlc.cltv_expiry > height + CLTV_SHARED_CLAIM_BUFFER {
 								inputs.push(input);
-								values.push((tx.output[htlc.transaction_output_index as usize].value, payment_preimage));
+								values.push((
+									tx.output[htlc.transaction_output_index as usize].value,
+									payment_preimage,
+								));
 								total_value += htlc.amount_msat / 1000;
 							} else {
 								let mut single_htlc_tx = Transaction {
 									version: 2,
 									lock_time: 0,
 									input: vec![input],
-									output: vec!(TxOut {
+									output: vec![TxOut {
 										script_pubkey: self.destination_script.clone(),
 										value: htlc.amount_msat / 1000, //TODO: - fee
-									}),
+									}],
 								};
 								let sighash_parts = bip143::SighashComponents::new(&single_htlc_tx);
-								sign_input!(sighash_parts, single_htlc_tx.input[0], htlc.amount_msat / 1000, payment_preimage.to_vec());
+								sign_input!(
+									sighash_parts,
+									single_htlc_tx.input[0],
+									htlc.amount_msat / 1000,
+									payment_preimage.to_vec()
+								);
 								txn_to_broadcast.push(single_htlc_tx);
 							}
 						}
 					}
 
-					if inputs.is_empty() { return txn_to_broadcast; } // Nothing to be done...probably a false positive/local tx
+					if inputs.is_empty() {
+						return txn_to_broadcast;
+					} // Nothing to be done...probably a false positive/local tx
 
-					let outputs = vec!(TxOut {
+					let outputs = vec![TxOut {
 						script_pubkey: self.destination_script.clone(),
 						value: total_value, //TODO: - fee
-					});
+					}];
 					let mut spend_tx = Transaction {
 						version: 2,
 						lock_time: 0,
@@ -734,32 +984,70 @@ impl ChannelMonitor {
 
 		for &(ref htlc, ref their_sig, ref our_sig) in local_tx.htlc_outputs.iter() {
 			if htlc.offered {
-				let mut htlc_timeout_tx = chan_utils::build_htlc_transaction(&local_tx.txid, local_tx.feerate_per_kw, self.their_to_self_delay.unwrap(), htlc, &local_tx.delayed_payment_key, &local_tx.revocation_key);
+				let mut htlc_timeout_tx = chan_utils::build_htlc_transaction(
+					&local_tx.txid,
+					local_tx.feerate_per_kw,
+					self.their_to_self_delay.unwrap(),
+					htlc,
+					&local_tx.delayed_payment_key,
+					&local_tx.revocation_key,
+				);
 
 				htlc_timeout_tx.input[0].witness.push(Vec::new()); // First is the multisig dummy
 
-				htlc_timeout_tx.input[0].witness.push(their_sig.serialize_der(&self.secp_ctx).to_vec());
+				htlc_timeout_tx.input[0]
+					.witness
+					.push(their_sig.serialize_der(&self.secp_ctx).to_vec());
 				htlc_timeout_tx.input[0].witness[1].push(SigHashType::All as u8);
-				htlc_timeout_tx.input[0].witness.push(our_sig.serialize_der(&self.secp_ctx).to_vec());
+				htlc_timeout_tx.input[0]
+					.witness
+					.push(our_sig.serialize_der(&self.secp_ctx).to_vec());
 				htlc_timeout_tx.input[0].witness[2].push(SigHashType::All as u8);
 
 				htlc_timeout_tx.input[0].witness.push(Vec::new());
-				htlc_timeout_tx.input[0].witness.push(chan_utils::get_htlc_redeemscript_with_explicit_keys(htlc, &local_tx.a_htlc_key, &local_tx.b_htlc_key, &local_tx.revocation_key).into_vec());
+				htlc_timeout_tx.input[0].witness.push(
+					chan_utils::get_htlc_redeemscript_with_explicit_keys(
+						htlc,
+						&local_tx.a_htlc_key,
+						&local_tx.b_htlc_key,
+						&local_tx.revocation_key,
+					).into_vec(),
+				);
 
 				res.push(htlc_timeout_tx);
 			} else {
 				if let Some(payment_preimage) = self.payment_preimages.get(&htlc.payment_hash) {
-					let mut htlc_success_tx = chan_utils::build_htlc_transaction(&local_tx.txid, local_tx.feerate_per_kw, self.their_to_self_delay.unwrap(), htlc, &local_tx.delayed_payment_key, &local_tx.revocation_key);
+					let mut htlc_success_tx = chan_utils::build_htlc_transaction(
+						&local_tx.txid,
+						local_tx.feerate_per_kw,
+						self.their_to_self_delay.unwrap(),
+						htlc,
+						&local_tx.delayed_payment_key,
+						&local_tx.revocation_key,
+					);
 
 					htlc_success_tx.input[0].witness.push(Vec::new()); // First is the multisig dummy
 
-					htlc_success_tx.input[0].witness.push(their_sig.serialize_der(&self.secp_ctx).to_vec());
+					htlc_success_tx.input[0]
+						.witness
+						.push(their_sig.serialize_der(&self.secp_ctx).to_vec());
 					htlc_success_tx.input[0].witness[1].push(SigHashType::All as u8);
-					htlc_success_tx.input[0].witness.push(our_sig.serialize_der(&self.secp_ctx).to_vec());
+					htlc_success_tx.input[0]
+						.witness
+						.push(our_sig.serialize_der(&self.secp_ctx).to_vec());
 					htlc_success_tx.input[0].witness[2].push(SigHashType::All as u8);
 
-					htlc_success_tx.input[0].witness.push(payment_preimage.to_vec());
-					htlc_success_tx.input[0].witness.push(chan_utils::get_htlc_redeemscript_with_explicit_keys(htlc, &local_tx.a_htlc_key, &local_tx.b_htlc_key, &local_tx.revocation_key).into_vec());
+					htlc_success_tx.input[0]
+						.witness
+						.push(payment_preimage.to_vec());
+					htlc_success_tx.input[0].witness.push(
+						chan_utils::get_htlc_redeemscript_with_explicit_keys(
+							htlc,
+							&local_tx.a_htlc_key,
+							&local_tx.b_htlc_key,
+							&local_tx.revocation_key,
+						).into_vec(),
+					);
 
 					res.push(htlc_success_tx);
 				}
@@ -787,10 +1075,18 @@ impl ChannelMonitor {
 		Vec::new()
 	}
 
-	fn block_connected(&self, txn_matched: &[&Transaction], height: u32, broadcaster: &BroadcasterInterface) {
+	fn block_connected(
+		&self,
+		txn_matched: &[&Transaction],
+		height: u32,
+		broadcaster: &BroadcasterInterface,
+	) {
 		for tx in txn_matched {
 			for txin in tx.input.iter() {
-				if self.funding_txo.is_none() || (txin.prev_hash == self.funding_txo.unwrap().txid && txin.prev_index == self.funding_txo.unwrap().index as u32) {
+				if self.funding_txo.is_none()
+					|| (txin.prev_hash == self.funding_txo.unwrap().txid
+						&& txin.prev_index == self.funding_txo.unwrap().index as u32)
+				{
 					let mut txn = self.check_spend_remote_transaction(tx, height);
 					if txn.is_empty() {
 						txn = self.check_spend_local_transaction(tx, height);
@@ -836,16 +1132,16 @@ impl ChannelMonitor {
 
 #[cfg(test)]
 mod tests {
-	use bitcoin::util::misc::hex_bytes;
 	use bitcoin::blockdata::script::Script;
 	use bitcoin::blockdata::transaction::Transaction;
+	use bitcoin::util::misc::hex_bytes;
 	use crypto::digest::Digest;
-	use ln::channelmonitor::ChannelMonitor;
 	use ln::chan_utils::{HTLCOutputInCommitment, TxCreationKeys};
-	use util::sha2::Sha256;
-	use secp256k1::key::{SecretKey,PublicKey};
+	use ln::channelmonitor::ChannelMonitor;
+	use rand::{thread_rng, Rng};
+	use secp256k1::key::{PublicKey, SecretKey};
 	use secp256k1::{Secp256k1, Signature};
-	use rand::{thread_rng,Rng};
+	use util::sha2::Sha256;
 
 	#[test]
 	fn test_per_commitment_storage() {
@@ -860,7 +1156,7 @@ mod tests {
 				for secret in secrets.iter() {
 					assert_eq!(monitor.get_secret(idx).unwrap(), *secret);
 					idx -= 1;
-				}
+					}
 				assert_eq!(monitor.get_min_seen_secret(), idx + 1);
 				assert!(monitor.get_secret(idx).is_err());
 			};
@@ -868,336 +1164,638 @@ mod tests {
 
 		{
 			// insert_secret correct sequence
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd").unwrap());
-			monitor.provide_secret(281474976710651, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710651, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2").unwrap());
-			monitor.provide_secret(281474976710650, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710650, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32").unwrap());
-			monitor.provide_secret(281474976710649, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710649, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17").unwrap());
-			monitor.provide_secret(281474976710648, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710648, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 		}
 
 		{
 			// insert_secret #1 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("02a40c85b6f28da08dfdbe0926c53fab2de6d28c10301f8f7c4073d5e42e3148").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"02a40c85b6f28da08dfdbe0926c53fab2de6d28c10301f8f7c4073d5e42e3148",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #2 incorrect (#1 derived from incorrect)
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("02a40c85b6f28da08dfdbe0926c53fab2de6d28c10301f8f7c4073d5e42e3148").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"02a40c85b6f28da08dfdbe0926c53fab2de6d28c10301f8f7c4073d5e42e3148",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("dddc3a8d14fddf2b68fa8c7fbad2748274937479dd0f8930d5ebb4ab6bd866a3").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"dddc3a8d14fddf2b68fa8c7fbad2748274937479dd0f8930d5ebb4ab6bd866a3",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #3 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c51a18b13e8527e579ec56365482c62f180b7d5760b46e9477dae59e87ed423a").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c51a18b13e8527e579ec56365482c62f180b7d5760b46e9477dae59e87ed423a",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #4 incorrect (1,2,3 derived from incorrect)
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("02a40c85b6f28da08dfdbe0926c53fab2de6d28c10301f8f7c4073d5e42e3148").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"02a40c85b6f28da08dfdbe0926c53fab2de6d28c10301f8f7c4073d5e42e3148",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("dddc3a8d14fddf2b68fa8c7fbad2748274937479dd0f8930d5ebb4ab6bd866a3").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"dddc3a8d14fddf2b68fa8c7fbad2748274937479dd0f8930d5ebb4ab6bd866a3",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c51a18b13e8527e579ec56365482c62f180b7d5760b46e9477dae59e87ed423a").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c51a18b13e8527e579ec56365482c62f180b7d5760b46e9477dae59e87ed423a",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("ba65d7b0ef55a3ba300d4e87af29868f394f8f138d78a7011669c79b37b936f4").unwrap());
-			monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"ba65d7b0ef55a3ba300d4e87af29868f394f8f138d78a7011669c79b37b936f4",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd").unwrap());
-			monitor.provide_secret(281474976710651, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710651, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2").unwrap());
-			monitor.provide_secret(281474976710650, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710650, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32").unwrap());
-			monitor.provide_secret(281474976710649, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710649, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710648, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710648, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #5 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("631373ad5f9ef654bb3dade742d09504c567edd24320d2fcd68e3cc47e2ff6a6").unwrap());
-			monitor.provide_secret(281474976710651, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"631373ad5f9ef654bb3dade742d09504c567edd24320d2fcd68e3cc47e2ff6a6",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710651, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710650, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710650, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #6 incorrect (5 derived from incorrect)
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("631373ad5f9ef654bb3dade742d09504c567edd24320d2fcd68e3cc47e2ff6a6").unwrap());
-			monitor.provide_secret(281474976710651, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"631373ad5f9ef654bb3dade742d09504c567edd24320d2fcd68e3cc47e2ff6a6",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710651, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("b7e76a83668bde38b373970155c868a653304308f9896692f904a23731224bb1").unwrap());
-			monitor.provide_secret(281474976710650, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"b7e76a83668bde38b373970155c868a653304308f9896692f904a23731224bb1",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710650, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32").unwrap());
-			monitor.provide_secret(281474976710649, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710649, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710648, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710648, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #7 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd").unwrap());
-			monitor.provide_secret(281474976710651, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710651, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2").unwrap());
-			monitor.provide_secret(281474976710650, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710650, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("e7971de736e01da8ed58b94c2fc216cb1dca9e326f3a96e7194fe8ea8af6c0a3").unwrap());
-			monitor.provide_secret(281474976710649, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"e7971de736e01da8ed58b94c2fc216cb1dca9e326f3a96e7194fe8ea8af6c0a3",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710649, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710648, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"05cde6323d949933f7f7b78776bcc1ea6d9b31447732e3802e1f7ac44b650e17",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710648, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 
 		{
 			// insert_secret #8 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+			monitor = ChannelMonitor::new(
+				&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+				&PublicKey::new(),
+				&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+				0,
+				Script::new(),
+			);
 			secrets.clear();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-			monitor.provide_secret(281474976710655, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710655, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-			monitor.provide_secret(281474976710654, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710654, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-			monitor.provide_secret(281474976710653, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710653, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-			monitor.provide_secret(281474976710652, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710652, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd").unwrap());
-			monitor.provide_secret(281474976710651, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"c65716add7aa98ba7acb236352d665cab17345fe45b55fb879ff80e6bd0c41dd",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710651, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2").unwrap());
-			monitor.provide_secret(281474976710650, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"969660042a28f32d9be17344e09374b379962d03db1574df5a8a5a47e19ce3f2",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710650, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32").unwrap());
-			monitor.provide_secret(281474976710649, secrets.last().unwrap().clone(), None).unwrap();
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"a5a64476122ca0925fb344bdc1854c1c0a59fc614298e50a33e331980a220f32",
+			).unwrap());
+			monitor
+				.provide_secret(281474976710649, secrets.last().unwrap().clone(), None)
+				.unwrap();
 			test_secrets!();
 
 			secrets.push([0; 32]);
-			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes("a7efbc61aac46d34f77778bac22c8a20c6a46ca460addc49009bda875ec88fa4").unwrap());
-			assert_eq!(monitor.provide_secret(281474976710648, secrets.last().unwrap().clone(), None).unwrap_err().err,
-					"Previous secret did not match new one");
+			secrets.last_mut().unwrap()[0..32].clone_from_slice(&hex_bytes(
+				"a7efbc61aac46d34f77778bac22c8a20c6a46ca460addc49009bda875ec88fa4",
+			).unwrap());
+			assert_eq!(
+				monitor
+					.provide_secret(281474976710648, secrets.last().unwrap().clone(), None)
+					.unwrap_err()
+					.err,
+				"Previous secret did not match new one"
+			);
 		}
 	}
 
@@ -1215,14 +1813,19 @@ mod tests {
 					b_htlc_key: PublicKey::new(),
 					a_delayed_payment_key: PublicKey::new(),
 					b_payment_key: PublicKey::new(),
-				}
-			}
+					}
+			};
 		}
-		let dummy_tx = Transaction { version: 0, lock_time: 0, input: Vec::new(), output: Vec::new() };
+		let dummy_tx = Transaction {
+			version: 0,
+			lock_time: 0,
+			input: Vec::new(),
+			output: Vec::new(),
+		};
 
 		let mut preimages = Vec::new();
 		{
-			let mut rng  = thread_rng();
+			let mut rng = thread_rng();
 			for _ in 0..20 {
 				let mut preimage = [0; 32];
 				rng.fill_bytes(&mut preimage);
@@ -1235,82 +1838,133 @@ mod tests {
 		}
 
 		macro_rules! preimages_slice_to_htlc_outputs {
-			($preimages_slice: expr) => {
-				{
-					let mut res = Vec::new();
-					for (idx, preimage) in $preimages_slice.iter().enumerate() {
-						res.push(HTLCOutputInCommitment {
-							offered: true,
-							amount_msat: 0,
-							cltv_expiry: 0,
-							payment_hash: preimage.1.clone(),
-							transaction_output_index: idx as u32,
-						});
+			($preimages_slice:expr) => {{
+				let mut res = Vec::new();
+				for (idx, preimage) in $preimages_slice.iter().enumerate() {
+					res.push(HTLCOutputInCommitment {
+						offered: true,
+						amount_msat: 0,
+						cltv_expiry: 0,
+						payment_hash: preimage.1.clone(),
+						transaction_output_index: idx as u32,
+					});
 					}
-					res
-				}
-			}
+				res
+				}};
 		}
 		macro_rules! preimages_to_local_htlcs {
-			($preimages_slice: expr) => {
-				{
-					let mut inp = preimages_slice_to_htlc_outputs!($preimages_slice);
-					let res: Vec<_> = inp.drain(..).map(|e| { (e, dummy_sig.clone(), dummy_sig.clone()) }).collect();
-					res
-				}
-			}
+			($preimages_slice:expr) => {{
+				let mut inp = preimages_slice_to_htlc_outputs!($preimages_slice);
+				let res: Vec<_> = inp.drain(..)
+					.map(|e| (e, dummy_sig.clone(), dummy_sig.clone()))
+					.collect();
+				res
+				}};
 		}
 
 		macro_rules! test_preimages_exist {
-			($preimages_slice: expr, $monitor: expr) => {
+			($preimages_slice:expr, $monitor:expr) => {
 				for preimage in $preimages_slice {
 					assert!($monitor.payment_preimages.contains_key(&preimage.1));
-				}
-			}
+					}
+			};
 		}
 
 		// Prune with one old state and a local commitment tx holding a few overlaps with the
 		// old state.
-		let mut monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &PublicKey::new(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), 0, Script::new());
+		let mut monitor = ChannelMonitor::new(
+			&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(),
+			&PublicKey::new(),
+			&SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(),
+			0,
+			Script::new(),
+		);
 		monitor.set_their_to_self_delay(10);
 
-		monitor.provide_latest_local_commitment_tx_info(dummy_tx.clone(), dummy_keys!(), 0, preimages_to_local_htlcs!(preimages[0..10]));
-		monitor.provide_latest_remote_commitment_tx_info(&dummy_tx, preimages_slice_to_htlc_outputs!(preimages[5..15]), 281474976710655);
-		monitor.provide_latest_remote_commitment_tx_info(&dummy_tx, preimages_slice_to_htlc_outputs!(preimages[15..20]), 281474976710654);
-		monitor.provide_latest_remote_commitment_tx_info(&dummy_tx, preimages_slice_to_htlc_outputs!(preimages[17..20]), 281474976710653);
-		monitor.provide_latest_remote_commitment_tx_info(&dummy_tx, preimages_slice_to_htlc_outputs!(preimages[18..20]), 281474976710652);
+		monitor.provide_latest_local_commitment_tx_info(
+			dummy_tx.clone(),
+			dummy_keys!(),
+			0,
+			preimages_to_local_htlcs!(preimages[0..10]),
+		);
+		monitor.provide_latest_remote_commitment_tx_info(
+			&dummy_tx,
+			preimages_slice_to_htlc_outputs!(preimages[5..15]),
+			281474976710655,
+		);
+		monitor.provide_latest_remote_commitment_tx_info(
+			&dummy_tx,
+			preimages_slice_to_htlc_outputs!(preimages[15..20]),
+			281474976710654,
+		);
+		monitor.provide_latest_remote_commitment_tx_info(
+			&dummy_tx,
+			preimages_slice_to_htlc_outputs!(preimages[17..20]),
+			281474976710653,
+		);
+		monitor.provide_latest_remote_commitment_tx_info(
+			&dummy_tx,
+			preimages_slice_to_htlc_outputs!(preimages[18..20]),
+			281474976710652,
+		);
 		for &(ref preimage, ref hash) in preimages.iter() {
 			monitor.provide_payment_preimage(hash, preimage);
 		}
 
 		// Now provide a secret, pruning preimages 10-15
 		let mut secret = [0; 32];
-		secret[0..32].clone_from_slice(&hex_bytes("7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc").unwrap());
-		monitor.provide_secret(281474976710655, secret.clone(), None).unwrap();
+		secret[0..32].clone_from_slice(&hex_bytes(
+			"7cc854b54e3e0dcdb010d7a3fee464a9687be6e8db3be6854c475621e007a5dc",
+		).unwrap());
+		monitor
+			.provide_secret(281474976710655, secret.clone(), None)
+			.unwrap();
 		assert_eq!(monitor.payment_preimages.len(), 15);
 		test_preimages_exist!(&preimages[0..10], monitor);
 		test_preimages_exist!(&preimages[15..20], monitor);
 
 		// Now provide a further secret, pruning preimages 15-17
-		secret[0..32].clone_from_slice(&hex_bytes("c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964").unwrap());
-		monitor.provide_secret(281474976710654, secret.clone(), None).unwrap();
+		secret[0..32].clone_from_slice(&hex_bytes(
+			"c7518c8ae4660ed02894df8976fa1a3659c1a8b4b5bec0c4b872abeba4cb8964",
+		).unwrap());
+		monitor
+			.provide_secret(281474976710654, secret.clone(), None)
+			.unwrap();
 		assert_eq!(monitor.payment_preimages.len(), 13);
 		test_preimages_exist!(&preimages[0..10], monitor);
 		test_preimages_exist!(&preimages[17..20], monitor);
 
 		// Now update local commitment tx info, pruning only element 18 as we still care about the
 		// previous commitment tx's preimages too
-		monitor.provide_latest_local_commitment_tx_info(dummy_tx.clone(), dummy_keys!(), 0, preimages_to_local_htlcs!(preimages[0..5]));
-		secret[0..32].clone_from_slice(&hex_bytes("2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8").unwrap());
-		monitor.provide_secret(281474976710653, secret.clone(), None).unwrap();
+		monitor.provide_latest_local_commitment_tx_info(
+			dummy_tx.clone(),
+			dummy_keys!(),
+			0,
+			preimages_to_local_htlcs!(preimages[0..5]),
+		);
+		secret[0..32].clone_from_slice(&hex_bytes(
+			"2273e227a5b7449b6e70f1fb4652864038b1cbf9cd7c043a7d6456b7fc275ad8",
+		).unwrap());
+		monitor
+			.provide_secret(281474976710653, secret.clone(), None)
+			.unwrap();
 		assert_eq!(monitor.payment_preimages.len(), 12);
 		test_preimages_exist!(&preimages[0..10], monitor);
 		test_preimages_exist!(&preimages[18..20], monitor);
 
 		// But if we do it again, we'll prune 5-10
-		monitor.provide_latest_local_commitment_tx_info(dummy_tx.clone(), dummy_keys!(), 0, preimages_to_local_htlcs!(preimages[0..3]));
-		secret[0..32].clone_from_slice(&hex_bytes("27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116").unwrap());
-		monitor.provide_secret(281474976710652, secret.clone(), None).unwrap();
+		monitor.provide_latest_local_commitment_tx_info(
+			dummy_tx.clone(),
+			dummy_keys!(),
+			0,
+			preimages_to_local_htlcs!(preimages[0..3]),
+		);
+		secret[0..32].clone_from_slice(&hex_bytes(
+			"27cddaa5624534cb6cb9d7da077cf2b22ab21e9b506fd4998a51d54502e99116",
+		).unwrap());
+		monitor
+			.provide_secret(281474976710652, secret.clone(), None)
+			.unwrap();
 		assert_eq!(monitor.payment_preimages.len(), 5);
 		test_preimages_exist!(&preimages[0..5], monitor);
 	}

--- a/src/ln/mod.rs
+++ b/src/ln/mod.rs
@@ -1,9 +1,9 @@
 pub mod channelmanager;
 pub mod channelmonitor;
 pub mod msgs;
-pub mod router;
 pub mod peer_channel_encryptor;
 pub mod peer_handler;
+pub mod router;
 
 #[cfg(feature = "fuzztarget")]
 pub mod channel;

--- a/src/ln/peer_channel_encryptor.rs
+++ b/src/ln/peer_channel_encryptor.rs
@@ -1,23 +1,29 @@
-use ln::msgs::HandleError;
 use ln::msgs;
+use ln::msgs::HandleError;
 
-use secp256k1::Secp256k1;
-use secp256k1::key::{PublicKey,SecretKey};
 use secp256k1::ecdh::SharedSecret;
+use secp256k1::key::{PublicKey, SecretKey};
+use secp256k1::Secp256k1;
 
 use crypto::digest::Digest;
-use crypto::hkdf::{hkdf_extract,hkdf_expand};
+use crypto::hkdf::{hkdf_expand, hkdf_extract};
 
-use crypto::aead::{AeadEncryptor, AeadDecryptor};
+use crypto::aead::{AeadDecryptor, AeadEncryptor};
 
 use util::chacha20poly1305rfc::ChaCha20Poly1305RFC;
-use util::{byte_utils,rng};
 use util::sha2::Sha256;
+use util::{byte_utils, rng};
 
 // Sha256("Noise_XK_secp256k1_ChaChaPoly_SHA256")
-const NOISE_CK: [u8; 32] = [0x26, 0x40, 0xf5, 0x2e, 0xeb, 0xcd, 0x9e, 0x88, 0x29, 0x58, 0x95, 0x1c, 0x79, 0x42, 0x50, 0xee, 0xdb, 0x28, 0x00, 0x2c, 0x05, 0xd7, 0xdc, 0x2e, 0xa0, 0xf1, 0x95, 0x40, 0x60, 0x42, 0xca, 0xf1];
+const NOISE_CK: [u8; 32] = [
+	0x26, 0x40, 0xf5, 0x2e, 0xeb, 0xcd, 0x9e, 0x88, 0x29, 0x58, 0x95, 0x1c, 0x79, 0x42, 0x50, 0xee,
+	0xdb, 0x28, 0x00, 0x2c, 0x05, 0xd7, 0xdc, 0x2e, 0xa0, 0xf1, 0x95, 0x40, 0x60, 0x42, 0xca, 0xf1,
+];
 // Sha256(NOISE_CK || "lightning")
-const NOISE_H: [u8; 32] = [0xd1, 0xfb, 0xf6, 0xde, 0xe4, 0xf6, 0x86, 0xf1, 0x32, 0xfd, 0x70, 0x2c, 0x4a, 0xbf, 0x8f, 0xba, 0x4b, 0xb4, 0x20, 0xd8, 0x9d, 0x2a, 0x04, 0x8a, 0x3c, 0x4f, 0x4c, 0x09, 0x2e, 0x37, 0xb6, 0x76];
+const NOISE_H: [u8; 32] = [
+	0xd1, 0xfb, 0xf6, 0xde, 0xe4, 0xf6, 0x86, 0xf1, 0x32, 0xfd, 0x70, 0x2c, 0x4a, 0xbf, 0x8f, 0xba,
+	0x4b, 0xb4, 0x20, 0xd8, 0x9d, 0x2a, 0x04, 0x8a, 0x3c, 0x4f, 0x4c, 0x09, 0x2e, 0x37, 0xb6, 0x76,
+];
 
 pub enum NextNoiseStep {
 	ActOne,
@@ -43,10 +49,10 @@ enum DirectionalNoiseState {
 		ie: SecretKey,
 	},
 	Inbound {
-		ie: Option<PublicKey>, // filled in if state >= PostActOne
-		re: Option<SecretKey>, // filled in if state >= PostActTwo
+		ie: Option<PublicKey>,     // filled in if state >= PostActOne
+		re: Option<SecretKey>,     // filled in if state >= PostActTwo
 		temp_k2: Option<[u8; 32]>, // filled in if state >= PostActTwo
-	}
+	},
 }
 enum NoiseState {
 	InProgress {
@@ -61,7 +67,7 @@ enum NoiseState {
 		rk: [u8; 32],
 		rn: u64,
 		rck: [u8; 32],
-	}
+	},
 }
 
 pub struct PeerChannelEncryptor {
@@ -90,14 +96,9 @@ impl PeerChannelEncryptor {
 			secp_ctx: secp_ctx,
 			noise_state: NoiseState::InProgress {
 				state: NoiseStep::PreActOne,
-				directional_state: DirectionalNoiseState::Outbound {
-					ie: sec_key,
-				},
-				bidirectional_state: BidirectionalNoiseState {
-					h: h,
-					ck: NOISE_CK,
-				},
-			}
+				directional_state: DirectionalNoiseState::Outbound { ie: sec_key },
+				bidirectional_state: BidirectionalNoiseState { h: h, ck: NOISE_CK },
+			},
 		}
 	}
 
@@ -121,16 +122,13 @@ impl PeerChannelEncryptor {
 					re: None,
 					temp_k2: None,
 				},
-				bidirectional_state: BidirectionalNoiseState {
-					h: h,
-					ck: NOISE_CK,
-				},
-			}
+				bidirectional_state: BidirectionalNoiseState { h: h, ck: NOISE_CK },
+			},
 		}
 	}
 
 	#[inline]
-	fn encrypt_with_ad(res: &mut[u8], n: u64, key: &[u8; 32], h: &[u8], plaintext: &[u8]) {
+	fn encrypt_with_ad(res: &mut [u8], n: u64, key: &[u8; 32], h: &[u8], plaintext: &[u8]) {
 		let mut nonce = [0; 12];
 		nonce[4..].copy_from_slice(&byte_utils::le64_to_array(n));
 
@@ -141,13 +139,26 @@ impl PeerChannelEncryptor {
 	}
 
 	#[inline]
-	fn decrypt_with_ad(res: &mut[u8], n: u64, key: &[u8; 32], h: &[u8], cyphertext: &[u8]) -> Result<(), HandleError> {
+	fn decrypt_with_ad(
+		res: &mut [u8],
+		n: u64,
+		key: &[u8; 32],
+		h: &[u8],
+		cyphertext: &[u8],
+	) -> Result<(), HandleError> {
 		let mut nonce = [0; 12];
 		nonce[4..].copy_from_slice(&byte_utils::le64_to_array(n));
 
 		let mut chacha = ChaCha20Poly1305RFC::new(key, &nonce, h);
-		if !chacha.decrypt(&cyphertext[0..cyphertext.len() - 16], res, &cyphertext[cyphertext.len() - 16..]) {
-			return Err(HandleError{err: "Bad MAC", msg: Some(msgs::ErrorAction::DisconnectPeer{})});
+		if !chacha.decrypt(
+			&cyphertext[0..cyphertext.len() - 16],
+			res,
+			&cyphertext[cyphertext.len() - 16..],
+		) {
+			return Err(HandleError {
+				err: "Bad MAC",
+				msg: Some(msgs::ErrorAction::DisconnectPeer {}),
+			});
 		}
 		Ok(())
 	}
@@ -158,7 +169,7 @@ impl PeerChannelEncryptor {
 		{
 			let mut prk = [0; 32];
 			hkdf_extract(Sha256::new(), &state.ck, &ss[..], &mut prk);
-			hkdf_expand(Sha256::new(), &prk, &[0;0], &mut hkdf);
+			hkdf_expand(Sha256::new(), &prk, &[0; 0], &mut hkdf);
 		}
 		state.ck.copy_from_slice(&hkdf[0..32]);
 		let mut res = [0; 32];
@@ -167,7 +178,12 @@ impl PeerChannelEncryptor {
 	}
 
 	#[inline]
-	fn outbound_noise_act(secp_ctx: &Secp256k1, state: &mut BidirectionalNoiseState, our_key: &SecretKey, their_key: &PublicKey) -> ([u8; 50], [u8; 32]) {
+	fn outbound_noise_act(
+		secp_ctx: &Secp256k1,
+		state: &mut BidirectionalNoiseState,
+		our_key: &SecretKey,
+		their_key: &PublicKey,
+	) -> ([u8; 50], [u8; 32]) {
 		let our_pub = PublicKey::from_secret_key(secp_ctx, &our_key).unwrap(); //TODO: nicer rng-is-bad error message
 
 		let mut sha = Sha256::new();
@@ -191,15 +207,28 @@ impl PeerChannelEncryptor {
 	}
 
 	#[inline]
-	fn inbound_noise_act(secp_ctx: &Secp256k1, state: &mut BidirectionalNoiseState, act: &[u8], our_key: &SecretKey) -> Result<(PublicKey, [u8; 32]), HandleError> {
+	fn inbound_noise_act(
+		secp_ctx: &Secp256k1,
+		state: &mut BidirectionalNoiseState,
+		act: &[u8],
+		our_key: &SecretKey,
+	) -> Result<(PublicKey, [u8; 32]), HandleError> {
 		assert_eq!(act.len(), 50);
 
 		if act[0] != 0 {
-			return Err(HandleError{err: "Unknown handshake version number", msg: Some(msgs::ErrorAction::DisconnectPeer{})});
+			return Err(HandleError {
+				err: "Unknown handshake version number",
+				msg: Some(msgs::ErrorAction::DisconnectPeer {}),
+			});
 		}
 
 		let their_pub = match PublicKey::from_slice(secp_ctx, &act[1..34]) {
-			Err(_) => return Err(HandleError{err: "Invalid public key", msg: Some(msgs::ErrorAction::DisconnectPeer{})}),
+			Err(_) => {
+				return Err(HandleError {
+					err: "Invalid public key",
+					msg: Some(msgs::ErrorAction::DisconnectPeer {}),
+				})
+			}
 			Ok(key) => key,
 		};
 
@@ -224,52 +253,86 @@ impl PeerChannelEncryptor {
 
 	pub fn get_act_one(&mut self) -> [u8; 50] {
 		match self.noise_state {
-			NoiseState::InProgress { ref mut state, ref directional_state, ref mut bidirectional_state } =>
-				match directional_state {
-					&DirectionalNoiseState::Outbound { ref ie } => {
-						if *state != NoiseStep::PreActOne {
-							panic!("Requested act at wrong step");
-						}
+			NoiseState::InProgress {
+				ref mut state,
+				ref directional_state,
+				ref mut bidirectional_state,
+			} => match directional_state {
+				&DirectionalNoiseState::Outbound { ref ie } => {
+					if *state != NoiseStep::PreActOne {
+						panic!("Requested act at wrong step");
+					}
 
-						let (res, _) = PeerChannelEncryptor::outbound_noise_act(&self.secp_ctx, bidirectional_state, &ie, &self.their_node_id.unwrap());
-						*state = NoiseStep::PostActOne;
-						res
-					},
-					_ => panic!("Wrong direction for act"),
-				},
+					let (res, _) = PeerChannelEncryptor::outbound_noise_act(
+						&self.secp_ctx,
+						bidirectional_state,
+						&ie,
+						&self.their_node_id.unwrap(),
+					);
+					*state = NoiseStep::PostActOne;
+					res
+				}
+				_ => panic!("Wrong direction for act"),
+			},
 			_ => panic!("Cannot get act one after noise handshake completes"),
 		}
 	}
 
 	// Separated for testing:
-	fn process_act_one_with_ephemeral_key(&mut self, act_one: &[u8], our_node_secret: &SecretKey, our_ephemeral: SecretKey) -> Result<[u8; 50], HandleError> {
+	fn process_act_one_with_ephemeral_key(
+		&mut self,
+		act_one: &[u8],
+		our_node_secret: &SecretKey,
+		our_ephemeral: SecretKey,
+	) -> Result<[u8; 50], HandleError> {
 		assert_eq!(act_one.len(), 50);
 
 		match self.noise_state {
-			NoiseState::InProgress { ref mut state, ref mut directional_state, ref mut bidirectional_state } =>
-				match directional_state {
-					&mut DirectionalNoiseState::Inbound { ref mut ie, ref mut re, ref mut temp_k2 } => {
-						if *state != NoiseStep::PreActOne {
-							panic!("Requested act at wrong step");
-						}
+			NoiseState::InProgress {
+				ref mut state,
+				ref mut directional_state,
+				ref mut bidirectional_state,
+			} => match directional_state {
+				&mut DirectionalNoiseState::Inbound {
+					ref mut ie,
+					ref mut re,
+					ref mut temp_k2,
+				} => {
+					if *state != NoiseStep::PreActOne {
+						panic!("Requested act at wrong step");
+					}
 
-						let (their_pub, _) = PeerChannelEncryptor::inbound_noise_act(&self.secp_ctx, bidirectional_state, act_one, &our_node_secret)?;
-						ie.get_or_insert(their_pub);
+					let (their_pub, _) = PeerChannelEncryptor::inbound_noise_act(
+						&self.secp_ctx,
+						bidirectional_state,
+						act_one,
+						&our_node_secret,
+					)?;
+					ie.get_or_insert(their_pub);
 
-						re.get_or_insert(our_ephemeral);
+					re.get_or_insert(our_ephemeral);
 
-						let (res, temp_k) = PeerChannelEncryptor::outbound_noise_act(&self.secp_ctx, bidirectional_state, &re.unwrap(), &ie.unwrap());
-						*temp_k2 = Some(temp_k);
-						*state = NoiseStep::PostActTwo;
-						Ok(res)
-					},
-					_ => panic!("Wrong direction for act"),
-				},
+					let (res, temp_k) = PeerChannelEncryptor::outbound_noise_act(
+						&self.secp_ctx,
+						bidirectional_state,
+						&re.unwrap(),
+						&ie.unwrap(),
+					);
+					*temp_k2 = Some(temp_k);
+					*state = NoiseStep::PostActTwo;
+					Ok(res)
+				}
+				_ => panic!("Wrong direction for act"),
+			},
 			_ => panic!("Cannot get act one after noise handshake completes"),
 		}
 	}
 
-	pub fn process_act_one_with_key(&mut self, act_one: &[u8], our_node_secret: &SecretKey) -> Result<[u8; 50], HandleError> {
+	pub fn process_act_one_with_key(
+		&mut self,
+		act_one: &[u8],
+		our_node_secret: &SecretKey,
+	) -> Result<[u8; 50], HandleError> {
 		assert_eq!(act_one.len(), 50);
 
 		let mut key = [0u8; 32];
@@ -278,44 +341,69 @@ impl PeerChannelEncryptor {
 		self.process_act_one_with_ephemeral_key(act_one, our_node_secret, our_ephemeral_key)
 	}
 
-	pub fn process_act_two(&mut self, act_two: &[u8], our_node_secret: &SecretKey) -> Result<[u8; 66], HandleError> {
+	pub fn process_act_two(
+		&mut self,
+		act_two: &[u8],
+		our_node_secret: &SecretKey,
+	) -> Result<[u8; 66], HandleError> {
 		assert_eq!(act_two.len(), 50);
 
 		let mut final_hkdf = [0; 64];
 		let ck;
 		let res: [u8; 66] = match self.noise_state {
-			NoiseState::InProgress { ref state, ref directional_state, ref mut bidirectional_state } =>
-				match directional_state {
-					&DirectionalNoiseState::Outbound { ref ie } => {
-						if *state != NoiseStep::PostActOne {
-							panic!("Requested act at wrong step");
-						}
+			NoiseState::InProgress {
+				ref state,
+				ref directional_state,
+				ref mut bidirectional_state,
+			} => match directional_state {
+				&DirectionalNoiseState::Outbound { ref ie } => {
+					if *state != NoiseStep::PostActOne {
+						panic!("Requested act at wrong step");
+					}
 
-						let (re, temp_k2) = PeerChannelEncryptor::inbound_noise_act(&self.secp_ctx, bidirectional_state, act_two, &ie)?;
+					let (re, temp_k2) = PeerChannelEncryptor::inbound_noise_act(
+						&self.secp_ctx,
+						bidirectional_state,
+						act_two,
+						&ie,
+					)?;
 
-						let mut res = [0; 66];
-						let our_node_id = PublicKey::from_secret_key(&self.secp_ctx, &our_node_secret).unwrap(); //TODO: nicer rng-is-bad error message
+					let mut res = [0; 66];
+					let our_node_id =
+						PublicKey::from_secret_key(&self.secp_ctx, &our_node_secret).unwrap(); //TODO: nicer rng-is-bad error message
 
-						PeerChannelEncryptor::encrypt_with_ad(&mut res[1..50], 1, &temp_k2, &bidirectional_state.h, &our_node_id.serialize()[..]);
+					PeerChannelEncryptor::encrypt_with_ad(
+						&mut res[1..50],
+						1,
+						&temp_k2,
+						&bidirectional_state.h,
+						&our_node_id.serialize()[..],
+					);
 
-						let mut sha = Sha256::new();
-						sha.input(&bidirectional_state.h);
-						sha.input(&res[1..50]);
-						sha.result(&mut bidirectional_state.h);
+					let mut sha = Sha256::new();
+					sha.input(&bidirectional_state.h);
+					sha.input(&res[1..50]);
+					sha.result(&mut bidirectional_state.h);
 
-						let ss = SharedSecret::new(&self.secp_ctx, &re, our_node_secret);
-						let temp_k = PeerChannelEncryptor::hkdf(bidirectional_state, ss);
+					let ss = SharedSecret::new(&self.secp_ctx, &re, our_node_secret);
+					let temp_k = PeerChannelEncryptor::hkdf(bidirectional_state, ss);
 
-						PeerChannelEncryptor::encrypt_with_ad(&mut res[50..], 0, &temp_k, &bidirectional_state.h, &[0; 0]);
+					PeerChannelEncryptor::encrypt_with_ad(
+						&mut res[50..],
+						0,
+						&temp_k,
+						&bidirectional_state.h,
+						&[0; 0],
+					);
 
-						let mut prk = [0; 32];
-						hkdf_extract(Sha256::new(), &bidirectional_state.ck, &[0; 0], &mut prk);
-						hkdf_expand(Sha256::new(), &prk, &[0;0], &mut final_hkdf);
-						ck = bidirectional_state.ck.clone();
-						res
-					},
-					_ => panic!("Wrong direction for act"),
-				},
+					let mut prk = [0; 32];
+					hkdf_extract(Sha256::new(), &bidirectional_state.ck, &[0; 0], &mut prk);
+					hkdf_expand(Sha256::new(), &prk, &[0; 0], &mut final_hkdf);
+					ck = bidirectional_state.ck.clone();
+					res
+				}
+				_ => panic!("Wrong direction for act"),
+			},
 			_ => panic!("Cannot get act one after noise handshake completes"),
 		};
 
@@ -342,40 +430,74 @@ impl PeerChannelEncryptor {
 		let mut final_hkdf = [0; 64];
 		let ck;
 		match self.noise_state {
-			NoiseState::InProgress { ref state, ref directional_state, ref mut bidirectional_state } =>
-				match directional_state {
-					&DirectionalNoiseState::Inbound { ie: _, ref re, ref temp_k2 } => {
-						if *state != NoiseStep::PostActTwo {
-							panic!("Requested act at wrong step");
-						}
-						if act_three[0] != 0 {
-							return Err(HandleError{err: "Unknown handshake version number", msg: Some(msgs::ErrorAction::DisconnectPeer{})});
-						}
-
-						let mut their_node_id = [0; 33];
-						PeerChannelEncryptor::decrypt_with_ad(&mut their_node_id, 1, &temp_k2.unwrap(), &bidirectional_state.h, &act_three[1..50])?;
-						self.their_node_id = Some(match PublicKey::from_slice(&self.secp_ctx, &their_node_id) {
-							Ok(key) => key,
-							Err(_) => return Err(HandleError{err: "Bad node_id from peer", msg: Some(msgs::ErrorAction::DisconnectPeer{})}),
+			NoiseState::InProgress {
+				ref state,
+				ref directional_state,
+				ref mut bidirectional_state,
+			} => match directional_state {
+				&DirectionalNoiseState::Inbound {
+					ie: _,
+					ref re,
+					ref temp_k2,
+				} => {
+					if *state != NoiseStep::PostActTwo {
+						panic!("Requested act at wrong step");
+					}
+					if act_three[0] != 0 {
+						return Err(HandleError {
+							err: "Unknown handshake version number",
+							msg: Some(msgs::ErrorAction::DisconnectPeer {}),
 						});
+					}
 
-						let mut sha = Sha256::new();
-						sha.input(&bidirectional_state.h);
-						sha.input(&act_three[1..50]);
-						sha.result(&mut bidirectional_state.h);
+					let mut their_node_id = [0; 33];
+					PeerChannelEncryptor::decrypt_with_ad(
+						&mut their_node_id,
+						1,
+						&temp_k2.unwrap(),
+						&bidirectional_state.h,
+						&act_three[1..50],
+					)?;
+					self.their_node_id = Some(match PublicKey::from_slice(
+						&self.secp_ctx,
+						&their_node_id,
+					) {
+						Ok(key) => key,
+						Err(_) => {
+							return Err(HandleError {
+								err: "Bad node_id from peer",
+								msg: Some(msgs::ErrorAction::DisconnectPeer {}),
+							})
+						}
+					});
 
-						let ss = SharedSecret::new(&self.secp_ctx, &self.their_node_id.unwrap(), &re.unwrap());
-						let temp_k = PeerChannelEncryptor::hkdf(bidirectional_state, ss);
+					let mut sha = Sha256::new();
+					sha.input(&bidirectional_state.h);
+					sha.input(&act_three[1..50]);
+					sha.result(&mut bidirectional_state.h);
 
-						PeerChannelEncryptor::decrypt_with_ad(&mut [0; 0], 0, &temp_k, &bidirectional_state.h, &act_three[50..])?;
+					let ss = SharedSecret::new(
+						&self.secp_ctx,
+						&self.their_node_id.unwrap(),
+						&re.unwrap(),
+					);
+					let temp_k = PeerChannelEncryptor::hkdf(bidirectional_state, ss);
 
-						let mut prk = [0; 32];
-						hkdf_extract(Sha256::new(), &bidirectional_state.ck, &[0; 0], &mut prk);
-						hkdf_expand(Sha256::new(), &prk, &[0;0], &mut final_hkdf);
-						ck = bidirectional_state.ck.clone();
-					},
-					_ => panic!("Wrong direction for act"),
-				},
+					PeerChannelEncryptor::decrypt_with_ad(
+						&mut [0; 0],
+						0,
+						&temp_k,
+						&bidirectional_state.h,
+						&act_three[50..],
+					)?;
+
+					let mut prk = [0; 32];
+					hkdf_extract(Sha256::new(), &bidirectional_state.ck, &[0; 0], &mut prk);
+					hkdf_expand(Sha256::new(), &prk, &[0; 0], &mut final_hkdf);
+					ck = bidirectional_state.ck.clone();
+				}
+				_ => panic!("Wrong direction for act"),
+			},
 			_ => panic!("Cannot get act one after noise handshake completes"),
 		}
 
@@ -403,28 +525,41 @@ impl PeerChannelEncryptor {
 			panic!("Attempted to encrypt message longer than 65535 bytes!");
 		}
 
-		let mut res = Vec::with_capacity(msg.len() + 16*2 + 2);
-		res.resize(msg.len() + 16*2 + 2, 0);
+		let mut res = Vec::with_capacity(msg.len() + 16 * 2 + 2);
+		res.resize(msg.len() + 16 * 2 + 2, 0);
 
 		match self.noise_state {
-			NoiseState::Finished { ref mut sk, ref mut sn, ref mut sck, rk: _, rn: _, rck: _ } => {
+			NoiseState::Finished {
+				ref mut sk,
+				ref mut sn,
+				ref mut sck,
+				rk: _,
+				rn: _,
+				rck: _,
+			} => {
 				if *sn >= 1000 {
 					let mut prk = [0; 32];
 					hkdf_extract(Sha256::new(), sck, sk, &mut prk);
 					let mut hkdf = [0; 64];
-					hkdf_expand(Sha256::new(), &prk, &[0;0], &mut hkdf);
+					hkdf_expand(Sha256::new(), &prk, &[0; 0], &mut hkdf);
 
 					sck[..].copy_from_slice(&hkdf[0..32]);
 					sk[..].copy_from_slice(&hkdf[32..]);
 					*sn = 0;
 				}
 
-				Self::encrypt_with_ad(&mut res[0..16+2], *sn, sk, &[0; 0], &byte_utils::be16_to_array(msg.len() as u16));
+				Self::encrypt_with_ad(
+					&mut res[0..16 + 2],
+					*sn,
+					sk,
+					&[0; 0],
+					&byte_utils::be16_to_array(msg.len() as u16),
+				);
 				*sn += 1;
 
-				Self::encrypt_with_ad(&mut res[16+2..], *sn, sk, &[0; 0], msg);
+				Self::encrypt_with_ad(&mut res[16 + 2..], *sn, sk, &[0; 0], msg);
 				*sn += 1;
-			},
+			}
 			_ => panic!("Tried to encrypt a message prior to noise handshake completion"),
 		}
 
@@ -434,15 +569,22 @@ impl PeerChannelEncryptor {
 	/// Decrypts a message length header from the remote peer.
 	/// panics if noise handshake has not yet finished or msg.len() != 18
 	pub fn decrypt_length_header(&mut self, msg: &[u8]) -> Result<u16, HandleError> {
-		assert_eq!(msg.len(), 16+2);
+		assert_eq!(msg.len(), 16 + 2);
 
 		match self.noise_state {
-			NoiseState::Finished { sk: _, sn: _, sck: _, ref mut rk, ref mut rn, ref mut rck } => {
+			NoiseState::Finished {
+				sk: _,
+				sn: _,
+				sck: _,
+				ref mut rk,
+				ref mut rn,
+				ref mut rck,
+			} => {
 				if *rn >= 1000 {
 					let mut prk = [0; 32];
 					hkdf_extract(Sha256::new(), rck, rk, &mut prk);
 					let mut hkdf = [0; 64];
-					hkdf_expand(Sha256::new(), &prk, &[0;0], &mut hkdf);
+					hkdf_expand(Sha256::new(), &prk, &[0; 0], &mut hkdf);
 
 					rck[..].copy_from_slice(&hkdf[0..32]);
 					rk[..].copy_from_slice(&hkdf[32..]);
@@ -453,7 +595,7 @@ impl PeerChannelEncryptor {
 				Self::decrypt_with_ad(&mut res, *rn, rk, &[0; 0], msg)?;
 				*rn += 1;
 				Ok(byte_utils::slice_to_be16(&res))
-			},
+			}
 			_ => panic!("Tried to encrypt a message prior to noise handshake completion"),
 		}
 	}
@@ -466,60 +608,79 @@ impl PeerChannelEncryptor {
 		}
 
 		match self.noise_state {
-			NoiseState::Finished { sk: _, sn: _, sck: _, ref rk, ref mut rn, rck: _ } => {
+			NoiseState::Finished {
+				sk: _,
+				sn: _,
+				sck: _,
+				ref rk,
+				ref mut rn,
+				rck: _,
+			} => {
 				let mut res = Vec::with_capacity(msg.len() - 16);
 				res.resize(msg.len() - 16, 0);
 				Self::decrypt_with_ad(&mut res[..], *rn, rk, &[0; 0], msg)?;
 				*rn += 1;
 
 				Ok(res)
-			},
+			}
 			_ => panic!("Tried to encrypt a message prior to noise handshake completion"),
 		}
 	}
 
 	pub fn get_noise_step(&self) -> NextNoiseStep {
 		match self.noise_state {
-			NoiseState::InProgress {ref state, ..} => {
-				match state {
-					&NoiseStep::PreActOne => NextNoiseStep::ActOne,
-					&NoiseStep::PostActOne => NextNoiseStep::ActTwo,
-					&NoiseStep::PostActTwo => NextNoiseStep::ActThree,
-				}
+			NoiseState::InProgress { ref state, .. } => match state {
+				&NoiseStep::PreActOne => NextNoiseStep::ActOne,
+				&NoiseStep::PostActOne => NextNoiseStep::ActTwo,
+				&NoiseStep::PostActTwo => NextNoiseStep::ActThree,
 			},
-			NoiseState::Finished {..} => NextNoiseStep::NoiseComplete,
+			NoiseState::Finished { .. } => NextNoiseStep::NoiseComplete,
 		}
 	}
 
 	pub fn is_ready_for_encryption(&self) -> bool {
 		match self.noise_state {
-			NoiseState::InProgress {..} => { false },
-			NoiseState::Finished {..} => { true }
+			NoiseState::InProgress { .. } => false,
+			NoiseState::Finished { .. } => true,
 		}
 	}
 }
 
 #[cfg(test)]
 mod tests {
+	use secp256k1::key::{PublicKey, SecretKey};
 	use secp256k1::Secp256k1;
-	use secp256k1::key::{PublicKey,SecretKey};
 
 	use bitcoin::util::misc::hex_bytes;
 
-	use ln::peer_channel_encryptor::{PeerChannelEncryptor,NoiseState,DirectionalNoiseState};
+	use ln::peer_channel_encryptor::{DirectionalNoiseState, NoiseState, PeerChannelEncryptor};
 
 	fn get_outbound_peer_for_initiator_test_vectors() -> PeerChannelEncryptor {
 		let secp_ctx = Secp256k1::new();
-		let their_node_id = PublicKey::from_slice(&secp_ctx, &hex_bytes("028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7").unwrap()[..]).unwrap();
+		let their_node_id = PublicKey::from_slice(
+			&secp_ctx,
+			&hex_bytes("028d7500dd4c12685d1f568b4c2b5048e8534b873319f3a8daa612b469132ec7f7")
+				.unwrap()[..],
+		).unwrap();
 
 		let mut outbound_peer = PeerChannelEncryptor::new_outbound(their_node_id);
 		match outbound_peer.noise_state {
-			NoiseState::InProgress { state: _, ref mut directional_state, bidirectional_state: _ } => {
-				*directional_state = DirectionalNoiseState::Outbound { // overwrite ie...
-					ie: SecretKey::from_slice(&secp_ctx, &hex_bytes("1212121212121212121212121212121212121212121212121212121212121212").unwrap()[..]).unwrap(),
+			NoiseState::InProgress {
+				state: _,
+				ref mut directional_state,
+				bidirectional_state: _,
+			} => {
+				*directional_state = DirectionalNoiseState::Outbound {
+					// overwrite ie...
+					ie: SecretKey::from_slice(
+						&secp_ctx,
+						&hex_bytes(
+							"1212121212121212121212121212121212121212121212121212121212121212",
+						).unwrap()[..],
+					).unwrap(),
 				};
-			},
-			_ => panic!()
+			}
+			_ => panic!(),
 		}
 
 		assert_eq!(outbound_peer.get_act_one()[..], hex_bytes("00036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a").unwrap()[..]);
@@ -529,7 +690,11 @@ mod tests {
 	#[test]
 	fn noise_initiator_test_vectors() {
 		let secp_ctx = Secp256k1::new();
-		let our_node_id = SecretKey::from_slice(&secp_ctx, &hex_bytes("1111111111111111111111111111111111111111111111111111111111111111").unwrap()[..]).unwrap();
+		let our_node_id = SecretKey::from_slice(
+			&secp_ctx,
+			&hex_bytes("1111111111111111111111111111111111111111111111111111111111111111").unwrap()
+				[..],
+		).unwrap();
 
 		{
 			// transport-initiator successful handshake
@@ -539,15 +704,42 @@ mod tests {
 			assert_eq!(outbound_peer.process_act_two(&act_two[..], &our_node_id).unwrap()[..], hex_bytes("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba").unwrap()[..]);
 
 			match outbound_peer.noise_state {
-				NoiseState::Finished { sk, sn, sck, rk, rn, rck } => {
-					assert_eq!(sk, hex_bytes("969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9").unwrap()[..]);
+				NoiseState::Finished {
+					sk,
+					sn,
+					sck,
+					rk,
+					rn,
+					rck,
+				} => {
+					assert_eq!(
+						sk,
+						hex_bytes(
+							"969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9"
+						).unwrap()[..]
+					);
 					assert_eq!(sn, 0);
-					assert_eq!(sck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-					assert_eq!(rk, hex_bytes("bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442").unwrap()[..]);
+					assert_eq!(
+						sck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+					assert_eq!(
+						rk,
+						hex_bytes(
+							"bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442"
+						).unwrap()[..]
+					);
 					assert_eq!(rn, 0);
-					assert_eq!(rck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-				},
-				_ => panic!()
+					assert_eq!(
+						rck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+				}
+				_ => panic!(),
 			}
 		}
 		{
@@ -559,7 +751,11 @@ mod tests {
 			let mut outbound_peer = get_outbound_peer_for_initiator_test_vectors();
 
 			let act_two = hex_bytes("0102466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae").unwrap().to_vec();
-			assert!(outbound_peer.process_act_two(&act_two[..], &our_node_id).is_err());
+			assert!(
+				outbound_peer
+					.process_act_two(&act_two[..], &our_node_id)
+					.is_err()
+			);
 		}
 
 		{
@@ -567,7 +763,11 @@ mod tests {
 			let mut outbound_peer = get_outbound_peer_for_initiator_test_vectors();
 
 			let act_two = hex_bytes("0004466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae").unwrap().to_vec();
-			assert!(outbound_peer.process_act_two(&act_two[..], &our_node_id).is_err());
+			assert!(
+				outbound_peer
+					.process_act_two(&act_two[..], &our_node_id)
+					.is_err()
+			);
 		}
 
 		{
@@ -575,15 +775,27 @@ mod tests {
 			let mut outbound_peer = get_outbound_peer_for_initiator_test_vectors();
 
 			let act_two = hex_bytes("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730af").unwrap().to_vec();
-			assert!(outbound_peer.process_act_two(&act_two[..], &our_node_id).is_err());
+			assert!(
+				outbound_peer
+					.process_act_two(&act_two[..], &our_node_id)
+					.is_err()
+			);
 		}
 	}
 
 	#[test]
 	fn noise_responder_test_vectors() {
 		let secp_ctx = Secp256k1::new();
-		let our_node_id = SecretKey::from_slice(&secp_ctx, &hex_bytes("2121212121212121212121212121212121212121212121212121212121212121").unwrap()[..]).unwrap();
-		let our_ephemeral = SecretKey::from_slice(&secp_ctx, &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap()[..]).unwrap();
+		let our_node_id = SecretKey::from_slice(
+			&secp_ctx,
+			&hex_bytes("2121212121212121212121212121212121212121212121212121212121212121").unwrap()
+				[..],
+		).unwrap();
+		let our_ephemeral = SecretKey::from_slice(
+			&secp_ctx,
+			&hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap()
+				[..],
+		).unwrap();
 
 		{
 			// transport-responder successful handshake
@@ -595,18 +807,52 @@ mod tests {
 			let act_three = hex_bytes("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba").unwrap().to_vec();
 			// test vector doesn't specify the initiator static key, but its the same as the one
 			// from trasport-initiator successful handshake
-			assert_eq!(inbound_peer.process_act_three(&act_three[..]).unwrap().serialize()[..], hex_bytes("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa").unwrap()[..]);
+			assert_eq!(
+				inbound_peer
+					.process_act_three(&act_three[..])
+					.unwrap()
+					.serialize()[..],
+				hex_bytes("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa")
+					.unwrap()[..]
+			);
 
 			match inbound_peer.noise_state {
-				NoiseState::Finished { sk, sn, sck, rk, rn, rck } => {
-					assert_eq!(sk, hex_bytes("bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442").unwrap()[..]);
+				NoiseState::Finished {
+					sk,
+					sn,
+					sck,
+					rk,
+					rn,
+					rck,
+				} => {
+					assert_eq!(
+						sk,
+						hex_bytes(
+							"bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442"
+						).unwrap()[..]
+					);
 					assert_eq!(sn, 0);
-					assert_eq!(sck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-					assert_eq!(rk, hex_bytes("969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9").unwrap()[..]);
+					assert_eq!(
+						sck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+					assert_eq!(
+						rk,
+						hex_bytes(
+							"969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9"
+						).unwrap()[..]
+					);
 					assert_eq!(rn, 0);
-					assert_eq!(rck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-				},
-				_ => panic!()
+					assert_eq!(
+						rck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+				}
+				_ => panic!(),
 			}
 		}
 		{
@@ -618,21 +864,45 @@ mod tests {
 			let mut inbound_peer = PeerChannelEncryptor::new_inbound(&our_node_id);
 
 			let act_one = hex_bytes("01036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a").unwrap().to_vec();
-			assert!(inbound_peer.process_act_one_with_ephemeral_key(&act_one[..], &our_node_id, our_ephemeral.clone()).is_err());
+			assert!(
+				inbound_peer
+					.process_act_one_with_ephemeral_key(
+						&act_one[..],
+						&our_node_id,
+						our_ephemeral.clone()
+					)
+					.is_err()
+			);
 		}
 		{
 			// transport-responder act1 bad key serialization test
 			let mut inbound_peer = PeerChannelEncryptor::new_inbound(&our_node_id);
 
 			let act_one =hex_bytes("00046360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6a").unwrap().to_vec();
-			assert!(inbound_peer.process_act_one_with_ephemeral_key(&act_one[..], &our_node_id, our_ephemeral.clone()).is_err());
+			assert!(
+				inbound_peer
+					.process_act_one_with_ephemeral_key(
+						&act_one[..],
+						&our_node_id,
+						our_ephemeral.clone()
+					)
+					.is_err()
+			);
 		}
 		{
 			// transport-responder act1 bad MAC test
 			let mut inbound_peer = PeerChannelEncryptor::new_inbound(&our_node_id);
 
 			let act_one = hex_bytes("00036360e856310ce5d294e8be33fc807077dc56ac80d95d9cd4ddbd21325eff73f70df6086551151f58b8afe6c195782c6b").unwrap().to_vec();
-			assert!(inbound_peer.process_act_one_with_ephemeral_key(&act_one[..], &our_node_id, our_ephemeral.clone()).is_err());
+			assert!(
+				inbound_peer
+					.process_act_one_with_ephemeral_key(
+						&act_one[..],
+						&our_node_id,
+						our_ephemeral.clone()
+					)
+					.is_err()
+			);
 		}
 		{
 			// transport-responder act3 bad version test
@@ -680,7 +950,6 @@ mod tests {
 		}
 	}
 
-
 	#[test]
 	fn message_encryption_decryption_test_vectors() {
 		let secp_ctx = Secp256k1::new();
@@ -690,21 +959,52 @@ mod tests {
 		let mut outbound_peer = get_outbound_peer_for_initiator_test_vectors();
 
 		{
-			let our_node_id = SecretKey::from_slice(&secp_ctx, &hex_bytes("1111111111111111111111111111111111111111111111111111111111111111").unwrap()[..]).unwrap();
+			let our_node_id = SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("1111111111111111111111111111111111111111111111111111111111111111")
+					.unwrap()[..],
+			).unwrap();
 
 			let act_two = hex_bytes("0002466d7fcae563e5cb09a0d1870bb580344804617879a14949cf22285f1bae3f276e2470b93aac583c9ef6eafca3f730ae").unwrap().to_vec();
 			assert_eq!(outbound_peer.process_act_two(&act_two[..], &our_node_id).unwrap()[..], hex_bytes("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba").unwrap()[..]);
 
 			match outbound_peer.noise_state {
-				NoiseState::Finished { sk, sn, sck, rk, rn, rck } => {
-					assert_eq!(sk, hex_bytes("969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9").unwrap()[..]);
+				NoiseState::Finished {
+					sk,
+					sn,
+					sck,
+					rk,
+					rn,
+					rck,
+				} => {
+					assert_eq!(
+						sk,
+						hex_bytes(
+							"969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9"
+						).unwrap()[..]
+					);
 					assert_eq!(sn, 0);
-					assert_eq!(sck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-					assert_eq!(rk, hex_bytes("bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442").unwrap()[..]);
+					assert_eq!(
+						sck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+					assert_eq!(
+						rk,
+						hex_bytes(
+							"bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442"
+						).unwrap()[..]
+					);
 					assert_eq!(rn, 0);
-					assert_eq!(rck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-				},
-				_ => panic!()
+					assert_eq!(
+						rck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+				}
+				_ => panic!(),
 			}
 		}
 
@@ -712,8 +1012,16 @@ mod tests {
 
 		{
 			// transport-responder successful handshake
-			let our_node_id = SecretKey::from_slice(&secp_ctx, &hex_bytes("2121212121212121212121212121212121212121212121212121212121212121").unwrap()[..]).unwrap();
-			let our_ephemeral = SecretKey::from_slice(&secp_ctx, &hex_bytes("2222222222222222222222222222222222222222222222222222222222222222").unwrap()[..]).unwrap();
+			let our_node_id = SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("2121212121212121212121212121212121212121212121212121212121212121")
+					.unwrap()[..],
+			).unwrap();
+			let our_ephemeral = SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("2222222222222222222222222222222222222222222222222222222222222222")
+					.unwrap()[..],
+			).unwrap();
 
 			inbound_peer = PeerChannelEncryptor::new_inbound(&our_node_id);
 
@@ -723,29 +1031,69 @@ mod tests {
 			let act_three = hex_bytes("00b9e3a702e93e3a9948c2ed6e5fd7590a6e1c3a0344cfc9d5b57357049aa22355361aa02e55a8fc28fef5bd6d71ad0c38228dc68b1c466263b47fdf31e560e139ba").unwrap().to_vec();
 			// test vector doesn't specify the initiator static key, but its the same as the one
 			// from trasport-initiator successful handshake
-			assert_eq!(inbound_peer.process_act_three(&act_three[..]).unwrap().serialize()[..], hex_bytes("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa").unwrap()[..]);
+			assert_eq!(
+				inbound_peer
+					.process_act_three(&act_three[..])
+					.unwrap()
+					.serialize()[..],
+				hex_bytes("034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa")
+					.unwrap()[..]
+			);
 
 			match inbound_peer.noise_state {
-				NoiseState::Finished { sk, sn, sck, rk, rn, rck } => {
-					assert_eq!(sk, hex_bytes("bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442").unwrap()[..]);
+				NoiseState::Finished {
+					sk,
+					sn,
+					sck,
+					rk,
+					rn,
+					rck,
+				} => {
+					assert_eq!(
+						sk,
+						hex_bytes(
+							"bb9020b8965f4df047e07f955f3c4b88418984aadc5cdb35096b9ea8fa5c3442"
+						).unwrap()[..]
+					);
 					assert_eq!(sn, 0);
-					assert_eq!(sck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-					assert_eq!(rk, hex_bytes("969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9").unwrap()[..]);
+					assert_eq!(
+						sck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+					assert_eq!(
+						rk,
+						hex_bytes(
+							"969ab31b4d288cedf6218839b27a3e2140827047f2c0f01bf5c04435d43511a9"
+						).unwrap()[..]
+					);
 					assert_eq!(rn, 0);
-					assert_eq!(rck, hex_bytes("919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01").unwrap()[..]);
-				},
-				_ => panic!()
+					assert_eq!(
+						rck,
+						hex_bytes(
+							"919219dbb2920afa8db80f9a51787a840bcf111ed8d588caf9ab4be716e42b01"
+						).unwrap()[..]
+					);
+				}
+				_ => panic!(),
 			}
 		}
 
 		for i in 0..1005 {
 			let msg = [0x68, 0x65, 0x6c, 0x6c, 0x6f];
 			let res = outbound_peer.encrypt_message(&msg);
-			assert_eq!(res.len(), 5 + 2*16 + 2);
+			assert_eq!(res.len(), 5 + 2 * 16 + 2);
 
-			let len_header = res[0..2+16].to_vec();
-			assert_eq!(inbound_peer.decrypt_length_header(&len_header[..]).unwrap() as usize, msg.len());
-			assert_eq!(inbound_peer.decrypt_message(&res[2+16..]).unwrap()[..], msg[..]);
+			let len_header = res[0..2 + 16].to_vec();
+			assert_eq!(
+				inbound_peer.decrypt_length_header(&len_header[..]).unwrap() as usize,
+				msg.len()
+			);
+			assert_eq!(
+				inbound_peer.decrypt_message(&res[2 + 16..]).unwrap()[..],
+				msg[..]
+			);
 
 			if i == 0 {
 				assert_eq!(res, hex_bytes("cf2b30ddf0cf3f80e7c35a6e6730b59fe802473180f396d88a8fb0db8cbcf25d2f214cf9ea1d95").unwrap());

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -1,15 +1,15 @@
-use secp256k1::key::{SecretKey,PublicKey};
+use secp256k1::key::{PublicKey, SecretKey};
 
 use ln::msgs;
-use ln::msgs::{MsgEncodable,MsgDecodable};
-use ln::peer_channel_encryptor::{PeerChannelEncryptor,NextNoiseStep};
+use ln::msgs::{MsgDecodable, MsgEncodable};
+use ln::peer_channel_encryptor::{NextNoiseStep, PeerChannelEncryptor};
 use util::byte_utils;
-use util::events::{EventsProvider,Event};
+use util::events::{Event, EventsProvider};
 
-use std::collections::{HashMap,LinkedList};
-use std::sync::{Arc, Mutex};
+use std::collections::{HashMap, LinkedList};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{cmp,error,mem,hash,fmt};
+use std::sync::{Arc, Mutex};
+use std::{cmp, error, fmt, hash, mem};
 
 pub struct MessageHandler {
 	pub chan_handler: Arc<msgs::ChannelMessageHandler>,
@@ -22,7 +22,7 @@ pub struct MessageHandler {
 /// For efficiency, Clone should be relatively cheap for this type.
 /// You probably want to just extend an int and put a file descriptor in a struct and implement
 /// send_data.
-pub trait SocketDescriptor : cmp::Eq + hash::Hash + Clone {
+pub trait SocketDescriptor: cmp::Eq + hash::Hash + Clone {
 	/// Attempts to send some data from the given Vec starting at the given offset to the peer.
 	/// Returns the amount of data which was sent, possibly 0 if the socket has since disconnected.
 	/// Note that in the disconnected case, a disconnect_event must still fire and further write
@@ -90,17 +90,14 @@ pub struct PeerManager<Descriptor: SocketDescriptor> {
 	initial_syncs_sent: AtomicUsize,
 }
 
-
 macro_rules! encode_msg {
-	($msg: expr, $msg_code: expr) => {
-		{
-			let just_msg = $msg.encode();
-			let mut encoded_msg = Vec::with_capacity(just_msg.len() + 2);
-			encoded_msg.extend_from_slice(&byte_utils::be16_to_array($msg_code));
-			encoded_msg.extend_from_slice(&just_msg[..]);
-			encoded_msg
-		}
-	}
+	($msg:expr, $msg_code:expr) => {{
+		let just_msg = $msg.encode();
+		let mut encoded_msg = Vec::with_capacity(just_msg.len() + 2);
+		encoded_msg.extend_from_slice(&byte_utils::be16_to_array($msg_code));
+		encoded_msg.extend_from_slice(&just_msg[..]);
+		encoded_msg
+		}};
 }
 
 //TODO: Really should do something smarter for this
@@ -109,10 +106,16 @@ const INITIAL_SYNCS_TO_SEND: usize = 5;
 /// Manages and reacts to connection events. You probably want to use file descriptors as PeerIds.
 /// PeerIds may repeat, but only after disconnect_event() has been called.
 impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
-	pub fn new(message_handler: MessageHandler, our_node_secret: SecretKey) -> PeerManager<Descriptor> {
+	pub fn new(
+		message_handler: MessageHandler,
+		our_node_secret: SecretKey,
+	) -> PeerManager<Descriptor> {
 		PeerManager {
 			message_handler: message_handler,
-			peers: Mutex::new(PeerHolder { peers: HashMap::new(), node_id_to_descriptor: HashMap::new() }),
+			peers: Mutex::new(PeerHolder {
+				peers: HashMap::new(),
+				node_id_to_descriptor: HashMap::new(),
+			}),
 			pending_events: Mutex::new(Vec::new()),
 			our_node_secret: our_node_secret,
 			initial_syncs_sent: AtomicUsize::new(0),
@@ -125,27 +128,38 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 	/// Returns some bytes to send to the remote node.
 	/// Panics if descriptor is duplicative with some other descriptor which has not yet has a
 	/// disconnect_event.
-	pub fn new_outbound_connection(&self, their_node_id: PublicKey, descriptor: Descriptor) -> Result<Vec<u8>, PeerHandleError> {
+	pub fn new_outbound_connection(
+		&self,
+		their_node_id: PublicKey,
+		descriptor: Descriptor,
+	) -> Result<Vec<u8>, PeerHandleError> {
 		let mut peer_encryptor = PeerChannelEncryptor::new_outbound(their_node_id.clone());
 		let res = peer_encryptor.get_act_one().to_vec();
 		let pending_read_buffer = [0; 50].to_vec(); // Noise act two is 50 bytes
 
 		let mut peers = self.peers.lock().unwrap();
-		if peers.peers.insert(descriptor, Peer {
-			channel_encryptor: peer_encryptor,
-			outbound: true,
-			their_node_id: Some(their_node_id),
-			their_global_features: None,
-			their_local_features: None,
+		if peers
+			.peers
+			.insert(
+				descriptor,
+				Peer {
+					channel_encryptor: peer_encryptor,
+					outbound: true,
+					their_node_id: Some(their_node_id),
+					their_global_features: None,
+					their_local_features: None,
 
-			pending_outbound_buffer: LinkedList::new(),
-			pending_outbound_buffer_first_msg_offset: 0,
-			awaiting_write_event: false,
+					pending_outbound_buffer: LinkedList::new(),
+					pending_outbound_buffer_first_msg_offset: 0,
+					awaiting_write_event: false,
 
-			pending_read_buffer: pending_read_buffer,
-			pending_read_buffer_pos: 0,
-			pending_read_is_header: false,
-		}).is_some() {
+					pending_read_buffer: pending_read_buffer,
+					pending_read_buffer_pos: 0,
+					pending_read_is_header: false,
+				},
+			)
+			.is_some()
+		{
 			panic!("PeerManager driver duplicated descriptors!");
 		};
 		Ok(res)
@@ -163,21 +177,28 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 		let pending_read_buffer = [0; 50].to_vec(); // Noise act one is 50 bytes
 
 		let mut peers = self.peers.lock().unwrap();
-		if peers.peers.insert(descriptor, Peer {
-			channel_encryptor: peer_encryptor,
-			outbound: false,
-			their_node_id: None,
-			their_global_features: None,
-			their_local_features: None,
+		if peers
+			.peers
+			.insert(
+				descriptor,
+				Peer {
+					channel_encryptor: peer_encryptor,
+					outbound: false,
+					their_node_id: None,
+					their_global_features: None,
+					their_local_features: None,
 
-			pending_outbound_buffer: LinkedList::new(),
-			pending_outbound_buffer_first_msg_offset: 0,
-			awaiting_write_event: false,
+					pending_outbound_buffer: LinkedList::new(),
+					pending_outbound_buffer_first_msg_offset: 0,
+					awaiting_write_event: false,
 
-			pending_read_buffer: pending_read_buffer,
-			pending_read_buffer_pos: 0,
-			pending_read_is_header: false,
-		}).is_some() {
+					pending_read_buffer: pending_read_buffer,
+					pending_read_buffer_pos: 0,
+					pending_read_is_header: false,
+				},
+			)
+			.is_some()
+		{
 			panic!("PeerManager driver duplicated descriptors!");
 		};
 		Ok(())
@@ -192,9 +213,17 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 				};
 				let should_be_reading = peer.pending_outbound_buffer.len() < 10;
 
-				let data_sent = descriptor.send_data(next_buff, peer.pending_outbound_buffer_first_msg_offset, should_be_reading);
+				let data_sent = descriptor.send_data(
+					next_buff,
+					peer.pending_outbound_buffer_first_msg_offset,
+					should_be_reading,
+				);
 				peer.pending_outbound_buffer_first_msg_offset += data_sent;
-				if peer.pending_outbound_buffer_first_msg_offset == next_buff.len() { true } else { false }
+				if peer.pending_outbound_buffer_first_msg_offset == next_buff.len() {
+					true
+				} else {
+					false
+				}
 			} {
 				peer.pending_outbound_buffer_first_msg_offset = 0;
 				peer.pending_outbound_buffer.pop_front();
@@ -235,7 +264,11 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 	/// that this must be true even if a send_data call with resume_read=true was made during the
 	/// course of this function!
 	/// Panics if the descriptor was not previously registered in a new_*_connection event.
-	pub fn read_event(&self, peer_descriptor: &mut Descriptor, data: Vec<u8>) -> Result<bool, PeerHandleError> {
+	pub fn read_event(
+		&self,
+		peer_descriptor: &mut Descriptor,
+		data: Vec<u8>,
+	) -> Result<bool, PeerHandleError> {
 		match self.do_read_event(peer_descriptor, data) {
 			Ok(res) => Ok(res),
 			Err(e) => {
@@ -245,7 +278,11 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 		}
 	}
 
-	fn do_read_event(&self, peer_descriptor: &mut Descriptor, data: Vec<u8>) -> Result<bool, PeerHandleError> {
+	fn do_read_event(
+		&self,
+		peer_descriptor: &mut Descriptor,
+		data: Vec<u8>,
+	) -> Result<bool, PeerHandleError> {
 		let pause_read = {
 			let mut peers = self.peers.lock().unwrap();
 			let (should_insert_node_id, pause_read) = match peers.peers.get_mut(peer_descriptor) {
@@ -258,8 +295,14 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 					let mut read_pos = 0;
 					while read_pos < data.len() {
 						{
-							let data_to_copy = cmp::min(peer.pending_read_buffer.len() - peer.pending_read_buffer_pos, data.len() - read_pos);
-							peer.pending_read_buffer[peer.pending_read_buffer_pos..peer.pending_read_buffer_pos + data_to_copy].copy_from_slice(&data[read_pos..read_pos + data_to_copy]);
+							let data_to_copy = cmp::min(
+								peer.pending_read_buffer.len() - peer.pending_read_buffer_pos,
+								data.len() - read_pos,
+							);
+							peer.pending_read_buffer[peer.pending_read_buffer_pos
+								                         ..peer.pending_read_buffer_pos
+								                             + data_to_copy]
+								.copy_from_slice(&data[read_pos..read_pos + data_to_copy]);
 							read_pos += data_to_copy;
 							peer.pending_read_buffer_pos += data_to_copy;
 						}
@@ -268,49 +311,60 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 							peer.pending_read_buffer_pos = 0;
 
 							macro_rules! encode_and_send_msg {
-								($msg: expr, $msg_code: expr) => {
-									peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!($msg, $msg_code)[..]));
-								}
+								($msg:expr, $msg_code:expr) => {
+									peer.pending_outbound_buffer
+										.push_back(peer.channel_encryptor.encrypt_message(
+											&encode_msg!($msg, $msg_code)[..],
+										));
+								};
 							}
 
 							macro_rules! try_potential_handleerror {
-								($thing: expr) => {
+								($thing:expr) => {
 									match $thing {
 										Ok(x) => x,
 										Err(e) => {
 											println!("Got error handling message: {}!", e.err);
 											if let Some(action) = e.msg {
 												match action {
-													msgs::ErrorAction::UpdateFailHTLC { msg } => {
+													msgs::ErrorAction::UpdateFailHTLC {
+														msg,
+													} => {
 														encode_and_send_msg!(msg, 131);
 														continue;
-													},
+													}
 													msgs::ErrorAction::DisconnectPeer => {
-														return Err(PeerHandleError{ no_connection_possible: false });
-													},
+														return Err(PeerHandleError {
+															no_connection_possible: false,
+														});
+													}
 													msgs::ErrorAction::IgnoreError => {
 														continue;
-													},
+													}
 												}
 											} else {
-												return Err(PeerHandleError{ no_connection_possible: false });
+												return Err(PeerHandleError {
+													no_connection_possible: false,
+												});
+												}
 											}
-										}
-									};
-								}
+										};
+								};
 							}
 
 							macro_rules! try_potential_decodeerror {
-								($thing: expr) => {
+								($thing:expr) => {
 									match $thing {
 										Ok(x) => x,
 										Err(_e) => {
 											println!("Error decoding message");
 											//TODO: Handle e?
-											return Err(PeerHandleError{ no_connection_possible: false });
-										}
-									};
-								}
+											return Err(PeerHandleError {
+												no_connection_possible: false,
+											});
+											}
+										};
+								};
 							}
 
 							macro_rules! try_ignore_potential_decodeerror {
@@ -328,45 +382,74 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 							let next_step = peer.channel_encryptor.get_noise_step();
 							match next_step {
 								NextNoiseStep::ActOne => {
-									let act_two = try_potential_handleerror!(peer.channel_encryptor.process_act_one_with_key(&peer.pending_read_buffer[..], &self.our_node_secret)).to_vec();
+									let act_two = try_potential_handleerror!(
+										peer.channel_encryptor.process_act_one_with_key(
+											&peer.pending_read_buffer[..],
+											&self.our_node_secret
+										)
+									).to_vec();
 									peer.pending_outbound_buffer.push_back(act_two);
 									peer.pending_read_buffer = [0; 66].to_vec(); // act three is 66 bytes long
-								},
+								}
 								NextNoiseStep::ActTwo => {
-									let act_three = try_potential_handleerror!(peer.channel_encryptor.process_act_two(&peer.pending_read_buffer[..], &self.our_node_secret)).to_vec();
+									let act_three = try_potential_handleerror!(
+										peer.channel_encryptor.process_act_two(
+											&peer.pending_read_buffer[..],
+											&self.our_node_secret
+										)
+									).to_vec();
 									peer.pending_outbound_buffer.push_back(act_three);
 									peer.pending_read_buffer = [0; 18].to_vec(); // Message length header is 18 bytes
 									peer.pending_read_is_header = true;
 
 									insert_node_id = Some(peer.their_node_id.unwrap());
 									let mut local_features = msgs::LocalFeatures::new();
-									if self.initial_syncs_sent.load(Ordering::Acquire) < INITIAL_SYNCS_TO_SEND {
+									if self.initial_syncs_sent.load(Ordering::Acquire)
+										< INITIAL_SYNCS_TO_SEND
+									{
 										self.initial_syncs_sent.fetch_add(1, Ordering::AcqRel);
 										local_features.set_initial_routing_sync();
 									}
-									encode_and_send_msg!(msgs::Init {
-										global_features: msgs::GlobalFeatures::new(),
-										local_features,
-									}, 16);
-								},
+									encode_and_send_msg!(
+										msgs::Init {
+											global_features: msgs::GlobalFeatures::new(),
+											local_features,
+										},
+										16
+									);
+								}
 								NextNoiseStep::ActThree => {
-									let their_node_id = try_potential_handleerror!(peer.channel_encryptor.process_act_three(&peer.pending_read_buffer[..]));
+									let their_node_id = try_potential_handleerror!(
+										peer.channel_encryptor
+											.process_act_three(&peer.pending_read_buffer[..])
+									);
 									peer.pending_read_buffer = [0; 18].to_vec(); // Message length header is 18 bytes
 									peer.pending_read_is_header = true;
 									peer.their_node_id = Some(their_node_id);
 									insert_node_id = Some(peer.their_node_id.unwrap());
-								},
+								}
 								NextNoiseStep::NoiseComplete => {
 									if peer.pending_read_is_header {
-										let msg_len = try_potential_handleerror!(peer.channel_encryptor.decrypt_length_header(&peer.pending_read_buffer[..]));
-										peer.pending_read_buffer = Vec::with_capacity(msg_len as usize + 16);
+										let msg_len = try_potential_handleerror!(
+											peer.channel_encryptor.decrypt_length_header(
+												&peer.pending_read_buffer[..]
+											)
+										);
+										peer.pending_read_buffer =
+											Vec::with_capacity(msg_len as usize + 16);
 										peer.pending_read_buffer.resize(msg_len as usize + 16, 0);
-										if msg_len < 2 { // Need at least the message type tag
-											return Err(PeerHandleError{ no_connection_possible: false });
+										if msg_len < 2 {
+											// Need at least the message type tag
+											return Err(PeerHandleError {
+												no_connection_possible: false,
+											});
 										}
 										peer.pending_read_is_header = false;
 									} else {
-										let msg_data = try_potential_handleerror!(peer.channel_encryptor.decrypt_message(&peer.pending_read_buffer[..]));
+										let msg_data = try_potential_handleerror!(
+											peer.channel_encryptor
+												.decrypt_message(&peer.pending_read_buffer[..])
+										);
 										assert!(msg_data.len() >= 2);
 
 										// Reset read buffer
@@ -376,126 +459,272 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 										let msg_type = byte_utils::slice_to_be16(&msg_data[0..2]);
 										if msg_type != 16 && peer.their_global_features.is_none() {
 											// Need an init message as first message
-											return Err(PeerHandleError{ no_connection_possible: false });
+											return Err(PeerHandleError {
+												no_connection_possible: false,
+											});
 										}
 										match msg_type {
 											// Connection control:
 											16 => {
-												let msg = try_potential_decodeerror!(msgs::Init::decode(&msg_data[2..]));
+												let msg = try_potential_decodeerror!(
+													msgs::Init::decode(&msg_data[2..])
+												);
 												if msg.global_features.requires_unknown_bits() {
-													return Err(PeerHandleError{ no_connection_possible: true });
+													return Err(PeerHandleError {
+														no_connection_possible: true,
+													});
 												}
 												if msg.local_features.requires_unknown_bits() {
-													return Err(PeerHandleError{ no_connection_possible: true });
+													return Err(PeerHandleError {
+														no_connection_possible: true,
+													});
 												}
-												peer.their_global_features = Some(msg.global_features);
-												peer.their_local_features = Some(msg.local_features);
+												peer.their_global_features =
+													Some(msg.global_features);
+												peer.their_local_features =
+													Some(msg.local_features);
 
 												if !peer.outbound {
-													let mut local_features = msgs::LocalFeatures::new();
-													if self.initial_syncs_sent.load(Ordering::Acquire) < INITIAL_SYNCS_TO_SEND {
-														self.initial_syncs_sent.fetch_add(1, Ordering::AcqRel);
+													let mut local_features =
+														msgs::LocalFeatures::new();
+													if self.initial_syncs_sent
+														.load(Ordering::Acquire)
+														< INITIAL_SYNCS_TO_SEND
+													{
+														self.initial_syncs_sent
+															.fetch_add(1, Ordering::AcqRel);
 														local_features.set_initial_routing_sync();
 													}
-													encode_and_send_msg!(msgs::Init {
-														global_features: msgs::GlobalFeatures::new(),
-														local_features,
-													}, 16);
+													encode_and_send_msg!(
+														msgs::Init {
+															global_features:
+																msgs::GlobalFeatures::new(),
+															local_features,
+														},
+														16
+													);
 												}
-											},
+											}
 											17 => {
 												// Error msg
-											},
+											}
 
 											18 => {
-												let msg = try_potential_decodeerror!(msgs::Ping::decode(&msg_data[2..]));
+												let msg = try_potential_decodeerror!(
+													msgs::Ping::decode(&msg_data[2..])
+												);
 												if msg.ponglen < 65532 {
-													let resp = msgs::Pong { byteslen: msg.ponglen };
+													let resp = msgs::Pong {
+														byteslen: msg.ponglen,
+													};
 													encode_and_send_msg!(resp, 19);
 												}
-											},
+											}
 											19 => {
-												try_potential_decodeerror!(msgs::Pong::decode(&msg_data[2..]));
-											},
+												try_potential_decodeerror!(msgs::Pong::decode(
+													&msg_data[2..]
+												));
+											}
 
 											// Channel control:
 											32 => {
-												let msg = try_potential_decodeerror!(msgs::OpenChannel::decode(&msg_data[2..]));
-												let resp = try_potential_handleerror!(self.message_handler.chan_handler.handle_open_channel(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::OpenChannel::decode(&msg_data[2..])
+												);
+												let resp = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_open_channel(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												encode_and_send_msg!(resp, 33);
-											},
+											}
 											33 => {
-												let msg = try_potential_decodeerror!(msgs::AcceptChannel::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_accept_channel(&peer.their_node_id.unwrap(), &msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::AcceptChannel::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_accept_channel(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
 
 											34 => {
-												let msg = try_potential_decodeerror!(msgs::FundingCreated::decode(&msg_data[2..]));
-												let resp = try_potential_handleerror!(self.message_handler.chan_handler.handle_funding_created(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::FundingCreated::decode(&msg_data[2..])
+												);
+												let resp = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_funding_created(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												encode_and_send_msg!(resp, 35);
-											},
+											}
 											35 => {
-												let msg = try_potential_decodeerror!(msgs::FundingSigned::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_funding_signed(&peer.their_node_id.unwrap(), &msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::FundingSigned::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_funding_signed(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
 											36 => {
-												let msg = try_potential_decodeerror!(msgs::FundingLocked::decode(&msg_data[2..]));
-												let resp_option = try_potential_handleerror!(self.message_handler.chan_handler.handle_funding_locked(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::FundingLocked::decode(&msg_data[2..])
+												);
+												let resp_option = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_funding_locked(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												match resp_option {
 													Some(resp) => encode_and_send_msg!(resp, 259),
-													None => {},
+													None => {}
 												}
-											},
+											}
 
 											38 => {
-												let msg = try_potential_decodeerror!(msgs::Shutdown::decode(&msg_data[2..]));
-												let resp_options = try_potential_handleerror!(self.message_handler.chan_handler.handle_shutdown(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::Shutdown::decode(&msg_data[2..])
+												);
+												let resp_options = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_shutdown(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												if let Some(resp) = resp_options.0 {
 													encode_and_send_msg!(resp, 38);
 												}
 												if let Some(resp) = resp_options.1 {
 													encode_and_send_msg!(resp, 39);
 												}
-											},
+											}
 											39 => {
-												let msg = try_potential_decodeerror!(msgs::ClosingSigned::decode(&msg_data[2..]));
-												let resp_option = try_potential_handleerror!(self.message_handler.chan_handler.handle_closing_signed(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::ClosingSigned::decode(&msg_data[2..])
+												);
+												let resp_option = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_closing_signed(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												if let Some(resp) = resp_option {
 													encode_and_send_msg!(resp, 39);
 												}
-											},
+											}
 
 											128 => {
-												let msg = try_potential_decodeerror!(msgs::UpdateAddHTLC::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_update_add_htlc(&peer.their_node_id.unwrap(), &msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::UpdateAddHTLC::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_update_add_htlc(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
 											130 => {
-												let msg = try_potential_decodeerror!(msgs::UpdateFulfillHTLC::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_update_fulfill_htlc(&peer.their_node_id.unwrap(), &msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::UpdateFulfillHTLC::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_update_fulfill_htlc(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
 											131 => {
-												let msg = try_potential_decodeerror!(msgs::UpdateFailHTLC::decode(&msg_data[2..]));
-												let chan_update = try_potential_handleerror!(self.message_handler.chan_handler.handle_update_fail_htlc(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::UpdateFailHTLC::decode(&msg_data[2..])
+												);
+												let chan_update = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_update_fail_htlc(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												if let Some(update) = chan_update {
-													self.message_handler.route_handler.handle_htlc_fail_channel_update(&update);
+													self.message_handler
+														.route_handler
+														.handle_htlc_fail_channel_update(&update);
 												}
-											},
+											}
 											135 => {
-												let msg = try_potential_decodeerror!(msgs::UpdateFailMalformedHTLC::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_update_fail_malformed_htlc(&peer.their_node_id.unwrap(), &msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::UpdateFailMalformedHTLC::decode(
+														&msg_data[2..]
+													)
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_update_fail_malformed_htlc(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
 
 											132 => {
-												let msg = try_potential_decodeerror!(msgs::CommitmentSigned::decode(&msg_data[2..]));
-												let resps = try_potential_handleerror!(self.message_handler.chan_handler.handle_commitment_signed(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::CommitmentSigned::decode(&msg_data[2..])
+												);
+												let resps = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_commitment_signed(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												encode_and_send_msg!(resps.0, 133);
 												if let Some(resp) = resps.1 {
 													encode_and_send_msg!(resp, 132);
 												}
-											},
+											}
 											133 => {
-												let msg = try_potential_decodeerror!(msgs::RevokeAndACK::decode(&msg_data[2..]));
-												let resp_option = try_potential_handleerror!(self.message_handler.chan_handler.handle_revoke_and_ack(&peer.their_node_id.unwrap(), &msg));
+												let msg = try_potential_decodeerror!(
+													msgs::RevokeAndACK::decode(&msg_data[2..])
+												);
+												let resp_option = try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_revoke_and_ack(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
 												match resp_option {
 													Some(resps) => {
 														for resp in resps.update_add_htlcs {
@@ -507,43 +736,88 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 														for resp in resps.update_fail_htlcs {
 															encode_and_send_msg!(resp, 131);
 														}
-														encode_and_send_msg!(resps.commitment_signed, 132);
-													},
-													None => {},
+														encode_and_send_msg!(
+															resps.commitment_signed,
+															132
+														);
+													}
+													None => {}
 												}
-											},
+											}
 											134 => {
-												let msg = try_potential_decodeerror!(msgs::UpdateFee::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_update_fee(&peer.their_node_id.unwrap(), &msg));
-											},
-											136 => { }, // TODO: channel_reestablish
+												let msg = try_potential_decodeerror!(
+													msgs::UpdateFee::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_update_fee(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
+											136 => {} // TODO: channel_reestablish
 
 											// Routing control:
 											259 => {
-												let msg = try_potential_decodeerror!(msgs::AnnouncementSignatures::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_announcement_signatures(&peer.their_node_id.unwrap(), &msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::AnnouncementSignatures::decode(
+														&msg_data[2..]
+													)
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.chan_handler
+														.handle_announcement_signatures(
+															&peer.their_node_id.unwrap(),
+															&msg
+														)
+												);
+											}
 											256 => {
-												let msg = try_potential_decodeerror!(msgs::ChannelAnnouncement::decode(&msg_data[2..]));
-												let should_forward = try_potential_handleerror!(self.message_handler.route_handler.handle_channel_announcement(&msg));
+												let msg = try_potential_decodeerror!(
+													msgs::ChannelAnnouncement::decode(
+														&msg_data[2..]
+													)
+												);
+												let should_forward = try_potential_handleerror!(
+													self.message_handler
+														.route_handler
+														.handle_channel_announcement(&msg)
+												);
 
 												if should_forward {
 													// TODO: forward msg along to all our other peers!
 												}
-											},
+											}
 											257 => {
-												let msg = try_ignore_potential_decodeerror!(msgs::NodeAnnouncement::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.route_handler.handle_node_announcement(&msg));
-											},
+												let msg = try_ignore_potential_decodeerror!(
+													msgs::NodeAnnouncement::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.route_handler
+														.handle_node_announcement(&msg)
+												);
+											}
 											258 => {
-												let msg = try_potential_decodeerror!(msgs::ChannelUpdate::decode(&msg_data[2..]));
-												try_potential_handleerror!(self.message_handler.route_handler.handle_channel_update(&msg));
-											},
+												let msg = try_potential_decodeerror!(
+													msgs::ChannelUpdate::decode(&msg_data[2..])
+												);
+												try_potential_handleerror!(
+													self.message_handler
+														.route_handler
+														.handle_channel_update(&msg)
+												);
+											}
 											_ => {
 												if (msg_type & 1) == 0 {
-													return Err(PeerHandleError{ no_connection_possible: true });
+													return Err(PeerHandleError {
+														no_connection_possible: true,
+													});
 												}
-											},
+											}
 										}
 									}
 								}
@@ -553,12 +827,19 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 
 					Self::do_attempt_write_data(peer_descriptor, peer);
 
-					(insert_node_id /* should_insert_node_id */, peer.pending_outbound_buffer.len() > 10) // pause_read
+					(
+						insert_node_id, /* should_insert_node_id */
+						peer.pending_outbound_buffer.len() > 10,
+					) // pause_read
 				}
 			};
 
 			match should_insert_node_id {
-				Some(node_id) => { peers.node_id_to_descriptor.insert(node_id, peer_descriptor.clone()); },
+				Some(node_id) => {
+					peers
+						.node_id_to_descriptor
+						.insert(node_id, peer_descriptor.clone());
+				}
 				None => {}
 			};
 
@@ -579,127 +860,195 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 			// buffer by doing things like announcing channels on another node. We should be willing to
 			// drop optional-ish messages when send buffers get full!
 
-			let mut events_generated = self.message_handler.chan_handler.get_and_clear_pending_events();
+			let mut events_generated = self.message_handler
+				.chan_handler
+				.get_and_clear_pending_events();
 			let mut peers = self.peers.lock().unwrap();
 			for event in events_generated.drain(..) {
 				macro_rules! get_peer_for_forwarding {
-					($node_id: expr, $handle_no_such_peer: block) => {
-						{
-							let descriptor = match peers.node_id_to_descriptor.get($node_id) {
-								Some(descriptor) => descriptor.clone(),
-								None => {
-									$handle_no_such_peer;
-									continue;
-								},
+					($node_id:expr, $handle_no_such_peer:block) => {{
+						let descriptor = match peers.node_id_to_descriptor.get($node_id) {
+							Some(descriptor) => descriptor.clone(),
+							None => {
+								$handle_no_such_peer;
+								continue;
+								}
 							};
-							match peers.peers.get_mut(&descriptor) {
-								Some(peer) => {
-									(descriptor, peer)
-								},
-								None => panic!("Inconsistent peers set state!"),
+						match peers.peers.get_mut(&descriptor) {
+							Some(peer) => (descriptor, peer),
+							None => panic!("Inconsistent peers set state!"),
 							}
-						}
-					}
+						}};
 				}
 				match event {
-					Event::FundingGenerationReady {..} => { /* Hand upstream */ },
-					Event::FundingBroadcastSafe {..} => { /* Hand upstream */ },
-					Event::PaymentReceived {..} => { /* Hand upstream */ },
-					Event::PaymentSent {..} => { /* Hand upstream */ },
-					Event::PaymentFailed {..} => { /* Hand upstream */ },
+					Event::FundingGenerationReady { .. } => { /* Hand upstream */ }
+					Event::FundingBroadcastSafe { .. } => { /* Hand upstream */ }
+					Event::PaymentReceived { .. } => { /* Hand upstream */ }
+					Event::PaymentSent { .. } => { /* Hand upstream */ }
+					Event::PaymentFailed { .. } => { /* Hand upstream */ }
 
-					Event::PendingHTLCsForwardable {..} => {
+					Event::PendingHTLCsForwardable { .. } => {
 						//TODO: Handle upstream in some confused form so that upstream just knows
 						//to call us somehow?
-					},
-					Event::SendFundingCreated { ref node_id, ref msg } => {
+					}
+					Event::SendFundingCreated {
+						ref node_id,
+						ref msg,
+					} => {
 						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
-								//TODO: generate a DiscardFunding event indicating to the wallet that
-								//they should just throw away this funding transaction
-							});
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg, 34)));
+							//TODO: generate a DiscardFunding event indicating to the wallet that
+							//they should just throw away this funding transaction
+						});
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(msg, 34)),
+						);
 						Self::do_attempt_write_data(&mut descriptor, peer);
 						continue;
-					},
-					Event::SendFundingLocked { ref node_id, ref msg, ref announcement_sigs } => {
+					}
+					Event::SendFundingLocked {
+						ref node_id,
+						ref msg,
+						ref announcement_sigs,
+					} => {
 						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
-								//TODO: Do whatever we're gonna do for handling dropped messages
-							});
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg, 36)));
+							//TODO: Do whatever we're gonna do for handling dropped messages
+						});
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(msg, 36)),
+						);
 						match announcement_sigs {
-							&Some(ref announce_msg) => peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(announce_msg, 259))),
-							&None => {},
+							&Some(ref announce_msg) => peer.pending_outbound_buffer.push_back(
+								peer.channel_encryptor
+									.encrypt_message(&encode_msg!(announce_msg, 259)),
+							),
+							&None => {}
 						}
 						Self::do_attempt_write_data(&mut descriptor, peer);
 						continue;
-					},
-					Event::SendHTLCs { ref node_id, ref msgs, ref commitment_msg } => {
+					}
+					Event::SendHTLCs {
+						ref node_id,
+						ref msgs,
+						ref commitment_msg,
+					} => {
 						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
-								//TODO: Do whatever we're gonna do for handling dropped messages
-							});
+							//TODO: Do whatever we're gonna do for handling dropped messages
+						});
 						for msg in msgs {
-							peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg, 128)));
+							peer.pending_outbound_buffer.push_back(
+								peer.channel_encryptor
+									.encrypt_message(&encode_msg!(msg, 128)),
+							);
 						}
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(commitment_msg, 132)));
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(commitment_msg, 132)),
+						);
 						Self::do_attempt_write_data(&mut descriptor, peer);
 						continue;
-					},
-					Event::SendFulfillHTLC { ref node_id, ref msg, ref commitment_msg } => {
+					}
+					Event::SendFulfillHTLC {
+						ref node_id,
+						ref msg,
+						ref commitment_msg,
+					} => {
 						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
-								//TODO: Do whatever we're gonna do for handling dropped messages
-							});
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg, 130)));
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(commitment_msg, 132)));
+							//TODO: Do whatever we're gonna do for handling dropped messages
+						});
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(msg, 130)),
+						);
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(commitment_msg, 132)),
+						);
 						Self::do_attempt_write_data(&mut descriptor, peer);
 						continue;
-					},
-					Event::SendFailHTLC { ref node_id, ref msg, ref commitment_msg } => {
+					}
+					Event::SendFailHTLC {
+						ref node_id,
+						ref msg,
+						ref commitment_msg,
+					} => {
 						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
-								//TODO: Do whatever we're gonna do for handling dropped messages
-							});
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg, 131)));
-						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(commitment_msg, 132)));
+							//TODO: Do whatever we're gonna do for handling dropped messages
+						});
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(msg, 131)),
+						);
+						peer.pending_outbound_buffer.push_back(
+							peer.channel_encryptor
+								.encrypt_message(&encode_msg!(commitment_msg, 132)),
+						);
 						Self::do_attempt_write_data(&mut descriptor, peer);
 						continue;
-					},
-					Event::BroadcastChannelAnnouncement { ref msg, ref update_msg } => {
-						if self.message_handler.route_handler.handle_channel_announcement(msg).is_ok() && self.message_handler.route_handler.handle_channel_update(update_msg).is_ok() {
+					}
+					Event::BroadcastChannelAnnouncement {
+						ref msg,
+						ref update_msg,
+					} => {
+						if self.message_handler
+							.route_handler
+							.handle_channel_announcement(msg)
+							.is_ok()
+							&& self.message_handler
+								.route_handler
+								.handle_channel_update(update_msg)
+								.is_ok()
+						{
 							let encoded_msg = encode_msg!(msg, 256);
 							let encoded_update_msg = encode_msg!(update_msg, 258);
 
 							for (ref descriptor, ref mut peer) in peers.peers.iter_mut() {
 								if !peer.channel_encryptor.is_ready_for_encryption() {
-									continue
+									continue;
 								}
 								match peer.their_node_id {
 									None => continue,
 									Some(their_node_id) => {
-										if their_node_id == msg.contents.node_id_1 || their_node_id == msg.contents.node_id_2 {
-											continue
+										if their_node_id == msg.contents.node_id_1
+											|| their_node_id == msg.contents.node_id_2
+										{
+											continue;
 										}
 									}
 								}
-								peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encoded_msg[..]));
-								peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encoded_update_msg[..]));
+								peer.pending_outbound_buffer.push_back(
+									peer.channel_encryptor.encrypt_message(&encoded_msg[..]),
+								);
+								peer.pending_outbound_buffer.push_back(
+									peer.channel_encryptor
+										.encrypt_message(&encoded_update_msg[..]),
+								);
 								Self::do_attempt_write_data(&mut (*descriptor).clone(), peer);
 							}
 						}
 						continue;
-					},
+					}
 					Event::BroadcastChannelUpdate { ref msg } => {
-						if self.message_handler.route_handler.handle_channel_update(msg).is_ok() {
+						if self.message_handler
+							.route_handler
+							.handle_channel_update(msg)
+							.is_ok()
+						{
 							let encoded_msg = encode_msg!(msg, 258);
 
 							for (ref descriptor, ref mut peer) in peers.peers.iter_mut() {
 								if !peer.channel_encryptor.is_ready_for_encryption() {
-									continue
+									continue;
 								}
-								peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encoded_msg[..]));
+								peer.pending_outbound_buffer.push_back(
+									peer.channel_encryptor.encrypt_message(&encoded_msg[..]),
+								);
 								Self::do_attempt_write_data(&mut (*descriptor).clone(), peer);
 							}
 						}
 						continue;
-					},
+					}
 				}
 
 				upstream_events.push(event);
@@ -725,15 +1074,15 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 		let peer_option = peers.peers.remove(descriptor);
 		match peer_option {
 			None => panic!("Descriptor for disconnect_event is not already known to PeerManager"),
-			Some(peer) => {
-				match peer.their_node_id {
-					Some(node_id) => {
-						peers.node_id_to_descriptor.remove(&node_id);
-						self.message_handler.chan_handler.peer_disconnected(&node_id, no_connection_possible);
-					},
-					None => {}
+			Some(peer) => match peer.their_node_id {
+				Some(node_id) => {
+					peers.node_id_to_descriptor.remove(&node_id);
+					self.message_handler
+						.chan_handler
+						.peer_disconnected(&node_id, no_connection_possible);
 				}
-			}
+				None => {}
+			},
 		};
 	}
 }

--- a/src/ln/router.rs
+++ b/src/ln/router.rs
@@ -1,15 +1,17 @@
 use secp256k1::key::PublicKey;
-use secp256k1::{Secp256k1,Message};
+use secp256k1::{Message, Secp256k1};
 
 use bitcoin::util::hash::Sha256dHash;
 
-use ln::msgs::{ErrorAction,HandleError,RoutingMessageHandler,MsgEncodable,NetAddress,GlobalFeatures};
 use ln::msgs;
+use ln::msgs::{
+	ErrorAction, GlobalFeatures, HandleError, MsgEncodable, NetAddress, RoutingMessageHandler,
+};
 
 use std::cmp;
-use std::sync::RwLock;
-use std::collections::{HashMap,BinaryHeap};
 use std::collections::hash_map::Entry;
+use std::collections::{BinaryHeap, HashMap};
+use std::sync::RwLock;
 
 /// A hop in a route
 #[derive(Clone)]
@@ -107,25 +109,42 @@ pub struct Router {
 }
 
 macro_rules! secp_verify_sig {
-	( $secp_ctx: expr, $msg: expr, $sig: expr, $pubkey: expr ) => {
+	($secp_ctx:expr, $msg:expr, $sig:expr, $pubkey:expr) => {
 		match $secp_ctx.verify($msg, $sig, $pubkey) {
-			Ok(_) => {},
-			Err(_) => return Err(HandleError{err: "Invalid signature from remote node", msg: None}),
-		}
+			Ok(_) => {}
+			Err(_) => {
+				return Err(HandleError {
+					err: "Invalid signature from remote node",
+					msg: None,
+				})
+				}
+			}
 	};
 }
 
 impl RoutingMessageHandler for Router {
 	fn handle_node_announcement(&self, msg: &msgs::NodeAnnouncement) -> Result<(), HandleError> {
-		let msg_hash = Message::from_slice(&Sha256dHash::from_data(&msg.contents.encode()[..])[..]).unwrap();
-		secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.signature, &msg.contents.node_id);
+		let msg_hash =
+			Message::from_slice(&Sha256dHash::from_data(&msg.contents.encode()[..])[..]).unwrap();
+		secp_verify_sig!(
+			self.secp_ctx,
+			&msg_hash,
+			&msg.signature,
+			&msg.contents.node_id
+		);
 
 		let mut network = self.network_map.write().unwrap();
 		match network.nodes.get_mut(&msg.contents.node_id) {
-			None => Err(HandleError{err: "No existing channels for node_announcement", msg: Some(ErrorAction::IgnoreError)}),
+			None => Err(HandleError {
+				err: "No existing channels for node_announcement",
+				msg: Some(ErrorAction::IgnoreError),
+			}),
 			Some(node) => {
 				if node.last_update >= msg.contents.timestamp {
-					return Err(HandleError{err: "Update older than last processed update", msg: Some(ErrorAction::IgnoreError)});
+					return Err(HandleError {
+						err: "Update older than last processed update",
+						msg: Some(ErrorAction::IgnoreError),
+					});
 				}
 
 				node.features = msg.contents.features.clone();
@@ -138,29 +157,62 @@ impl RoutingMessageHandler for Router {
 		}
 	}
 
-	fn handle_channel_announcement(&self, msg: &msgs::ChannelAnnouncement) -> Result<bool, HandleError> {
-		let msg_hash = Message::from_slice(&Sha256dHash::from_data(&msg.contents.encode()[..])[..]).unwrap();
-		secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.node_signature_1, &msg.contents.node_id_1);
-		secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.node_signature_2, &msg.contents.node_id_2);
-		secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.bitcoin_signature_1, &msg.contents.bitcoin_key_1);
-		secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.bitcoin_signature_2, &msg.contents.bitcoin_key_2);
+	fn handle_channel_announcement(
+		&self,
+		msg: &msgs::ChannelAnnouncement,
+	) -> Result<bool, HandleError> {
+		let msg_hash =
+			Message::from_slice(&Sha256dHash::from_data(&msg.contents.encode()[..])[..]).unwrap();
+		secp_verify_sig!(
+			self.secp_ctx,
+			&msg_hash,
+			&msg.node_signature_1,
+			&msg.contents.node_id_1
+		);
+		secp_verify_sig!(
+			self.secp_ctx,
+			&msg_hash,
+			&msg.node_signature_2,
+			&msg.contents.node_id_2
+		);
+		secp_verify_sig!(
+			self.secp_ctx,
+			&msg_hash,
+			&msg.bitcoin_signature_1,
+			&msg.contents.bitcoin_key_1
+		);
+		secp_verify_sig!(
+			self.secp_ctx,
+			&msg_hash,
+			&msg.bitcoin_signature_2,
+			&msg.contents.bitcoin_key_2
+		);
 
 		//TODO: Call blockchain thing to ask if the short_channel_id is valid
 		//TODO: Only allow bitcoin chain_hash
 
 		if msg.contents.features.requires_unknown_bits() {
-			return Err(HandleError{err: "Channel announcement required unknown feature flags", msg: None});
+			return Err(HandleError {
+				err: "Channel announcement required unknown feature flags",
+				msg: None,
+			});
 		}
 
 		let mut network = self.network_map.write().unwrap();
 
-		match network.channels.entry(NetworkMap::get_key(msg.contents.short_channel_id, msg.contents.chain_hash)) {
+		match network.channels.entry(NetworkMap::get_key(
+			msg.contents.short_channel_id,
+			msg.contents.chain_hash,
+		)) {
 			Entry::Occupied(_) => {
 				//TODO: because asking the blockchain if short_channel_id is valid is only optional
 				//in the blockchain API, we need to handle it smartly here, though its unclear
 				//exactly how...
-				return Err(HandleError{err: "Already have knowledge of channel", msg: Some(ErrorAction::IgnoreError)})
-			},
+				return Err(HandleError {
+					err: "Already have knowledge of channel",
+					msg: Some(ErrorAction::IgnoreError),
+				});
+			}
 			Entry::Vacant(entry) => {
 				entry.insert(ChannelInfo {
 					features: msg.contents.features.clone(),
@@ -181,30 +233,37 @@ impl RoutingMessageHandler for Router {
 						htlc_minimum_msat: u64::max_value(),
 						fee_base_msat: u32::max_value(),
 						fee_proportional_millionths: u32::max_value(),
-					}
+					},
 				});
 			}
 		};
 
 		macro_rules! add_channel_to_node {
-			( $node_id: expr ) => {
+			($node_id:expr) => {
 				match network.nodes.entry($node_id) {
 					Entry::Occupied(node_entry) => {
-						node_entry.into_mut().channels.push(NetworkMap::get_key(msg.contents.short_channel_id, msg.contents.chain_hash));
-					},
+						node_entry.into_mut().channels.push(NetworkMap::get_key(
+							msg.contents.short_channel_id,
+							msg.contents.chain_hash,
+						));
+						}
 					Entry::Vacant(node_entry) => {
 						node_entry.insert(NodeInfo {
-							channels: vec!(NetworkMap::get_key(msg.contents.short_channel_id, msg.contents.chain_hash)),
+							channels: vec![NetworkMap::get_key(
+								msg.contents.short_channel_id,
+								msg.contents.chain_hash,
+							)],
 							lowest_inbound_channel_fee_base_msat: u32::max_value(),
-							lowest_inbound_channel_fee_proportional_millionths: u32::max_value(),
+							lowest_inbound_channel_fee_proportional_millionths: u32::max_value(
+							),
 							features: GlobalFeatures::new(),
 							last_update: 0,
 							rgb: [0; 3],
 							alias: [0; 32],
 							addresses: Vec::new(),
 						});
+						}
 					}
-				}
 			};
 		}
 
@@ -218,11 +277,13 @@ impl RoutingMessageHandler for Router {
 		match update {
 			&msgs::HTLCFailChannelUpdate::ChannelUpdateMessage { ref msg } => {
 				let _ = self.handle_channel_update(msg);
-			},
-			&msgs::HTLCFailChannelUpdate::ChannelClosed { ref short_channel_id } => {
+			}
+			&msgs::HTLCFailChannelUpdate::ChannelClosed {
+				ref short_channel_id,
+			} => {
 				let mut network = self.network_map.write().unwrap();
 				network.channels.remove(short_channel_id);
-			},
+			}
 		}
 	}
 
@@ -232,32 +293,56 @@ impl RoutingMessageHandler for Router {
 		let chan_enabled = msg.contents.flags & (1 << 1) != (1 << 1);
 		let chan_was_enabled;
 
-		match network.channels.get_mut(&NetworkMap::get_key(msg.contents.short_channel_id, msg.contents.chain_hash)) {
-			None => return Err(HandleError{err: "Couldn't find channel for update", msg: Some(ErrorAction::IgnoreError)}),
+		match network.channels.get_mut(&NetworkMap::get_key(
+			msg.contents.short_channel_id,
+			msg.contents.chain_hash,
+		)) {
+			None => {
+				return Err(HandleError {
+					err: "Couldn't find channel for update",
+					msg: Some(ErrorAction::IgnoreError),
+				})
+			}
 			Some(channel) => {
 				macro_rules! maybe_update_channel_info {
-					( $target: expr) => {
+					($target:expr) => {
 						if $target.last_update >= msg.contents.timestamp {
-							return Err(HandleError{err: "Update older than last processed update", msg: Some(ErrorAction::IgnoreError)});
-						}
+							return Err(HandleError {
+								err: "Update older than last processed update",
+								msg: Some(ErrorAction::IgnoreError),
+							});
+							}
 						chan_was_enabled = $target.enabled;
 						$target.last_update = msg.contents.timestamp;
 						$target.enabled = chan_enabled;
 						$target.cltv_expiry_delta = msg.contents.cltv_expiry_delta;
 						$target.htlc_minimum_msat = msg.contents.htlc_minimum_msat;
 						$target.fee_base_msat = msg.contents.fee_base_msat;
-						$target.fee_proportional_millionths = msg.contents.fee_proportional_millionths;
-					}
+						$target.fee_proportional_millionths =
+							msg.contents.fee_proportional_millionths;
+					};
 				}
 
-				let msg_hash = Message::from_slice(&Sha256dHash::from_data(&msg.contents.encode()[..])[..]).unwrap();
+				let msg_hash = Message::from_slice(
+					&Sha256dHash::from_data(&msg.contents.encode()[..])[..],
+				).unwrap();
 				if msg.contents.flags & 1 == 1 {
 					dest_node_id = channel.one_to_two.src_node_id.clone();
-					secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.signature, &channel.two_to_one.src_node_id);
+					secp_verify_sig!(
+						self.secp_ctx,
+						&msg_hash,
+						&msg.signature,
+						&channel.two_to_one.src_node_id
+					);
 					maybe_update_channel_info!(channel.two_to_one);
 				} else {
 					dest_node_id = channel.two_to_one.src_node_id.clone();
-					secp_verify_sig!(self.secp_ctx, &msg_hash, &msg.signature, &channel.one_to_two.src_node_id);
+					secp_verify_sig!(
+						self.secp_ctx,
+						&msg_hash,
+						&msg.signature,
+						&channel.one_to_two.src_node_id
+					);
 					maybe_update_channel_info!(channel.one_to_two);
 				}
 			}
@@ -265,8 +350,14 @@ impl RoutingMessageHandler for Router {
 
 		if chan_enabled {
 			let node = network.nodes.get_mut(&dest_node_id).unwrap();
-			node.lowest_inbound_channel_fee_base_msat = cmp::min(node.lowest_inbound_channel_fee_base_msat, msg.contents.fee_base_msat);
-			node.lowest_inbound_channel_fee_proportional_millionths = cmp::min(node.lowest_inbound_channel_fee_proportional_millionths, msg.contents.fee_proportional_millionths);
+			node.lowest_inbound_channel_fee_base_msat = cmp::min(
+				node.lowest_inbound_channel_fee_base_msat,
+				msg.contents.fee_base_msat,
+			);
+			node.lowest_inbound_channel_fee_proportional_millionths = cmp::min(
+				node.lowest_inbound_channel_fee_proportional_millionths,
+				msg.contents.fee_proportional_millionths,
+			);
 		} else if chan_was_enabled {
 			let mut lowest_inbound_channel_fee_base_msat = u32::max_value();
 			let mut lowest_inbound_channel_fee_proportional_millionths = u32::max_value();
@@ -277,11 +368,23 @@ impl RoutingMessageHandler for Router {
 				for chan_id in node.channels.iter() {
 					let chan = network.channels.get(chan_id).unwrap();
 					if chan.one_to_two.src_node_id == dest_node_id {
-						lowest_inbound_channel_fee_base_msat = cmp::min(lowest_inbound_channel_fee_base_msat, chan.two_to_one.fee_base_msat);
-						lowest_inbound_channel_fee_proportional_millionths = cmp::min(lowest_inbound_channel_fee_proportional_millionths, chan.two_to_one.fee_proportional_millionths);
+						lowest_inbound_channel_fee_base_msat = cmp::min(
+							lowest_inbound_channel_fee_base_msat,
+							chan.two_to_one.fee_base_msat,
+						);
+						lowest_inbound_channel_fee_proportional_millionths = cmp::min(
+							lowest_inbound_channel_fee_proportional_millionths,
+							chan.two_to_one.fee_proportional_millionths,
+						);
 					} else {
-						lowest_inbound_channel_fee_base_msat = cmp::min(lowest_inbound_channel_fee_base_msat, chan.one_to_two.fee_base_msat);
-						lowest_inbound_channel_fee_proportional_millionths = cmp::min(lowest_inbound_channel_fee_proportional_millionths, chan.one_to_two.fee_proportional_millionths);
+						lowest_inbound_channel_fee_base_msat = cmp::min(
+							lowest_inbound_channel_fee_base_msat,
+							chan.one_to_two.fee_base_msat,
+						);
+						lowest_inbound_channel_fee_proportional_millionths = cmp::min(
+							lowest_inbound_channel_fee_proportional_millionths,
+							chan.one_to_two.fee_proportional_millionths,
+						);
 					}
 				}
 			}
@@ -289,7 +392,8 @@ impl RoutingMessageHandler for Router {
 			//TODO: satisfy the borrow-checker without a double-map-lookup :(
 			let mut_node = network.nodes.get_mut(&dest_node_id).unwrap();
 			mut_node.lowest_inbound_channel_fee_base_msat = lowest_inbound_channel_fee_base_msat;
-			mut_node.lowest_inbound_channel_fee_proportional_millionths = lowest_inbound_channel_fee_proportional_millionths;
+			mut_node.lowest_inbound_channel_fee_proportional_millionths =
+				lowest_inbound_channel_fee_proportional_millionths;
 		}
 
 		Ok(())
@@ -304,7 +408,9 @@ struct RouteGraphNode {
 
 impl cmp::Ord for RouteGraphNode {
 	fn cmp(&self, other: &RouteGraphNode) -> cmp::Ordering {
-		other.lowest_fee_to_peer_through_node.cmp(&self.lowest_fee_to_peer_through_node)
+		other
+			.lowest_fee_to_peer_through_node
+			.cmp(&self.lowest_fee_to_peer_through_node)
 			.then_with(|| other.pubkey.serialize().cmp(&self.pubkey.serialize()))
 	}
 }
@@ -318,16 +424,19 @@ impl cmp::PartialOrd for RouteGraphNode {
 impl Router {
 	pub fn new(our_pubkey: PublicKey) -> Router {
 		let mut nodes = HashMap::new();
-		nodes.insert(our_pubkey.clone(), NodeInfo {
-			channels: Vec::new(),
-			lowest_inbound_channel_fee_base_msat: u32::max_value(),
-			lowest_inbound_channel_fee_proportional_millionths: u32::max_value(),
-			features: GlobalFeatures::new(),
-			last_update: 0,
-			rgb: [0; 3],
-			alias: [0; 32],
-			addresses: Vec::new(),
-		});
+		nodes.insert(
+			our_pubkey.clone(),
+			NodeInfo {
+				channels: Vec::new(),
+				lowest_inbound_channel_fee_base_msat: u32::max_value(),
+				lowest_inbound_channel_fee_proportional_millionths: u32::max_value(),
+				features: GlobalFeatures::new(),
+				last_update: 0,
+				rgb: [0; 3],
+				alias: [0; 32],
+				addresses: Vec::new(),
+			},
+		);
 		Router {
 			secp_ctx: Secp256k1::new(),
 			network_map: RwLock::new(NetworkMap {
@@ -354,13 +463,22 @@ impl Router {
 	/// The fees on channels from us to next-hops are ignored (as they are assumed to all be
 	/// equal), however the enabled/disabled bit on such channels as well as the htlc_minimum_msat
 	/// *is* checked as they may change based on the receiving node.
-	pub fn get_route(&self, target: &PublicKey, last_hops: &Vec<RouteHint>, final_value_msat: u64, final_cltv: u32) -> Result<Route, HandleError> {
+	pub fn get_route(
+		&self,
+		target: &PublicKey,
+		last_hops: &Vec<RouteHint>,
+		final_value_msat: u64,
+		final_cltv: u32,
+	) -> Result<Route, HandleError> {
 		// TODO: Obviously *only* using total fee cost sucks. We should consider weighting by
 		// uptime/success in using a node in the past.
 		let network = self.network_map.read().unwrap();
 
 		if *target == network.our_node_id {
-			return Err(HandleError{err: "Cannot generate a route to ourselves", msg: None});
+			return Err(HandleError {
+				err: "Cannot generate a route to ourselves",
+				msg: None,
+			});
 		}
 
 		// We do a dest-to-source Dijkstra's sorting by each node's distance from the destination
@@ -372,37 +490,50 @@ impl Router {
 		let mut targets = BinaryHeap::new(); //TODO: Do we care about switching to eg Fibbonaci heap?
 		let mut dist = HashMap::with_capacity(network.nodes.len());
 		for (key, node) in network.nodes.iter() {
-			dist.insert(key.clone(), (u64::max_value(),
-				node.lowest_inbound_channel_fee_base_msat as u64,
-				node.lowest_inbound_channel_fee_proportional_millionths as u64,
-				RouteHop {
-					pubkey: PublicKey::new(),
-					short_channel_id: 0,
-					fee_msat: 0,
-					cltv_expiry_delta: 0,
-			}));
+			dist.insert(
+				key.clone(),
+				(
+					u64::max_value(),
+					node.lowest_inbound_channel_fee_base_msat as u64,
+					node.lowest_inbound_channel_fee_proportional_millionths as u64,
+					RouteHop {
+						pubkey: PublicKey::new(),
+						short_channel_id: 0,
+						fee_msat: 0,
+						cltv_expiry_delta: 0,
+					},
+				),
+			);
 		}
 
 		macro_rules! add_entry {
 			// Adds entry which goes from the node pointed to by $directional_info to
 			// $dest_node_id over the channel with id $chan_id with fees described in
 			// $directional_info.
-			( $chan_id: expr, $dest_node_id: expr, $directional_info: expr, $starting_fee_msat: expr ) => {
+			(
+				$chan_id:expr, $dest_node_id:expr, $directional_info:expr, $starting_fee_msat:expr
+			) => {
 				//TODO: Explore simply adding fee to hit htlc_minimum_msat
-				if $starting_fee_msat as u64 + final_value_msat > $directional_info.htlc_minimum_msat {
-					let new_fee = $directional_info.fee_base_msat as u64 + ($starting_fee_msat + final_value_msat) * ($directional_info.fee_proportional_millionths as u64) / 1000000;
+				if $starting_fee_msat as u64 + final_value_msat
+					> $directional_info.htlc_minimum_msat
+					{
+					let new_fee = $directional_info.fee_base_msat as u64
+						+ ($starting_fee_msat + final_value_msat)
+							* ($directional_info.fee_proportional_millionths as u64)
+							/ 1000000;
 					let mut total_fee = $starting_fee_msat as u64;
 					let old_entry = dist.get_mut(&$directional_info.src_node_id).unwrap();
 					if $directional_info.src_node_id != network.our_node_id {
 						// Ignore new_fee for channel-from-us as we assume all channels-from-us
 						// will have the same effective-fee
 						total_fee += new_fee;
-						total_fee += old_entry.2 * (final_value_msat + total_fee) / 1000000 + old_entry.1;
-					}
+						total_fee += old_entry.2 * (final_value_msat + total_fee) / 1000000
+							+ old_entry.1;
+						}
 					let new_graph_node = RouteGraphNode {
 						pubkey: $directional_info.src_node_id,
 						lowest_fee_to_peer_through_node: total_fee,
-					};
+						};
 					if old_entry.0 > total_fee {
 						targets.push(new_graph_node);
 						old_entry.0 = total_fee;
@@ -411,35 +542,45 @@ impl Router {
 							short_channel_id: $chan_id.clone(),
 							fee_msat: new_fee, // This field is ignored on the last-hop anyway
 							cltv_expiry_delta: $directional_info.cltv_expiry_delta as u32,
+							}
 						}
 					}
-				}
 			};
 		}
 
 		macro_rules! add_entries_to_cheapest_to_target_node {
-			( $node: expr, $node_id: expr, $fee_to_target_msat: expr ) => {
+			($node:expr, $node_id:expr, $fee_to_target_msat:expr) => {
 				for chan_id in $node.channels.iter() {
 					let chan = network.channels.get(chan_id).unwrap();
 					if chan.one_to_two.src_node_id == *$node_id {
 						// ie $node is one, ie next hop in A* is two, via the two_to_one channel
 						if chan.two_to_one.enabled {
-							add_entry!(chan_id, chan.one_to_two.src_node_id, chan.two_to_one, $fee_to_target_msat);
-						}
+							add_entry!(
+								chan_id,
+								chan.one_to_two.src_node_id,
+								chan.two_to_one,
+								$fee_to_target_msat
+							);
+							}
 					} else {
 						if chan.one_to_two.enabled {
-							add_entry!(chan_id, chan.two_to_one.src_node_id, chan.one_to_two, $fee_to_target_msat);
+							add_entry!(
+								chan_id,
+								chan.two_to_one.src_node_id,
+								chan.one_to_two,
+								$fee_to_target_msat
+							);
+							}
 						}
 					}
-				}
 			};
 		}
 
 		match network.nodes.get(target) {
-			None => {},
+			None => {}
 			Some(node) => {
 				add_entries_to_cheapest_to_target_node!(node, target, 0);
-			},
+			}
 		}
 
 		for hop in last_hops.iter() {
@@ -448,9 +589,13 @@ impl Router {
 			}
 		}
 
-		while let Some(RouteGraphNode { pubkey, lowest_fee_to_peer_through_node }) = targets.pop() {
+		while let Some(RouteGraphNode {
+			pubkey,
+			lowest_fee_to_peer_through_node,
+		}) = targets.pop()
+		{
 			if pubkey == network.our_node_id {
-				let mut res = vec!(dist.remove(&network.our_node_id).unwrap().3);
+				let mut res = vec![dist.remove(&network.our_node_id).unwrap().3];
 				while res.last().unwrap().pubkey != *target {
 					let new_entry = dist.remove(&res.last().unwrap().pubkey).unwrap().3;
 					res.last_mut().unwrap().fee_msat = new_entry.fee_msat;
@@ -459,40 +604,52 @@ impl Router {
 				}
 				res.last_mut().unwrap().fee_msat = final_value_msat;
 				res.last_mut().unwrap().cltv_expiry_delta = final_cltv;
-				return Ok(Route {
-					hops: res
-				});
+				return Ok(Route { hops: res });
 			}
 
 			match network.nodes.get(&pubkey) {
-				None => {},
+				None => {}
 				Some(node) => {
-					let mut fee = lowest_fee_to_peer_through_node - node.lowest_inbound_channel_fee_base_msat as u64;
-					fee -= node.lowest_inbound_channel_fee_proportional_millionths as u64 * (fee + final_value_msat) / 1000000;
+					let mut fee = lowest_fee_to_peer_through_node
+						- node.lowest_inbound_channel_fee_base_msat as u64;
+					fee -= node.lowest_inbound_channel_fee_proportional_millionths as u64
+						* (fee + final_value_msat) / 1000000;
 					add_entries_to_cheapest_to_target_node!(node, &pubkey, fee);
-				},
+				}
 			}
 		}
 
-		Err(HandleError{err: "Failed to find a path to the given destination", msg: None})
+		Err(HandleError {
+			err: "Failed to find a path to the given destination",
+			msg: None,
+		})
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use ln::router::{Router,NodeInfo,NetworkMap,ChannelInfo,DirectionalChannelInfo,RouteHint};
 	use ln::msgs::GlobalFeatures;
+	use ln::router::{
+		ChannelInfo, DirectionalChannelInfo, NetworkMap, NodeInfo, RouteHint, Router,
+	};
 
-	use bitcoin::util::misc::hex_bytes;
 	use bitcoin::util::hash::Sha256dHash;
+	use bitcoin::util::misc::hex_bytes;
 
-	use secp256k1::key::{PublicKey,SecretKey};
+	use secp256k1::key::{PublicKey, SecretKey};
 	use secp256k1::Secp256k1;
 
 	#[test]
 	fn route_test() {
 		let secp_ctx = Secp256k1::new();
-		let our_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0101010101010101010101010101010101010101010101010101010101010101").unwrap()[..]).unwrap()).unwrap();
+		let our_id = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0101010101010101010101010101010101010101010101010101010101010101")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
 		let router = Router::new(our_id);
 
 		// Build network from our_id to node8:
@@ -547,247 +704,360 @@ mod tests {
 		// chan11 1-to-2: enabled, 0 fee
 		// chan11 2-to-1: enabled, 0 fee
 
-		let node1 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0202020202020202020202020202020202020202020202020202020202020202").unwrap()[..]).unwrap()).unwrap();
-		let node2 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0303030303030303030303030303030303030303030303030303030303030303").unwrap()[..]).unwrap()).unwrap();
-		let node3 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0404040404040404040404040404040404040404040404040404040404040404").unwrap()[..]).unwrap()).unwrap();
-		let node4 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0505050505050505050505050505050505050505050505050505050505050505").unwrap()[..]).unwrap()).unwrap();
-		let node5 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0606060606060606060606060606060606060606060606060606060606060606").unwrap()[..]).unwrap()).unwrap();
-		let node6 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0707070707070707070707070707070707070707070707070707070707070707").unwrap()[..]).unwrap()).unwrap();
-		let node7 = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &hex_bytes("0808080808080808080808080808080808080808080808080808080808080808").unwrap()[..]).unwrap()).unwrap();
+		let node1 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0202020202020202020202020202020202020202020202020202020202020202")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
+		let node2 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0303030303030303030303030303030303030303030303030303030303030303")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
+		let node3 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0404040404040404040404040404040404040404040404040404040404040404")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
+		let node4 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0505050505050505050505050505050505050505050505050505050505050505")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
+		let node5 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0606060606060606060606060606060606060606060606060606060606060606")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
+		let node6 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0707070707070707070707070707070707070707070707070707070707070707")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
+		let node7 = PublicKey::from_secret_key(
+			&secp_ctx,
+			&SecretKey::from_slice(
+				&secp_ctx,
+				&hex_bytes("0808080808080808080808080808080808080808080808080808080808080808")
+					.unwrap()[..],
+			).unwrap(),
+		).unwrap();
 
 		let zero_hash = Sha256dHash::from_data(&[0; 32]);
 
 		{
 			let mut network = router.network_map.write().unwrap();
 
-			network.nodes.insert(node1.clone(), NodeInfo {
-				channels: vec!(NetworkMap::get_key(1, zero_hash.clone()), NetworkMap::get_key(3, zero_hash.clone())),
-				lowest_inbound_channel_fee_base_msat: 100,
-				lowest_inbound_channel_fee_proportional_millionths: 0,
-				features: GlobalFeatures::new(),
-				last_update: 1,
-				rgb: [0; 3],
-				alias: [0; 32],
-				addresses: Vec::new(),
-			});
-			network.channels.insert(NetworkMap::get_key(1, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: our_id.clone(),
-					last_update: 0,
-					enabled: false,
-					cltv_expiry_delta: u16::max_value(), // This value should be ignored
-					htlc_minimum_msat: 0,
-					fee_base_msat: u32::max_value(), // This value should be ignored
-					fee_proportional_millionths: u32::max_value(), // This value should be ignored
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node1.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: 0,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			network.nodes.insert(
+				node1.clone(),
+				NodeInfo {
+					channels: vec![
+						NetworkMap::get_key(1, zero_hash.clone()),
+						NetworkMap::get_key(3, zero_hash.clone()),
+					],
+					lowest_inbound_channel_fee_base_msat: 100,
+					lowest_inbound_channel_fee_proportional_millionths: 0,
+					features: GlobalFeatures::new(),
+					last_update: 1,
+					rgb: [0; 3],
+					alias: [0; 32],
+					addresses: Vec::new(),
 				},
-			});
-			network.nodes.insert(node2.clone(), NodeInfo {
-				channels: vec!(NetworkMap::get_key(2, zero_hash.clone()), NetworkMap::get_key(4, zero_hash.clone())),
-				lowest_inbound_channel_fee_base_msat: 0,
-				lowest_inbound_channel_fee_proportional_millionths: 0,
-				features: GlobalFeatures::new(),
-				last_update: 1,
-				rgb: [0; 3],
-				alias: [0; 32],
-				addresses: Vec::new(),
-			});
-			network.channels.insert(NetworkMap::get_key(2, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: our_id.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: u16::max_value(), // This value should be ignored
-					htlc_minimum_msat: 0,
-					fee_base_msat: u32::max_value(), // This value should be ignored
-					fee_proportional_millionths: u32::max_value(), // This value should be ignored
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node2.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: 0,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			);
+			network.channels.insert(
+				NetworkMap::get_key(1, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: our_id.clone(),
+						last_update: 0,
+						enabled: false,
+						cltv_expiry_delta: u16::max_value(), // This value should be ignored
+						htlc_minimum_msat: 0,
+						fee_base_msat: u32::max_value(), // This value should be ignored
+						fee_proportional_millionths: u32::max_value(), // This value should be ignored
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node1.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: 0,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
 				},
-			});
-			network.nodes.insert(node3.clone(), NodeInfo {
-				channels: vec!(
-					NetworkMap::get_key(3, zero_hash.clone()),
-					NetworkMap::get_key(4, zero_hash.clone()),
-					NetworkMap::get_key(5, zero_hash.clone()),
-					NetworkMap::get_key(6, zero_hash.clone()),
-					NetworkMap::get_key(7, zero_hash.clone())),
-				lowest_inbound_channel_fee_base_msat: 0,
-				lowest_inbound_channel_fee_proportional_millionths: 0,
-				features: GlobalFeatures::new(),
-				last_update: 1,
-				rgb: [0; 3],
-				alias: [0; 32],
-				addresses: Vec::new(),
-			});
-			network.channels.insert(NetworkMap::get_key(3, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: node1.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (3 << 8) | 1,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node3.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (3 << 8) | 2,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 100,
-					fee_proportional_millionths: 0,
+			);
+			network.nodes.insert(
+				node2.clone(),
+				NodeInfo {
+					channels: vec![
+						NetworkMap::get_key(2, zero_hash.clone()),
+						NetworkMap::get_key(4, zero_hash.clone()),
+					],
+					lowest_inbound_channel_fee_base_msat: 0,
+					lowest_inbound_channel_fee_proportional_millionths: 0,
+					features: GlobalFeatures::new(),
+					last_update: 1,
+					rgb: [0; 3],
+					alias: [0; 32],
+					addresses: Vec::new(),
 				},
-			});
-			network.channels.insert(NetworkMap::get_key(4, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: node2.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (4 << 8) | 1,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 1000000,
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node3.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (4 << 8) | 2,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			);
+			network.channels.insert(
+				NetworkMap::get_key(2, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: our_id.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: u16::max_value(), // This value should be ignored
+						htlc_minimum_msat: 0,
+						fee_base_msat: u32::max_value(), // This value should be ignored
+						fee_proportional_millionths: u32::max_value(), // This value should be ignored
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node2.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: 0,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
 				},
-			});
-			network.nodes.insert(node4.clone(), NodeInfo {
-				channels: vec!(NetworkMap::get_key(5, zero_hash.clone()), NetworkMap::get_key(11, zero_hash.clone())),
-				lowest_inbound_channel_fee_base_msat: 0,
-				lowest_inbound_channel_fee_proportional_millionths: 0,
-				features: GlobalFeatures::new(),
-				last_update: 1,
-				rgb: [0; 3],
-				alias: [0; 32],
-				addresses: Vec::new(),
-			});
-			network.channels.insert(NetworkMap::get_key(5, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: node3.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (5 << 8) | 1,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 100,
-					fee_proportional_millionths: 0,
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node4.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (5 << 8) | 2,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			);
+			network.nodes.insert(
+				node3.clone(),
+				NodeInfo {
+					channels: vec![
+						NetworkMap::get_key(3, zero_hash.clone()),
+						NetworkMap::get_key(4, zero_hash.clone()),
+						NetworkMap::get_key(5, zero_hash.clone()),
+						NetworkMap::get_key(6, zero_hash.clone()),
+						NetworkMap::get_key(7, zero_hash.clone()),
+					],
+					lowest_inbound_channel_fee_base_msat: 0,
+					lowest_inbound_channel_fee_proportional_millionths: 0,
+					features: GlobalFeatures::new(),
+					last_update: 1,
+					rgb: [0; 3],
+					alias: [0; 32],
+					addresses: Vec::new(),
 				},
-			});
-			network.nodes.insert(node5.clone(), NodeInfo {
-				channels: vec!(NetworkMap::get_key(6, zero_hash.clone()), NetworkMap::get_key(11, zero_hash.clone())),
-				lowest_inbound_channel_fee_base_msat: 0,
-				lowest_inbound_channel_fee_proportional_millionths: 0,
-				features: GlobalFeatures::new(),
-				last_update: 1,
-				rgb: [0; 3],
-				alias: [0; 32],
-				addresses: Vec::new(),
-			});
-			network.channels.insert(NetworkMap::get_key(6, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: node3.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (6 << 8) | 1,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node5.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (6 << 8) | 2,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			);
+			network.channels.insert(
+				NetworkMap::get_key(3, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: node1.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (3 << 8) | 1,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node3.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (3 << 8) | 2,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 100,
+						fee_proportional_millionths: 0,
+					},
 				},
-			});
-			network.channels.insert(NetworkMap::get_key(11, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: node5.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (11 << 8) | 1,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node4.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (11 << 8) | 2,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			);
+			network.channels.insert(
+				NetworkMap::get_key(4, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: node2.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (4 << 8) | 1,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 1000000,
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node3.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (4 << 8) | 2,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
 				},
-			});
-			network.nodes.insert(node6.clone(), NodeInfo {
-				channels: vec!(NetworkMap::get_key(7, zero_hash.clone())),
-				lowest_inbound_channel_fee_base_msat: 0,
-				lowest_inbound_channel_fee_proportional_millionths: 0,
-				features: GlobalFeatures::new(),
-				last_update: 1,
-				rgb: [0; 3],
-				alias: [0; 32],
-				addresses: Vec::new(),
-			});
-			network.channels.insert(NetworkMap::get_key(7, zero_hash.clone()), ChannelInfo {
-				features: GlobalFeatures::new(),
-				one_to_two: DirectionalChannelInfo {
-					src_node_id: node3.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (7 << 8) | 1,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 1000000,
-				}, two_to_one: DirectionalChannelInfo {
-					src_node_id: node6.clone(),
-					last_update: 0,
-					enabled: true,
-					cltv_expiry_delta: (7 << 8) | 2,
-					htlc_minimum_msat: 0,
-					fee_base_msat: 0,
-					fee_proportional_millionths: 0,
+			);
+			network.nodes.insert(
+				node4.clone(),
+				NodeInfo {
+					channels: vec![
+						NetworkMap::get_key(5, zero_hash.clone()),
+						NetworkMap::get_key(11, zero_hash.clone()),
+					],
+					lowest_inbound_channel_fee_base_msat: 0,
+					lowest_inbound_channel_fee_proportional_millionths: 0,
+					features: GlobalFeatures::new(),
+					last_update: 1,
+					rgb: [0; 3],
+					alias: [0; 32],
+					addresses: Vec::new(),
 				},
-			});
+			);
+			network.channels.insert(
+				NetworkMap::get_key(5, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: node3.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (5 << 8) | 1,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 100,
+						fee_proportional_millionths: 0,
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node4.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (5 << 8) | 2,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+				},
+			);
+			network.nodes.insert(
+				node5.clone(),
+				NodeInfo {
+					channels: vec![
+						NetworkMap::get_key(6, zero_hash.clone()),
+						NetworkMap::get_key(11, zero_hash.clone()),
+					],
+					lowest_inbound_channel_fee_base_msat: 0,
+					lowest_inbound_channel_fee_proportional_millionths: 0,
+					features: GlobalFeatures::new(),
+					last_update: 1,
+					rgb: [0; 3],
+					alias: [0; 32],
+					addresses: Vec::new(),
+				},
+			);
+			network.channels.insert(
+				NetworkMap::get_key(6, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: node3.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (6 << 8) | 1,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node5.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (6 << 8) | 2,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+				},
+			);
+			network.channels.insert(
+				NetworkMap::get_key(11, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: node5.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (11 << 8) | 1,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node4.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (11 << 8) | 2,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+				},
+			);
+			network.nodes.insert(
+				node6.clone(),
+				NodeInfo {
+					channels: vec![NetworkMap::get_key(7, zero_hash.clone())],
+					lowest_inbound_channel_fee_base_msat: 0,
+					lowest_inbound_channel_fee_proportional_millionths: 0,
+					features: GlobalFeatures::new(),
+					last_update: 1,
+					rgb: [0; 3],
+					alias: [0; 32],
+					addresses: Vec::new(),
+				},
+			);
+			network.channels.insert(
+				NetworkMap::get_key(7, zero_hash.clone()),
+				ChannelInfo {
+					features: GlobalFeatures::new(),
+					one_to_two: DirectionalChannelInfo {
+						src_node_id: node3.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (7 << 8) | 1,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 1000000,
+					},
+					two_to_one: DirectionalChannelInfo {
+						src_node_id: node6.clone(),
+						last_update: 0,
+						enabled: true,
+						cltv_expiry_delta: (7 << 8) | 2,
+						htlc_minimum_msat: 0,
+						fee_base_msat: 0,
+						fee_proportional_millionths: 0,
+					},
+				},
+			);
 		}
 
-		{ // Simple route to 3 via 2
+		{
+			// Simple route to 3 via 2
 			let route = router.get_route(&node3, &Vec::new(), 100, 42).unwrap();
 			assert_eq!(route.hops.len(), 2);
 
@@ -802,7 +1072,8 @@ mod tests {
 			assert_eq!(route.hops[1].cltv_expiry_delta, 42);
 		}
 
-		{ // Route to 1 via 2 and 3 because our channel to 1 is disabled
+		{
+			// Route to 1 via 2 and 3 because our channel to 1 is disabled
 			let route = router.get_route(&node1, &Vec::new(), 100, 42).unwrap();
 			assert_eq!(route.hops.len(), 3);
 
@@ -822,30 +1093,35 @@ mod tests {
 			assert_eq!(route.hops[2].cltv_expiry_delta, 42);
 		}
 
-		let mut last_hops = vec!(RouteHint {
+		let mut last_hops = vec![
+			RouteHint {
 				src_node_id: node4.clone(),
 				short_channel_id: 8,
 				fee_base_msat: 0,
 				fee_proportional_millionths: 0,
 				cltv_expiry_delta: (8 << 8) | 1,
 				htlc_minimum_msat: 0,
-			}, RouteHint {
+			},
+			RouteHint {
 				src_node_id: node5.clone(),
 				short_channel_id: 9,
 				fee_base_msat: 1001,
 				fee_proportional_millionths: 0,
 				cltv_expiry_delta: (9 << 8) | 1,
 				htlc_minimum_msat: 0,
-			}, RouteHint {
+			},
+			RouteHint {
 				src_node_id: node6.clone(),
 				short_channel_id: 10,
 				fee_base_msat: 0,
 				fee_proportional_millionths: 0,
 				cltv_expiry_delta: (10 << 8) | 1,
 				htlc_minimum_msat: 0,
-			});
+			},
+		];
 
-		{ // Simple test across 2, 3, 5, and 4 via a last_hop channel
+		{
+			// Simple test across 2, 3, 5, and 4 via a last_hop channel
 			let route = router.get_route(&node7, &last_hops, 100, 42).unwrap();
 			assert_eq!(route.hops.len(), 5);
 
@@ -877,7 +1153,8 @@ mod tests {
 
 		last_hops[0].fee_base_msat = 1000;
 
-		{ // Revert to via 6 as the fee on 8 goes up
+		{
+			// Revert to via 6 as the fee on 8 goes up
 			let route = router.get_route(&node7, &last_hops, 100, 42).unwrap();
 			assert_eq!(route.hops.len(), 4);
 
@@ -902,7 +1179,8 @@ mod tests {
 			assert_eq!(route.hops[3].cltv_expiry_delta, 42);
 		}
 
-		{ // ...but still use 8 for larger payments as 6 has a variable feerate
+		{
+			// ...but still use 8 for larger payments as 6 has a variable feerate
 			let route = router.get_route(&node7, &last_hops, 2000, 42).unwrap();
 			assert_eq!(route.hops.len(), 5);
 

--- a/src/util/byte_utils.rs
+++ b/src/util/byte_utils.rs
@@ -1,67 +1,66 @@
 #[inline]
 pub fn slice_to_be16(v: &[u8]) -> u16 {
-	((v[0] as u16) << 8*1) |
-	((v[1] as u16) << 8*0)
+	((v[0] as u16) << 8 * 1) | ((v[1] as u16) << 8 * 0)
 }
 #[inline]
 pub fn slice_to_be32(v: &[u8]) -> u32 {
-	((v[0] as u32) << 8*3) |
-	((v[1] as u32) << 8*2) |
-	((v[2] as u32) << 8*1) |
-	((v[3] as u32) << 8*0)
+	((v[0] as u32) << 8 * 3)
+		| ((v[1] as u32) << 8 * 2)
+		| ((v[2] as u32) << 8 * 1)
+		| ((v[3] as u32) << 8 * 0)
 }
 #[inline]
 pub fn slice_to_be64(v: &[u8]) -> u64 {
-	((v[0] as u64) << 8*7) |
-	((v[1] as u64) << 8*6) |
-	((v[2] as u64) << 8*5) |
-	((v[3] as u64) << 8*4) |
-	((v[4] as u64) << 8*3) |
-	((v[5] as u64) << 8*2) |
-	((v[6] as u64) << 8*1) |
-	((v[7] as u64) << 8*0)
+	((v[0] as u64) << 8 * 7)
+		| ((v[1] as u64) << 8 * 6)
+		| ((v[2] as u64) << 8 * 5)
+		| ((v[3] as u64) << 8 * 4)
+		| ((v[4] as u64) << 8 * 3)
+		| ((v[5] as u64) << 8 * 2)
+		| ((v[6] as u64) << 8 * 1)
+		| ((v[7] as u64) << 8 * 0)
 }
 
 #[inline]
 pub fn be16_to_array(u: u16) -> [u8; 2] {
 	let mut v = [0; 2];
-	v[0] = ((u >> 8*1) & 0xff) as u8;
-	v[1] = ((u >> 8*0) & 0xff) as u8;
+	v[0] = ((u >> 8 * 1) & 0xff) as u8;
+	v[1] = ((u >> 8 * 0) & 0xff) as u8;
 	v
 }
 #[inline]
 pub fn be32_to_array(u: u32) -> [u8; 4] {
 	let mut v = [0; 4];
-	v[0] = ((u >> 8*3) & 0xff) as u8;
-	v[1] = ((u >> 8*2) & 0xff) as u8;
-	v[2] = ((u >> 8*1) & 0xff) as u8;
-	v[3] = ((u >> 8*0) & 0xff) as u8;
+	v[0] = ((u >> 8 * 3) & 0xff) as u8;
+	v[1] = ((u >> 8 * 2) & 0xff) as u8;
+	v[2] = ((u >> 8 * 1) & 0xff) as u8;
+	v[3] = ((u >> 8 * 0) & 0xff) as u8;
 	v
 }
 #[inline]
 pub fn be64_to_array(u: u64) -> [u8; 8] {
 	let mut v = [0; 8];
-	v[0] = ((u >> 8*7) & 0xff) as u8;
-	v[1] = ((u >> 8*6) & 0xff) as u8;
-	v[2] = ((u >> 8*5) & 0xff) as u8;
-	v[3] = ((u >> 8*4) & 0xff) as u8;
-	v[4] = ((u >> 8*3) & 0xff) as u8;
-	v[5] = ((u >> 8*2) & 0xff) as u8;
-	v[6] = ((u >> 8*1) & 0xff) as u8;
-	v[7] = ((u >> 8*0) & 0xff) as u8;
+	v[0] = ((u >> 8 * 7) & 0xff) as u8;
+	v[1] = ((u >> 8 * 6) & 0xff) as u8;
+	v[2] = ((u >> 8 * 5) & 0xff) as u8;
+	v[3] = ((u >> 8 * 4) & 0xff) as u8;
+	v[4] = ((u >> 8 * 3) & 0xff) as u8;
+	v[5] = ((u >> 8 * 2) & 0xff) as u8;
+	v[6] = ((u >> 8 * 1) & 0xff) as u8;
+	v[7] = ((u >> 8 * 0) & 0xff) as u8;
 	v
 }
 
 #[inline]
 pub fn le64_to_array(u: u64) -> [u8; 8] {
 	let mut v = [0; 8];
-	v[0] = ((u >> 8*0) & 0xff) as u8;
-	v[1] = ((u >> 8*1) & 0xff) as u8;
-	v[2] = ((u >> 8*2) & 0xff) as u8;
-	v[3] = ((u >> 8*3) & 0xff) as u8;
-	v[4] = ((u >> 8*4) & 0xff) as u8;
-	v[5] = ((u >> 8*5) & 0xff) as u8;
-	v[6] = ((u >> 8*6) & 0xff) as u8;
-	v[7] = ((u >> 8*7) & 0xff) as u8;
+	v[0] = ((u >> 8 * 0) & 0xff) as u8;
+	v[1] = ((u >> 8 * 1) & 0xff) as u8;
+	v[2] = ((u >> 8 * 2) & 0xff) as u8;
+	v[3] = ((u >> 8 * 3) & 0xff) as u8;
+	v[4] = ((u >> 8 * 4) & 0xff) as u8;
+	v[5] = ((u >> 8 * 5) & 0xff) as u8;
+	v[6] = ((u >> 8 * 6) & 0xff) as u8;
+	v[7] = ((u >> 8 * 7) & 0xff) as u8;
 	v
 }

--- a/src/util/chacha20poly1305rfc.rs
+++ b/src/util/chacha20poly1305rfc.rs
@@ -12,18 +12,18 @@
 
 #[cfg(not(feature = "fuzztarget"))]
 mod real_chachapoly {
-	use crypto::aead::{AeadEncryptor,AeadDecryptor};
+	use crypto::aead::{AeadDecryptor, AeadEncryptor};
 	use crypto::chacha20::ChaCha20;
-	use crypto::symmetriccipher::SynchronousStreamCipher;
-	use crypto::poly1305::Poly1305;
 	use crypto::mac::Mac;
+	use crypto::poly1305::Poly1305;
+	use crypto::symmetriccipher::SynchronousStreamCipher;
 	use crypto::util::fixed_time_eq;
 
 	use util::byte_utils;
 
 	#[derive(Clone, Copy)]
 	pub struct ChaCha20Poly1305RFC {
-		cipher  : ChaCha20,
+		cipher: ChaCha20,
 		mac: Poly1305,
 		finished: bool,
 		data_len: usize,
@@ -73,7 +73,8 @@ mod real_chachapoly {
 			ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
 			self.finished = true;
 			self.mac.input(&byte_utils::le64_to_array(self.aad_len));
-			self.mac.input(&byte_utils::le64_to_array(self.data_len as u64));
+			self.mac
+				.input(&byte_utils::le64_to_array(self.data_len as u64));
 			self.mac.raw_result(out_tag);
 		}
 	}
@@ -90,9 +91,10 @@ mod real_chachapoly {
 			self.data_len += input.len();
 			ChaCha20Poly1305RFC::pad_mac_16(&mut self.mac, self.data_len);
 			self.mac.input(&byte_utils::le64_to_array(self.aad_len));
-			self.mac.input(&byte_utils::le64_to_array(self.data_len as u64));
+			self.mac
+				.input(&byte_utils::le64_to_array(self.data_len as u64));
 
-			let mut calc_tag =  [0u8; 16];
+			let mut calc_tag = [0u8; 16];
 			self.mac.raw_result(&mut calc_tag);
 			if fixed_time_eq(&calc_tag, tag) {
 				self.cipher.process(input, output);
@@ -108,7 +110,7 @@ pub use self::real_chachapoly::ChaCha20Poly1305RFC;
 
 #[cfg(feature = "fuzztarget")]
 mod fuzzy_chachapoly {
-	use crypto::aead::{AeadEncryptor,AeadDecryptor};
+	use crypto::aead::{AeadDecryptor, AeadEncryptor};
 
 	#[derive(Clone, Copy)]
 	pub struct ChaCha20Poly1305RFC {
@@ -149,7 +151,9 @@ mod fuzzy_chachapoly {
 			assert!(input.len() == output.len());
 			assert!(self.finished == false);
 
-			if tag[..] != self.tag[..] { return false; }
+			if tag[..] != self.tag[..] {
+				return false;
+			}
 			output.copy_from_slice(input);
 			self.finished = true;
 			true

--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -1,5 +1,5 @@
-use ln::msgs;
 use chain::transaction::OutPoint;
+use ln::msgs;
 
 use bitcoin::blockdata::script::Script;
 use bitcoin::util::uint::Uint256;
@@ -32,28 +32,19 @@ pub enum Event {
 	/// ChannelManager::claim_funds to get it....
 	/// Note that if the preimage is not known, you must call ChannelManager::fail_htlc_backwards
 	/// to free up resources for this HTLC.
-	PaymentReceived {
-		payment_hash: [u8; 32],
-		amt: u64,
-	},
+	PaymentReceived { payment_hash: [u8; 32], amt: u64 },
 	/// Indicates an outbound payment we made succeeded (ie it made it all the way to its target
 	/// and we got back the payment preimage for it). payment_preimage serves as a payment receipt,
 	/// if you wish to have such a thing, you must store it somehow!
-	PaymentSent {
-		payment_preimage: [u8; 32],
-	},
+	PaymentSent { payment_preimage: [u8; 32] },
 	/// Indicates an outbound payment we made failed. Probably some intermediary node dropped
 	/// something. You may wish to retry with a different route.
-	PaymentFailed {
-		payment_hash: [u8; 32],
-	},
+	PaymentFailed { payment_hash: [u8; 32] },
 
 	// Events indicating the network loop should send a message to a peer:
 	/// Used to indicate that ChannelManager::process_pending_htlc_forwards should be called at a
 	/// time in the future.
-	PendingHTLCsForwardable {
-		time_forwardable: Instant,
-	},
+	PendingHTLCsForwardable { time_forwardable: Instant },
 	/// Used to indicate that a funding_created message should be sent to the peer with the given node_id.
 	SendFundingCreated {
 		node_id: PublicKey,
@@ -91,9 +82,7 @@ pub enum Event {
 		update_msg: msgs::ChannelUpdate,
 	},
 	/// Used to indicate that a channel_update should be broadcast to all peers.
-	BroadcastChannelUpdate {
-		msg: msgs::ChannelUpdate,
-	},
+	BroadcastChannelUpdate { msg: msgs::ChannelUpdate },
 }
 
 pub trait EventsProvider {

--- a/src/util/internal_traits.rs
+++ b/src/util/internal_traits.rs
@@ -4,4 +4,4 @@ pub unsafe trait NoDealloc {}
 
 /// Just call with test_no_dealloc::<Type>(None)
 #[inline]
-pub fn test_no_dealloc<T : NoDealloc>(_: Option<T>) { }
+pub fn test_no_dealloc<T: NoDealloc>(_: Option<T>) {}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,5 @@
-pub mod transaction_utils;
 pub mod events;
+pub mod transaction_utils;
 
 pub(crate) mod byte_utils;
 pub(crate) mod chacha20poly1305rfc;

--- a/src/util/rng.rs
+++ b/src/util/rng.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "fuzztarget"))]
 mod real_rng {
-	use rand::{thread_rng,Rng};
 	use bitcoin::util::uint::Uint256;
+	use rand::{thread_rng, Rng};
 
 	pub fn fill_bytes(data: &mut [u8]) {
 		let mut rng = thread_rng();
@@ -29,9 +29,12 @@ mod fuzzy_rng {
 	static mut RNG_ITER: u64 = 0;
 
 	pub fn fill_bytes(data: &mut [u8]) {
-		let rng = unsafe { RNG_ITER += 1; RNG_ITER -1 };
+		let rng = unsafe {
+			RNG_ITER += 1;
+			RNG_ITER - 1
+		};
 		for i in 0..data.len() / 8 {
-			data[i*8..(i+1)*8].copy_from_slice(&byte_utils::be64_to_array(rng));
+			data[i * 8..(i + 1) * 8].copy_from_slice(&byte_utils::be64_to_array(rng));
 		}
 		let rem = data.len() % 8;
 		let off = data.len() - rem;
@@ -39,17 +42,25 @@ mod fuzzy_rng {
 	}
 
 	pub fn rand_uint256() -> Uint256 {
-		let rng = unsafe { RNG_ITER += 1; RNG_ITER - 1 };
+		let rng = unsafe {
+			RNG_ITER += 1;
+			RNG_ITER - 1
+		};
 		Uint256([rng, rng, rng, rng])
 	}
 
 	pub fn rand_f32() -> f32 {
-		let rng = unsafe { RNG_ITER += 1; RNG_ITER - 1 };
+		let rng = unsafe {
+			RNG_ITER += 1;
+			RNG_ITER - 1
+		};
 		f64::from_bits(rng) as f32
 	}
 
 	pub fn reset_rng_state() {
-		unsafe { RNG_ITER = 0; }
+		unsafe {
+			RNG_ITER = 0;
+		}
 	}
 }
 #[cfg(feature = "fuzztarget")]

--- a/src/util/sha2.rs
+++ b/src/util/sha2.rs
@@ -11,9 +11,7 @@ mod fuzzy_sha {
 
 	impl Sha256 {
 		pub fn new() -> Sha256 {
-			Sha256 {
-				state: 0,
-			}
+			Sha256 { state: 0 }
 		}
 	}
 
@@ -25,10 +23,20 @@ mod fuzzy_sha {
 			}
 		}
 
-		fn input(&mut self, data: &[u8]) { for i in data { self.state ^= i; } }
-		fn reset(&mut self) { self.state = 0; }
-		fn output_bits(&self) -> usize { 256 }
-		fn block_size(&self) -> usize { 64 }
+		fn input(&mut self, data: &[u8]) {
+			for i in data {
+				self.state ^= i;
+			}
+		}
+		fn reset(&mut self) {
+			self.state = 0;
+		}
+		fn output_bits(&self) -> usize {
+			256
+		}
+		fn block_size(&self) -> usize {
+			64
+		}
 	}
 }
 #[cfg(feature = "fuzztarget")]

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -5,7 +5,7 @@ use ln::channelmonitor;
 
 use bitcoin::blockdata::transaction::Transaction;
 
-use std::sync::{Arc,Mutex};
+use std::sync::{Arc, Mutex};
 
 pub struct TestFeeEstimator {
 	pub sat_per_vbyte: u64,
@@ -21,16 +21,29 @@ pub struct TestChannelMonitor {
 	pub simple_monitor: Arc<channelmonitor::SimpleManyChannelMonitor<OutPoint>>,
 }
 impl TestChannelMonitor {
-	pub fn new(chain_monitor: Arc<chaininterface::ChainWatchInterface>, broadcaster: Arc<chaininterface::BroadcasterInterface>) -> Self {
+	pub fn new(
+		chain_monitor: Arc<chaininterface::ChainWatchInterface>,
+		broadcaster: Arc<chaininterface::BroadcasterInterface>,
+	) -> Self {
 		Self {
 			added_monitors: Mutex::new(Vec::new()),
-			simple_monitor: channelmonitor::SimpleManyChannelMonitor::new(chain_monitor, broadcaster),
+			simple_monitor: channelmonitor::SimpleManyChannelMonitor::new(
+				chain_monitor,
+				broadcaster,
+			),
 		}
 	}
 }
 impl channelmonitor::ManyChannelMonitor for TestChannelMonitor {
-	fn add_update_monitor(&self, funding_txo: OutPoint, monitor: channelmonitor::ChannelMonitor) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
-		self.added_monitors.lock().unwrap().push((funding_txo, monitor.clone()));
+	fn add_update_monitor(
+		&self,
+		funding_txo: OutPoint,
+		monitor: channelmonitor::ChannelMonitor,
+	) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
+		self.added_monitors
+			.lock()
+			.unwrap()
+			.push((funding_txo, monitor.clone()));
 		self.simple_monitor.add_update_monitor(funding_txo, monitor)
 	}
 }

--- a/src/util/transaction_utils.rs
+++ b/src/util/transaction_utils.rs
@@ -2,15 +2,18 @@ use bitcoin::blockdata::transaction::TxOut;
 
 use std::cmp::Ordering;
 
-pub fn sort_outputs<T>(outputs: &mut Vec<(TxOut, T)>) { //TODO: Make static and put it in some utils somewhere (+inputs sorting)
+pub fn sort_outputs<T>(outputs: &mut Vec<(TxOut, T)>) {
+	//TODO: Make static and put it in some utils somewhere (+inputs sorting)
 	outputs.sort_unstable_by(|a, b| {
 		if a.0.value < b.0.value {
 			Ordering::Less
 		} else if b.0.value < a.0.value {
 			Ordering::Greater
-		} else if a.0.script_pubkey[..] < b.0.script_pubkey[..] { //TODO: ordering of scripts shouldn't be len-based
+		} else if a.0.script_pubkey[..] < b.0.script_pubkey[..] {
+			//TODO: ordering of scripts shouldn't be len-based
 			Ordering::Less
-		} else if b.0.script_pubkey[..] < a.0.script_pubkey[..] { //TODO: ordering of scripts shouldn't be len-based
+		} else if b.0.script_pubkey[..] < a.0.script_pubkey[..] {
+			//TODO: ordering of scripts shouldn't be len-based
 			Ordering::Greater
 		} else {
 			Ordering::Equal


### PR DESCRIPTION
This adds a rustfmt config, as well as formatting the code with rustfmt.

It's a huge disruptive PR that'll be annoying to merge, but may be worth doing sooner rather than later. It's also nice since people often have their editors configured to use spaces instead of tabs for rust, and with the config/formatted code, they can just run rustfmt and it'll do the right thing.

To get `rustfmt`:
`rustup component add rustfmt-preview --toolchain=stable`

And format the code:
`cargo fmt`