### PR TITLE
Refactor ChannelManager handle functions into a Channel-closing macro

### DIFF
--- a/fuzz/fuzz_targets/channel_target.rs
+++ b/fuzz/fuzz_targets/channel_target.rs
@@ -230,7 +230,7 @@ pub fn do_test(data: &[u8]) {
 			Ok(chan) => chan,
 			Err(_) => return,
 		};
-		chan.get_accept_channel().unwrap();
+		chan.get_accept_channel();
 
 		tx.output.push(TxOut{ value: open_chan.funding_satoshis, script_pubkey: chan.get_funding_redeemscript().to_v0_p2wsh() });
 		let funding_output = OutPoint::new(Sha256dHash::from_data(&serialize(&tx).unwrap()[..]), 0);

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -2298,13 +2298,13 @@ impl Channel {
 	/// https://github.com/lightningnetwork/lightning-rfc/issues/468
 	pub fn get_channel_announcement(&self, our_node_id: PublicKey, chain_hash: Sha256dHash) -> Result<(msgs::UnsignedChannelAnnouncement, Signature), HandleError> {
 		if !self.announce_publicly {
-			return Err(HandleError{err: "Channel is not available for public announcements", action: None});
+			return Err(HandleError{err: "Channel is not available for public announcements", action: Some(msgs::ErrorAction::IgnoreError)});
 		}
 		if self.channel_state & (ChannelState::ChannelFunded as u32) == 0 {
-			return Err(HandleError{err: "Cannot get a ChannelAnnouncement until the channel funding has been locked", action: None});
+			return Err(HandleError{err: "Cannot get a ChannelAnnouncement until the channel funding has been locked", action: Some(msgs::ErrorAction::IgnoreError)});
 		}
 		if (self.channel_state & (ChannelState::LocalShutdownSent as u32 | ChannelState::ShutdownComplete as u32)) != 0 {
-			return Err(HandleError{err: "Cannot get a ChannelAnnouncement once the channel is closing", action: None});
+			return Err(HandleError{err: "Cannot get a ChannelAnnouncement once the channel is closing", action: Some(msgs::ErrorAction::IgnoreError)});
 		}
 
 		let were_node_one = our_node_id.serialize()[..] < self.their_node_id.serialize()[..];

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -2200,7 +2200,7 @@ impl Channel {
 		})
 	}
 
-	pub fn get_accept_channel(&self) -> Result<msgs::AcceptChannel, HandleError> {
+	pub fn get_accept_channel(&self) -> msgs::AcceptChannel {
 		if self.channel_outbound {
 			panic!("Tried to send accept_channel for an outbound channel?");
 		}
@@ -2213,7 +2213,7 @@ impl Channel {
 
 		let local_commitment_secret = self.build_local_commitment_secret(self.cur_local_commitment_transaction_number);
 
-		Ok(msgs::AcceptChannel {
+		msgs::AcceptChannel {
 			temporary_channel_id: self.channel_id,
 			dust_limit_satoshis: self.our_dust_limit_satoshis,
 			max_htlc_value_in_flight_msat: Channel::get_our_max_htlc_value_in_flight_msat(self.channel_value_satoshis),
@@ -2229,7 +2229,7 @@ impl Channel {
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, &self.local_keys.htlc_base_key),
 			first_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &local_commitment_secret),
 			shutdown_scriptpubkey: None,
-		})
+		}
 	}
 
 	fn get_outbound_funding_created_signature(&mut self) -> Result<(Signature, Transaction), HandleError> {

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -525,10 +525,10 @@ impl Channel {
 
 		let their_announce = if (msg.channel_flags & 1) == 1 { true } else { false };
 		if require_announce && !their_announce {
-			return Err(HandleError{err: "Peer tried to open unannounced channel, but we require public ones", action: Some(msgs::ErrorAction::IgnoreError) });
+			return_error_message!("Peer tried to open unannounced channel, but we require public ones");
 		}
 		if !allow_announce && their_announce {
-			return Err(HandleError{err: "Peer tried to open announced channel, but we require private ones", action: Some(msgs::ErrorAction::IgnoreError) });
+			return_error_message!("Peer tried to open announced channel, but we require private ones");
 		}
 
 		let background_feerate = fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::Background);

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1383,6 +1383,41 @@ impl ChannelManager {
 	pub fn test_restore_channel_monitor(&self) {
 		unimplemented!();
 	}
+
+	fn internal_open_channel(&self, their_node_id: &PublicKey, msg: &msgs::OpenChannel) -> Result<msgs::AcceptChannel, MsgHandleErrInternal> {
+		if msg.chain_hash != self.genesis_hash {
+			return Err(MsgHandleErrInternal::send_err_msg_no_close("Unknown genesis block hash", msg.temporary_channel_id.clone()));
+		}
+		let mut channel_state = self.channel_state.lock().unwrap();
+		if channel_state.by_id.contains_key(&msg.temporary_channel_id) {
+			return Err(MsgHandleErrInternal::send_err_msg_no_close("temporary_channel_id collision!", msg.temporary_channel_id.clone()));
+		}
+
+		let chan_keys = if cfg!(feature = "fuzztarget") {
+			ChannelKeys {
+				funding_key:               SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]).unwrap(),
+				revocation_base_key:       SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0]).unwrap(),
+				payment_base_key:          SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0]).unwrap(),
+				delayed_payment_base_key:  SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0]).unwrap(),
+				htlc_base_key:             SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0]).unwrap(),
+				channel_close_key:         SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0]).unwrap(),
+				channel_monitor_claim_key: SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0]).unwrap(),
+				commitment_seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+			}
+		} else {
+			let mut key_seed = [0u8; 32];
+			rng::fill_bytes(&mut key_seed);
+			match ChannelKeys::new_from_seed(&key_seed) {
+				Ok(key) => key,
+				Err(_) => panic!("RNG is busted!")
+			}
+		};
+
+		let channel = Channel::new_from_req(&*self.fee_estimator, chan_keys, their_node_id.clone(), msg, 0, false, self.announce_channels_publicly, Arc::clone(&self.logger)).map_err(|e| MsgHandleErrInternal::from_no_close(e))?;
+		let accept_msg = channel.get_accept_channel().map_err(|e| MsgHandleErrInternal::from_no_close(e))?;
+		channel_state.by_id.insert(channel.channel_id(), channel);
+		Ok(accept_msg)
+	}
 }
 
 impl events::EventsProvider for ChannelManager {
@@ -1544,38 +1579,7 @@ macro_rules! handle_error {
 impl ChannelMessageHandler for ChannelManager {
 	//TODO: Handle errors and close channel (or so)
 	fn handle_open_channel(&self, their_node_id: &PublicKey, msg: &msgs::OpenChannel) -> Result<msgs::AcceptChannel, HandleError> {
-		if msg.chain_hash != self.genesis_hash {
-			return Err(HandleError{err: "Unknown genesis block hash", action: None});
-		}
-		let mut channel_state = self.channel_state.lock().unwrap();
-		if channel_state.by_id.contains_key(&msg.temporary_channel_id) {
-			return Err(HandleError{err: "temporary_channel_id collision!", action: None});
-		}
-
-		let chan_keys = if cfg!(feature = "fuzztarget") {
-			ChannelKeys {
-				funding_key:               SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0]).unwrap(),
-				revocation_base_key:       SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0]).unwrap(),
-				payment_base_key:          SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 0]).unwrap(),
-				delayed_payment_base_key:  SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 0]).unwrap(),
-				htlc_base_key:             SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0]).unwrap(),
-				channel_close_key:         SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 6, 0]).unwrap(),
-				channel_monitor_claim_key: SecretKey::from_slice(&self.secp_ctx, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0]).unwrap(),
-				commitment_seed: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-			}
-		} else {
-			let mut key_seed = [0u8; 32];
-			rng::fill_bytes(&mut key_seed);
-			match ChannelKeys::new_from_seed(&key_seed) {
-				Ok(key) => key,
-				Err(_) => panic!("RNG is busted!")
-			}
-		};
-
-		let channel = Channel::new_from_req(&*self.fee_estimator, chan_keys, their_node_id.clone(), msg, 0, false, self.announce_channels_publicly, Arc::clone(&self.logger))?;
-		let accept_msg = channel.get_accept_channel()?;
-		channel_state.by_id.insert(channel.channel_id(), channel);
-		Ok(accept_msg)
+		handle_error!(self, self.internal_open_channel(their_node_id, msg), their_node_id)
 	}
 
 	fn handle_accept_channel(&self, their_node_id: &PublicKey, msg: &msgs::AcceptChannel) -> Result<(), HandleError> {

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1414,7 +1414,7 @@ impl ChannelManager {
 		};
 
 		let channel = Channel::new_from_req(&*self.fee_estimator, chan_keys, their_node_id.clone(), msg, 0, false, self.announce_channels_publicly, Arc::clone(&self.logger)).map_err(|e| MsgHandleErrInternal::from_no_close(e))?;
-		let accept_msg = channel.get_accept_channel().map_err(|e| MsgHandleErrInternal::from_no_close(e))?;
+		let accept_msg = channel.get_accept_channel();
 		channel_state.by_id.insert(channel.channel_id(), channel);
 		Ok(accept_msg)
 	}


### PR DESCRIPTION
This is a rebase/rewrite/extension of #140 since it was missing some stuff and I wanted to get the jump on using it to move announcement_signatures handling into it so we can finally close up BOLT 7 handling.