### PR TITLE
fix editorconfig so it applies to every file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
 # see https://editorconfig.org for more options, and setup instructions for yours editor
 
+[*]
 indent_style = tab


### PR DESCRIPTION
in my local testing I'd had `[*.rs]` but removed it thinking that it would still apply to all files (but neglected to test it). That was incorrect. We need to explicitly specify it should apply to all files.