### PR TITLE
Properly calculate Channel::announce_publicly

### DIFF
--- a/fuzz/fuzz_targets/channel_target.rs
+++ b/fuzz/fuzz_targets/channel_target.rs
@@ -213,7 +213,7 @@ pub fn do_test(data: &[u8]) {
 		} else {
 			decode_msg!(msgs::OpenChannel, 2*32+6*8+4+2*2+6*33+1)
 		};
-		let mut chan = match Channel::new_from_req(&fee_est, chan_keys!(), their_pubkey, &open_chan, slice_to_be64(get_slice!(8)), get_slice!(1)[0] == 0) {
+		let mut chan = match Channel::new_from_req(&fee_est, chan_keys!(), their_pubkey, &open_chan, slice_to_be64(get_slice!(8)), false, get_slice!(1)[0] == 0) {
 			Ok(chan) => chan,
 			Err(_) => return,
 		};

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1185,7 +1185,7 @@ impl ChannelMessageHandler for ChannelManager {
 			}
 		};
 
-		let channel = Channel::new_from_req(&*self.fee_estimator, chan_keys, their_node_id.clone(), msg, 0, self.announce_channels_publicly)?;
+		let channel = Channel::new_from_req(&*self.fee_estimator, chan_keys, their_node_id.clone(), msg, 0, false, self.announce_channels_publicly)?;
 		let accept_msg = channel.get_accept_channel()?;
 		channel_state.by_id.insert(channel.channel_id(), channel);
 		Ok(accept_msg)

--- a/src/ln/router.rs
+++ b/src/ln/router.rs
@@ -433,7 +433,7 @@ impl Router {
 							($directional_info.fee_base_msat as u64).checked_add(part / 1000000) })
 					{
 						let mut total_fee = $starting_fee_msat as u64;
-						let mut hm_entry = dist.entry(&$directional_info.src_node_id);
+						let hm_entry = dist.entry(&$directional_info.src_node_id);
 						let old_entry = hm_entry.or_insert_with(|| {
 							let node = network.nodes.get(&$directional_info.src_node_id).unwrap();
 							(u64::max_value(),


### PR DESCRIPTION
For some reason we were only setting "announce_publicly" when
Channel::new_from_req had announce_publicly set to true and the
open_channel message had the relevant flag set. However, this
resulted in us rejecting peers for sending unsolicited
announcement_signatures messages, despite them having indicated,
and us having accepted, their announce-bit-set open_channel.