### PR TITLE
Fix various spec bugs, can now open channels with real nodes!

### DIFF
--- a/src/chain/transaction.rs
+++ b/src/chain/transaction.rs
@@ -20,7 +20,9 @@ impl OutPoint {
 
 	/// Convert an `OutPoint` to a lightning channel id.
 	pub fn to_channel_id(&self) -> Uint256 {
-		// TODO: or le?
-		self.txid.into_be() ^ Uint256::from_u64(self.index as u64).unwrap()
+		let mut index = [0; 32];
+		index[30] = ((self.index >> 8) & 0xff) as u8;
+		index[31] = ((self.index >> 0) & 0xff) as u8;
+		self.txid.into_le() ^ Sha256dHash::from(&index[..]).into_le()
 	}
 }

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -910,7 +910,7 @@ impl ChannelMonitor {
 		let commitment_txid = tx.txid(); //TODO: This is gonna be a performance bottleneck for watchtowers!
 		let per_commitment_option = self.remote_claimable_outpoints.get(&commitment_txid);
 
-		let commitment_number = (((tx.input[0].sequence as u64 & 0xffffff) << 3*8) | (tx.lock_time as u64 & 0xffffff)) ^ self.commitment_transaction_number_obscure_factor;
+		let commitment_number = 0xffffffffffff - ((((tx.input[0].sequence as u64 & 0xffffff) << 3*8) | (tx.lock_time as u64 & 0xffffff)) ^ self.commitment_transaction_number_obscure_factor);
 		if commitment_number >= self.get_min_seen_secret() {
 			let secret = self.get_secret(commitment_number).unwrap();
 			let per_commitment_key = ignore_error!(SecretKey::from_slice(&self.secp_ctx, &secret));


### PR DESCRIPTION
 * commitment transaction number, as used in locktime/sequence
   fields is actually different from commitment transaction number,
   as used for revocation state. This is confusing and never stated
   in the spec, so we have to do the conversion.
 * max_htlc_value_in_flight is never constrained in the spec, but
   we were requiring it be <= channel size. Instead just clamp the
   values the peer sends us when storing.
 * channel_id calculation was incorrect, we now do some crazy
   conversion hops, which we shouldn't, but will need to change our
   types to fix.
 * Our channel_reserve_satoshis value was too low, just change the
   constant and leave the TODO to figure out what it really should
   be for now.