### PR TITLE
Bump version for API overhauls, update deps and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "lightning"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Matt Corallo"]
 license = "Apache-2.0"
 repository = "https://github.com/rust-bitcoin/rust-lightning/"
 description = """
-A Bitcoin Lightning implementation in Rust.
-Still super-early code-dump quality and is missing large chunks. See README in git repo for suggested projects if you want to contribute. Don't have to bother telling you not to use this for anything serious, because you'd have to finish building it to even try.
+A Bitcoin Lightning library in Rust.
+Does most of the hard work, without implying a specific runtime, requiring clients implement basic network logic, chain interactions and disk storage.
+Still missing tons of error-handling. See GitHub issues for suggested projects if you want to contribute. Don't have to bother telling you not to use this for anything serious, because you'd have to build a client around it to even try.
 """
 build = "build.rs"
 
@@ -22,7 +23,7 @@ rand = "0.4"
 secp256k1 = "0.9"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 [dev-dependencies.bitcoin]
 version = "0.13"

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
-extern crate gcc;
+extern crate cc;
 
 fn main() {
 	#[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "arm")))]
 	{
-		let mut cfg = gcc::Build::new();
+		let mut cfg = cc::Build::new();
 		cfg.file("src/util/rust_crypto_nonstd_arch.c");
 		cfg.compile("lib_rust_crypto_nonstd_arch.a");
 	}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -24,7 +24,7 @@ honggfuzz = { version = "0.5", optional = true }
 afl = { version = "0.3", optional = true }
 
 [build-dependencies]
-gcc = "0.3"
+cc = "1.0"
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/src/ln/mod.rs
+++ b/src/ln/mod.rs
@@ -2,8 +2,12 @@ pub mod channelmanager;
 pub mod channelmonitor;
 pub mod msgs;
 pub mod router;
-pub mod peer_channel_encryptor;
 pub mod peer_handler;
+
+#[cfg(feature = "fuzztarget")]
+pub mod peer_channel_encryptor;
+#[cfg(not(feature = "fuzztarget"))]
+pub(crate) mod peer_channel_encryptor;
 
 #[cfg(feature = "fuzztarget")]
 pub mod channel;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,3 @@
-pub mod transaction_utils;
 pub mod events;
 
 pub(crate) mod byte_utils;
@@ -6,6 +5,7 @@ pub(crate) mod chacha20poly1305rfc;
 pub(crate) mod internal_traits;
 pub(crate) mod rng;
 pub(crate) mod sha2;
+pub(crate) mod transaction_utils;
 
 #[cfg(feature = "fuzztarget")]
 pub use self::rng::reset_rng_state;


### PR DESCRIPTION
Might as well keep crates sorta-kinda up-to-date, at least on the API.