### PR TITLE
Added DeserializeFailure to decode error enum for better error mapping

### DIFF
--- a/fuzz/fuzz_targets/channel_target.rs
+++ b/fuzz/fuzz_targets/channel_target.rs
@@ -131,6 +131,7 @@ pub fn do_test(data: &[u8]) {
 					msgs::DecodeError::ExtraAddressesPerType => return,
 					msgs::DecodeError::BadLengthDescriptor => return,
 					msgs::DecodeError::ShortRead => panic!("We picked the length..."),
+					msgs::DecodeError::DeserializeFailure => return,
 				}
 			}
 		}
@@ -154,6 +155,7 @@ pub fn do_test(data: &[u8]) {
 						msgs::DecodeError::ExtraAddressesPerType => return,
 						msgs::DecodeError::BadLengthDescriptor => return,
 						msgs::DecodeError::ShortRead => panic!("We picked the length..."),
+						msgs::DecodeError::DeserializeFailure => return,
 					}
 				}
 			}

--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -82,6 +82,7 @@ pub fn do_test(data: &[u8]) {
 					msgs::DecodeError::ExtraAddressesPerType => return,
 					msgs::DecodeError::BadLengthDescriptor => return,
 					msgs::DecodeError::ShortRead => panic!("We picked the length..."),
+					msgs::DecodeError::DeserializeFailure => return,
 				}
 			}
 		}

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -4,6 +4,7 @@ use secp256k1;
 use bitcoin::util::hash::Sha256dHash;
 use bitcoin::network::serialize::{deserialize,serialize};
 use bitcoin::blockdata::script::Script;
+use bitcoin::network::serialize::Error as SerializeError;
 
 use std::error::Error;
 use std::{cmp, fmt};
@@ -43,6 +44,9 @@ pub enum DecodeError {
 	/// A length descriptor in the packet didn't describe the later data correctly
 	/// (currently only generated in node_announcement)
 	BadLengthDescriptor,
+	///This is a bitcoin::network::serialize::Error converted to decode error
+	///This happens when the chain_hash or temporary_channel_id fails deserialization
+	DeserializeFailure,
 }
 pub trait MsgDecodable: Sized {
 	fn decode(v: &[u8]) -> Result<Self, DecodeError>;
@@ -519,9 +523,17 @@ impl Error for DecodeError {
 			DecodeError::ShortRead => "Packet extended beyond the provided bytes",
 			DecodeError::ExtraAddressesPerType => "More than one address of a single type",
 			DecodeError::BadLengthDescriptor => "A length descriptor in the packet didn't describe the later data correctly",
+			DecodeError::DeserializeFailure => "Deserialization failed of packet, chain_hash or temporary_channel_id invalid",
 		}
 	}
 }
+
+impl From<SerializeError> for DecodeError{
+	fn from(_e: SerializeError) -> Self {
+        DecodeError::DeserializeFailure
+    } 
+}
+
 impl fmt::Display for DecodeError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.write_str(self.description())
@@ -683,8 +695,8 @@ impl MsgDecodable for OpenChannel {
 		}
 
 		Ok(OpenChannel {
-			chain_hash: deserialize(&v[0..32]).unwrap(),
-			temporary_channel_id: deserialize(&v[32..64]).unwrap(),
+			chain_hash: deserialize(&v[0..32])?,
+			temporary_channel_id: deserialize(&v[32..64])?,
 			funding_satoshis: byte_utils::slice_to_be64(&v[64..72]),
 			push_msat: byte_utils::slice_to_be64(&v[72..80]),
 			dust_limit_satoshis: byte_utils::slice_to_be64(&v[80..88]),

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -693,10 +693,11 @@ impl MsgDecodable for OpenChannel {
 			}
 			shutdown_scriptpubkey = Some(Script::from(v[321..321+len].to_vec()));
 		}
-
+		let mut temp_channel_id = [0; 32];
+		temp_channel_id[..].copy_from_slice(&v[32..64]);
 		Ok(OpenChannel {
 			chain_hash: deserialize(&v[0..32])?,
-			temporary_channel_id: deserialize(&v[32..64])?,
+			temporary_channel_id: temp_channel_id,
 			funding_satoshis: byte_utils::slice_to_be64(&v[64..72]),
 			push_msat: byte_utils::slice_to_be64(&v[72..80]),
 			dust_limit_satoshis: byte_utils::slice_to_be64(&v[80..88]),

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -347,6 +347,8 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 													continue;
 												},
 												msgs::DecodeError::BadLengthDescriptor => return Err(PeerHandleError{ no_connection_possible: false }),
+												msgs::DecodeError::DeserializeFailure => return Err(PeerHandleError{ no_connection_possible: false }),
+
 											}
 										}
 									};


### PR DESCRIPTION
Added From for DecodeError implementation so that a serialized error can return an error and not panic from unwrap().
This should allow for greater error handling in future as well.