### PR TITLE
 Fix crash introduced in #124

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1018,10 +1018,13 @@ impl Channel {
 		for (idx, htlc) in self.pending_htlcs.iter().enumerate() {
 			if !htlc.outbound && htlc.payment_hash == payment_hash_calc &&
 					htlc.state != HTLCState::LocalRemoved && htlc.state != HTLCState::LocalRemovedAwaitingCommitment {
-				if pending_idx != std::usize::MAX {
-					panic!("Duplicate HTLC payment_hash, ChannelManager should have prevented this!");
+				if let Some(PendingHTLCStatus::Fail(_)) = htlc.pending_forward_state {
+				} else {
+					if pending_idx != std::usize::MAX {
+						panic!("Duplicate HTLC payment_hash, ChannelManager should have prevented this!");
+					}
+					pending_idx = idx;
 				}
-				pending_idx = idx;
 			}
 		}
 		if pending_idx == std::usize::MAX {

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -2256,7 +2256,6 @@ mod tests {
 		chain_monitor: Arc<chaininterface::ChainWatchInterfaceUtil>,
 		tx_broadcaster: Arc<test_utils::TestBroadcaster>,
 		chan_monitor: Arc<test_utils::TestChannelMonitor>,
-		node_id: SecretKey,
 		node: Arc<ChannelManager>,
 		router: Router,
 	}
@@ -2803,7 +2802,7 @@ mod tests {
 			};
 			let node = ChannelManager::new(node_id.clone(), 0, true, Network::Testnet, feeest.clone(), chan_monitor.clone(), chain_monitor.clone(), tx_broadcaster.clone(), Arc::clone(&logger)).unwrap();
 			let router = Router::new(PublicKey::from_secret_key(&secp_ctx, &node_id), Arc::clone(&logger));
-			nodes.push(Node { feeest, chain_monitor, tx_broadcaster, chan_monitor, node_id, node, router });
+			nodes.push(Node { feeest, chain_monitor, tx_broadcaster, chan_monitor, node, router });
 		}
 
 		nodes


### PR DESCRIPTION
I'm rapidly starting to regret holding failed HTLCs in Channel,
given we allow them to violate the no-duplicate-hashes
precondition.

Oh well, hopefully this is the last one.