### PR TITLE
 Ensure the funding transaction is registered to be monitored

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1843,6 +1843,10 @@ impl Channel {
 		self.channel_update_count
 	}
 
+	pub fn should_announce(&self) -> bool {
+		self.announce_publicly
+	}
+
 	/// Gets the fee we'd want to charge for adding an HTLC output to this Channel
 	pub fn get_our_fee_base_msat(&self, fee_estimator: &FeeEstimator) -> u32 {
 		// For lack of a better metric, we calculate what it would cost to consolidate the new HTLC

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -710,7 +710,7 @@ impl ChannelManager {
 	}
 
 	fn get_announcement_sigs(&self, chan: &Channel) -> Result<Option<msgs::AnnouncementSignatures>, HandleError> {
-		if !chan.is_usable() { return Ok(None) }
+		if !chan.is_usable() || !chan.should_announce() { return Ok(None) }
 
 		let (announcement, our_bitcoin_sig) = chan.get_channel_announcement(self.get_our_node_id(), self.genesis_hash.clone())?;
 		let msghash = Message::from_slice(&Sha256dHash::from_data(&announcement.encode()[..])[..]).unwrap();

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -94,7 +94,10 @@ impl<Key : Send + cmp::Eq + hash::Hash + 'static> SimpleManyChannelMonitor<Key> 
 		};
 		match &monitor.funding_txo {
 			&None => self.chain_monitor.watch_all_txn(),
-			&Some((ref outpoint, ref script)) => self.chain_monitor.install_watch_outpoint((outpoint.txid, outpoint.index as u32), script),
+			&Some((ref outpoint, ref script)) => {
+				self.chain_monitor.install_watch_script(script);
+				self.chain_monitor.install_watch_outpoint((outpoint.txid, outpoint.index as u32), script);
+			},
 		}
 		monitors.insert(key, monitor);
 		Ok(())


### PR DESCRIPTION
Should fix a bug where we never send FundingLocked.