### PR TITLE
Move open_channel message handling into an event

### DIFF
--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -614,6 +614,14 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 						//TODO: Handle upstream in some confused form so that upstream just knows
 						//to call us somehow?
 					},
+					Event::SendOpenChannel { ref node_id, ref msg } => {
+						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
+								//TODO: Drop the pending channel? (or just let it timeout, but that sucks)
+							});
+						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg, 32)));
+						Self::do_attempt_write_data(&mut descriptor, peer);
+						continue;
+					},
 					Event::SendFundingCreated { ref node_id, ref msg } => {
 						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {
 								//TODO: generate a DiscardFunding event indicating to the wallet that

--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -54,6 +54,12 @@ pub enum Event {
 	PendingHTLCsForwardable {
 		time_forwardable: Instant,
 	},
+	/// Used to indicate that we've initialted a channel open and should send the open_channel
+	/// message provided to the given peer
+	SendOpenChannel {
+		node_id: PublicKey,
+		msg: msgs::OpenChannel,
+	},
 	/// Used to indicate that a funding_created message should be sent to the peer with the given node_id.
 	SendFundingCreated {
 		node_id: PublicKey,


### PR DESCRIPTION
This simplifies client usage cause peer_handler doesn't have an
interface to shove arbitrary messages in.