### PR TITLE
Add some trace logging in peer_handler

### DIFF
--- a/fuzz/fuzz_targets/channel_target.rs
+++ b/fuzz/fuzz_targets/channel_target.rs
@@ -107,7 +107,7 @@ pub fn do_test(data: &[u8]) {
 		input: &input,
 	};
 
-	let logger: Arc<Logger> = Arc::new(test_logger::TestLogger::new());
+	let logger: Arc<Logger> = Arc::new(test_logger::TestLogger{});
 
 	macro_rules! get_slice {
 		($len: expr) => {

--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -174,7 +174,7 @@ pub fn do_test(data: &[u8]) {
 		Err(_) => return,
 	};
 
-	let logger: Arc<Logger> = Arc::new(test_logger::TestLogger::new());
+	let logger: Arc<Logger> = Arc::new(test_logger::TestLogger{});
 	let monitor = Arc::new(TestChannelMonitor{});
 	let watch = Arc::new(ChainWatchInterfaceUtil::new(Arc::clone(&logger)));
 	let broadcast = Arc::new(TestBroadcaster{});

--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -105,7 +105,7 @@ pub fn do_test(data: &[u8]) {
 		}
 	}
 
-	let logger: Arc<Logger> = Arc::new(test_logger::TestLogger::new());
+	let logger: Arc<Logger> = Arc::new(test_logger::TestLogger{});
 
 	let our_pubkey = get_pubkey!();
 	let router = Router::new(our_pubkey.clone(), Arc::clone(&logger));

--- a/fuzz/fuzz_targets/utils/test_logger.rs
+++ b/fuzz/fuzz_targets/utils/test_logger.rs
@@ -1,19 +1,6 @@
-use lightning::util::logger::{Logger, Level, Record};
+use lightning::util::logger::{Logger, Record};
 
-pub struct TestLogger {
-	level: Level,
-}
-
-impl TestLogger {
-	pub fn new() -> TestLogger {
-		TestLogger {
-			level: Level::Off,
-		}
-	}
-	pub fn enable(&mut self, level: Level) {
-		self.level = level;
-	}
-}
+pub struct TestLogger {}
 
 impl Logger for TestLogger {
 	fn log(&self, record: &Record) {

--- a/src/util/macro_logger.rs
+++ b/src/util/macro_logger.rs
@@ -1,5 +1,3 @@
-use util::logger::Record;
-
 macro_rules! log_internal {
 	($self: ident, $lvl:expr, $($arg:tt)+) => (
 		&$self.logger.log(&Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()));

--- a/src/util/macro_logger.rs
+++ b/src/util/macro_logger.rs
@@ -1,3 +1,55 @@
+use chain::transaction::OutPoint;
+
+use bitcoin::util::hash::Sha256dHash;
+use secp256k1::key::PublicKey;
+
+use std;
+
+pub(crate) struct DebugPubKey<'a>(pub &'a PublicKey);
+impl<'a> std::fmt::Display for DebugPubKey<'a> {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+		for i in self.0.serialize().iter() {
+			write!(f, "{:02x}", i)?;
+		}
+		Ok(())
+	}
+}
+macro_rules! log_pubkey {
+	($obj: expr) => {
+		::util::macro_logger::DebugPubKey(&$obj)
+	}
+}
+
+pub(crate) struct DebugBytes<'a>(pub &'a [u8; 32]);
+impl<'a> std::fmt::Display for DebugBytes<'a> {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+		for i in self.0 {
+			write!(f, "{:02x}", i)?;
+		}
+		Ok(())
+	}
+}
+macro_rules! log_bytes {
+	($obj: expr) => {
+		::util::macro_logger::DebugBytes(&$obj)
+	}
+}
+
+pub(crate) struct DebugFundingChannelId<'a>(pub &'a Sha256dHash, pub u16);
+impl<'a> std::fmt::Display for DebugFundingChannelId<'a> {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+		for i in OutPoint::new(self.0.clone(), self.1).to_channel_id().iter() {
+			write!(f, "{:02x}", i)?;
+		}
+		Ok(())
+	}
+}
+macro_rules! log_funding_channel_id {
+	($funding_txid: expr, $funding_txo: expr) => {
+		::util::macro_logger::DebugFundingChannelId(&$funding_txid, $funding_txo)
+	}
+}
+
 macro_rules! log_internal {
 	($self: ident, $lvl:expr, $($arg:tt)+) => (
 		&$self.logger.log(&Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()));

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -154,7 +154,7 @@ pub struct TestLogger {
 impl TestLogger {
 	pub fn new() -> TestLogger {
 		TestLogger {
-			level: Level::Off,
+			level: Level::Trace,
 		}
 	}
 	pub fn enable(&mut self, level: Level) {


### PR DESCRIPTION
Also cleans up compile-time warnings from yet-unused bits in the new logger a decent amount.