### PR TITLE
[fuzz] remove \L in sed regex for filenames in gen_target.sh

### DIFF
--- a/fuzz/fuzz_targets/msg_targets/gen_target.sh
+++ b/fuzz/fuzz_targets/msg_targets/gen_target.sh
@@ -1,5 +1,5 @@
 for target in CommitmentSigned FundingCreated FundingLocked FundingSigned OpenChannel RevokeAndACK Shutdown UpdateAddHTLC UpdateFailHTLC UpdateFailMalformedHTLC UpdateFee UpdateFulfillHTLC AcceptChannel ClosingSigned; do
-	tn=$(echo $target | sed 's/\([a-z0-9]\)\([A-Z]\)/\1_\L\2/g')
+	tn=$(echo $target | sed 's/\([a-z0-9]\)\([A-Z]\)/\1_\2/g')
 	fn=msg_$(echo $tn | tr '[:upper:]' '[:lower:]')_target.rs
 	cat msg_target_template.txt | sed s/MSG_TARGET/$target/ > $fn
 done


### PR DESCRIPTION
Summary:
on `master` branch, if i ran `gen_target.sh` i would get the following output:
https://gist.github.com/savil/2b3114eaf34c3ef8499b65005e374841

Without it, I get the files generated that are already checked-in (as expected).

Looking at the sed docs (https://www.gnu.org/software/sed/manual/html_node/Regular-Expressions.html) i don't see an explanation for what `\L` may do in whatever regex sed follows. Does this look correct? cc @yuntai