### PR TITLE
Fill out failure codes for onion packet

### DIFF
--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -187,7 +187,7 @@ pub fn do_test(data: &[u8]) {
 					},
 					1 => {
 						let short_channel_id = slice_to_be64(get_slice!(8));
-						router.handle_htlc_fail_channel_update(&msgs::HTLCFailChannelUpdate::ChannelClosed {short_channel_id});
+						router.handle_htlc_fail_channel_update(&msgs::HTLCFailChannelUpdate::ChannelClosed {short_channel_id, is_permanent: false});
 					},
 					_ => return,
 				}

--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -223,6 +223,7 @@ pub fn do_test(data: &[u8]) {
 							fee_proportional_millionths: slice_to_be32(get_slice!(4)),
 							cltv_expiry_delta: slice_to_be16(get_slice!(2)),
 							htlc_minimum_msat: slice_to_be64(get_slice!(8)),
+							last_update: 0,
 						});
 					}
 					&last_hops_vec[..]

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -2450,6 +2450,11 @@ impl Channel {
 		self.our_htlc_minimum_msat
 	}
 
+	/// Allowed in any state (including after shutdown)
+	pub fn get_their_htlc_minimum_msat(&self) -> u64 {
+		self.our_htlc_minimum_msat
+	}
+
 	pub fn get_value_satoshis(&self) -> u64 {
 		self.channel_value_satoshis
 	}

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1545,7 +1545,7 @@ impl Channel {
 		Ok(())
 	}
 
-	/// Removes an outbound HTLC which has been commitment_signed by the remote end
+	/// Marks an outbound HTLC which we have received update_fail/fulfill/malformed
 	#[inline]
 	fn mark_outbound_htlc_removed(&mut self, htlc_id: u64, check_preimage: Option<[u8; 32]>, fail_reason: Option<HTLCFailReason>) -> Result<&HTLCSource, ChannelError> {
 		for htlc in self.pending_outbound_htlcs.iter_mut() {
@@ -1559,13 +1559,13 @@ impl Channel {
 				};
 				match htlc.state {
 					OutboundHTLCState::LocalAnnounced(_) =>
-						return Err(ChannelError::Close("Remote tried to fulfill HTLC before it had been committed")),
+						return Err(ChannelError::Close("Remote tried to fulfill/fail HTLC before it had been committed")),
 					OutboundHTLCState::Committed => {
 						htlc.state = OutboundHTLCState::RemoteRemoved;
 						htlc.fail_reason = fail_reason;
 					},
 					OutboundHTLCState::AwaitingRemoteRevokeToRemove | OutboundHTLCState::AwaitingRemovedRemoteRevoke | OutboundHTLCState::RemoteRemoved =>
-						return Err(ChannelError::Close("Remote tried to fulfill HTLC that they'd already fulfilled")),
+						return Err(ChannelError::Close("Remote tried to fulfill/fail HTLC that they'd already fulfilled/failed")),
 				}
 				return Ok(&htlc.source);
 			}

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -23,7 +23,7 @@ use secp256k1;
 use chain::chaininterface::{BroadcasterInterface,ChainListener,ChainWatchInterface,FeeEstimator};
 use chain::transaction::OutPoint;
 use ln::channel::{Channel, ChannelError, ChannelKeys};
-use ln::channelmonitor::ManyChannelMonitor;
+use ln::channelmonitor::{ManyChannelMonitor, CLTV_CLAIM_BUFFER, HTLC_FAIL_TIMEOUT_BLOCKS};
 use ln::router::{Route,RouteHop};
 use ln::msgs;
 use ln::msgs::{HandleError,ChannelMessageHandler};
@@ -300,7 +300,27 @@ pub struct ChannelManager {
 	logger: Arc<Logger>,
 }
 
+/// The minimum number of blocks between an inbound HTLC's CLTV and the corresponding outbound
+/// HTLC's CLTV. This should always be a few blocks greater than channelmonitor::CLTV_CLAIM_BUFFER,
+/// ie the node we forwarded the payment on to should always have enough room to reliably time out
+/// the HTLC via a full update_fail_htlc/commitment_signed dance before we hit the
+/// CLTV_CLAIM_BUFFER point (we static assert that its at least 3 blocks more).
 const CLTV_EXPIRY_DELTA: u16 = 6 * 24 * 2; //TODO?
+
+// Check that our CLTV_EXPIRY is at least CLTV_CLAIM_BUFFER + 2*HTLC_FAIL_TIMEOUT_BLOCKS, ie that
+// if the next-hop peer fails the HTLC within HTLC_FAIL_TIMEOUT_BLOCKS then we'll still have
+// HTLC_FAIL_TIMEOUT_BLOCKS left to fail it backwards ourselves before hitting the
+// CLTV_CLAIM_BUFFER point and failing the channel on-chain to time out the HTLC.
+#[deny(const_err)]
+#[allow(dead_code)]
+const CHECK_CLTV_EXPIRY_SANITY: u32 = CLTV_EXPIRY_DELTA as u32 - 2*HTLC_FAIL_TIMEOUT_BLOCKS - CLTV_CLAIM_BUFFER;
+
+// Check for ability of an attacker to make us fail on-chain by delaying inbound claim. See
+// ChannelMontior::would_broadcast_at_height for a description of why this is needed.
+#[deny(const_err)]
+#[allow(dead_code)]
+const CHECK_CLTV_EXPIRY_SANITY_2: u32 = CLTV_EXPIRY_DELTA as u32 - HTLC_FAIL_TIMEOUT_BLOCKS - 2*CLTV_CLAIM_BUFFER;
+
 const CLTV_FAR_FAR_AWAY: u16 = 6 * 24 * 7; //TODO?
 const FINAL_NODE_TIMEOUT: u16 = 3; //TODO?
 
@@ -2544,6 +2564,7 @@ mod tests {
 	use chain::transaction::OutPoint;
 	use chain::chaininterface::ChainListener;
 	use ln::channelmanager::{ChannelManager,OnionKeys};
+	use ln::channelmonitor::{CLTV_CLAIM_BUFFER, HTLC_FAIL_TIMEOUT_BLOCKS};
 	use ln::router::{Route, RouteHop, Router};
 	use ln::msgs;
 	use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler};
@@ -2576,6 +2597,7 @@ mod tests {
 	use std::default::Default;
 	use std::rc::Rc;
 	use std::sync::{Arc, Mutex};
+	use std::sync::atomic::Ordering;
 	use std::time::Instant;
 	use std::mem;
 
@@ -4470,13 +4492,17 @@ mod tests {
 		assert_eq!(nodes[2].node.list_channels().len(), 0);
 		assert_eq!(nodes[3].node.list_channels().len(), 1);
 
+		assert_eq!(nodes[3].node.latest_block_height.load(Ordering::Acquire), 1);
+		assert_eq!(nodes[4].node.latest_block_height.load(Ordering::Acquire), 1);
 		// One pending HTLC to time out:
 		let payment_preimage_2 = route_payment(&nodes[3], &vec!(&nodes[4])[..], 3000000).0;
+		// CLTV expires at TEST_FINAL_CLTV + 1 (current height) + 1 (added in send_payment for
+		// buffer space).
 
 		{
 			let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[3].chain_monitor.block_connected_checked(&header, 1, &Vec::new()[..], &[0; 0]);
-			for i in 2..TEST_FINAL_CLTV - 3 {
+			nodes[3].chain_monitor.block_connected_checked(&header, 2, &Vec::new()[..], &[0; 0]);
+			for i in 3..TEST_FINAL_CLTV + 2 + HTLC_FAIL_TIMEOUT_BLOCKS + 1 {
 				header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 				nodes[3].chain_monitor.block_connected_checked(&header, i, &Vec::new()[..], &[0; 0]);
 			}
@@ -4487,8 +4513,8 @@ mod tests {
 			claim_funds!(nodes[4], nodes[3], payment_preimage_2);
 
 			header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-			nodes[4].chain_monitor.block_connected_checked(&header, 1, &Vec::new()[..], &[0; 0]);
-			for i in 2..TEST_FINAL_CLTV - 3 {
+			nodes[4].chain_monitor.block_connected_checked(&header, 2, &Vec::new()[..], &[0; 0]);
+			for i in 3..TEST_FINAL_CLTV + 2 - CLTV_CLAIM_BUFFER + 1 {
 				header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 				nodes[4].chain_monitor.block_connected_checked(&header, i, &Vec::new()[..], &[0; 0]);
 			}

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -2418,23 +2418,23 @@ mod tests {
 			hops: vec!(
 					RouteHop {
 						pubkey: PublicKey::from_slice(&secp_ctx, &hex::decode("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0, channel_update_timestamp: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&secp_ctx, &hex::decode("0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0, channel_update_timestamp: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&secp_ctx, &hex::decode("027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0, channel_update_timestamp: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&secp_ctx, &hex::decode("032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0, channel_update_timestamp: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&secp_ctx, &hex::decode("02edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145").unwrap()[..]).unwrap(),
-						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
+						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0, channel_update_timestamp: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 			),
 		};
@@ -3723,19 +3723,22 @@ mod tests {
 			pubkey: nodes[2].node.get_our_node_id(),
 			short_channel_id: chan_2.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_3.0.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_3.0.contents.cltv_expiry_delta as u32,
+			channel_update_timestamp: 0,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[3].node.get_our_node_id(),
 			short_channel_id: chan_3.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_4.1.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_4.1.contents.cltv_expiry_delta as u32,
+			channel_update_timestamp: 0,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[1].node.get_our_node_id(),
 			short_channel_id: chan_4.0.contents.short_channel_id,
 			fee_msat: 1000000,
 			cltv_expiry_delta: TEST_FINAL_CLTV,
+			channel_update_timestamp: 0,
 		});
 		hops[1].fee_msat = chan_4.1.contents.fee_base_msat as u64 + chan_4.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64 / 1000000;
 		hops[0].fee_msat = chan_3.0.contents.fee_base_msat as u64 + chan_3.0.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64 / 1000000;
@@ -3746,19 +3749,22 @@ mod tests {
 			pubkey: nodes[3].node.get_our_node_id(),
 			short_channel_id: chan_4.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_3.1.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_3.1.contents.cltv_expiry_delta as u32,
+			channel_update_timestamp: 0,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[2].node.get_our_node_id(),
 			short_channel_id: chan_3.0.contents.short_channel_id,
 			fee_msat: 0,
-			cltv_expiry_delta: chan_2.1.contents.cltv_expiry_delta as u32
+			cltv_expiry_delta: chan_2.1.contents.cltv_expiry_delta as u32,
+			channel_update_timestamp: 0,
 		});
 		hops.push(RouteHop {
 			pubkey: nodes[1].node.get_our_node_id(),
 			short_channel_id: chan_2.0.contents.short_channel_id,
 			fee_msat: 1000000,
 			cltv_expiry_delta: TEST_FINAL_CLTV,
+			channel_update_timestamp: 0,
 		});
 		hops[1].fee_msat = chan_2.1.contents.fee_base_msat as u64 + chan_2.1.contents.fee_proportional_millionths as u64 * hops[2].fee_msat as u64 / 1000000;
 		hops[0].fee_msat = chan_3.1.contents.fee_base_msat as u64 + chan_3.1.contents.fee_proportional_millionths as u64 * hops[1].fee_msat as u64 / 1000000;

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1806,7 +1806,8 @@ impl ChannelManager {
 										// No such next-hop. We know this came from the
 										// current node as the HMAC validated.
 										res = Some(msgs::HTLCFailChannelUpdate::ChannelClosed {
-											short_channel_id: route_hop.short_channel_id
+											short_channel_id: route_hop.short_channel_id,
+											is_permanent: true,
 										});
 									},
 									_ => {}, //TODO: Enumerate all of these!
@@ -5115,7 +5116,7 @@ mod tests {
 		let as_chan = a_channel_lock.by_id.get(&chan_announcement.3).unwrap();
 		let bs_chan = b_channel_lock.by_id.get(&chan_announcement.3).unwrap();
 
-		let _ = nodes[0].router.handle_htlc_fail_channel_update(&msgs::HTLCFailChannelUpdate::ChannelClosed { short_channel_id : as_chan.get_short_channel_id().unwrap() } );
+		let _ = nodes[0].router.handle_htlc_fail_channel_update(&msgs::HTLCFailChannelUpdate::ChannelClosed { short_channel_id : as_chan.get_short_channel_id().unwrap(), is_permanent: false } );
 
 		let as_bitcoin_key = PublicKey::from_secret_key(&secp_ctx, &as_chan.get_local_keys().funding_key);
 		let bs_bitcoin_key = PublicKey::from_secret_key(&secp_ctx, &bs_chan.get_local_keys().funding_key);
@@ -5162,7 +5163,7 @@ mod tests {
 		let unsigned_msg = dummy_unsigned_msg!();
 		sign_msg!(unsigned_msg);
 		assert_eq!(nodes[0].router.handle_channel_announcement(&chan_announcement).unwrap(), true);
-		let _ = nodes[0].router.handle_htlc_fail_channel_update(&msgs::HTLCFailChannelUpdate::ChannelClosed { short_channel_id : as_chan.get_short_channel_id().unwrap() } );
+		let _ = nodes[0].router.handle_htlc_fail_channel_update(&msgs::HTLCFailChannelUpdate::ChannelClosed { short_channel_id : as_chan.get_short_channel_id().unwrap(), is_permanent: false } );
 
 		// Configured with Network::Testnet
 		let mut unsigned_msg = dummy_unsigned_msg!();

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -322,7 +322,6 @@ const CHECK_CLTV_EXPIRY_SANITY: u32 = CLTV_EXPIRY_DELTA as u32 - 2*HTLC_FAIL_TIM
 const CHECK_CLTV_EXPIRY_SANITY_2: u32 = CLTV_EXPIRY_DELTA as u32 - HTLC_FAIL_TIMEOUT_BLOCKS - 2*CLTV_CLAIM_BUFFER;
 
 const CLTV_FAR_FAR_AWAY: u16 = 6 * 24 * 7; //TODO?
-const FINAL_NODE_TIMEOUT: u16 = 3; //TODO?
 
 macro_rules! secp_call {
 	( $res: expr, $err: expr ) => {

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -98,6 +98,14 @@ mod channel_held_info {
 		pub(super) incoming_packet_shared_secret: SharedSecret,
 	}
 
+	/// First hop payment data. This can be used to reconstruct amt_to_forward
+	/// and outgoing_cltv_value for each hop combined with data from RouteHope
+	#[derive(Clone)]
+	pub struct PaymentData {
+		pub(super) htlc_msat: u64,
+		pub(super) block_height: u32,
+	}
+
 	/// Tracks the inbound corresponding to an outbound HTLC
 	#[derive(Clone)]
 	pub enum HTLCSource {
@@ -105,6 +113,7 @@ mod channel_held_info {
 		OutboundRoute {
 			route: Route,
 			session_priv: SecretKey,
+			payment_data: PaymentData,
 		},
 	}
 	#[cfg(test)]
@@ -113,6 +122,7 @@ mod channel_held_info {
 			HTLCSource::OutboundRoute {
 				route: Route { hops: Vec::new() },
 				session_priv: SecretKey::from_slice(&::secp256k1::Secp256k1::without_caps(), &[1; 32]).unwrap(),
+				payment_data: PaymentData {htlc_msat: 0, block_height: 0},
 			}
 		}
 	}
@@ -1090,6 +1100,10 @@ impl ChannelManager {
 				chan.send_htlc_and_commit(htlc_msat, payment_hash.clone(), htlc_cltv, HTLCSource::OutboundRoute {
 					route: route.clone(),
 					session_priv: session_priv.clone(),
+					payment_data: PaymentData {
+						htlc_msat: htlc_msat,
+						block_height: cur_height,
+					}
 				}, onion_packet).map_err(|he| APIError::ChannelUnavailable{err: he.err})?
 			};
 
@@ -1770,7 +1784,210 @@ impl ChannelManager {
 		Ok(())
 	}
 
+	// Process onion peacket processed in only in the origin node. Returns update
+	// for router and boolean flag indicating if payment can be retried
+	fn process_onion_failure(&self, route: &Route, mut packet_decrypted: Vec<u8>, session_priv: &SecretKey, payment_data: &PaymentData) -> Result<(Option<msgs::HTLCFailChannelUpdate>, bool), secp256k1::Error> {
+
+		macro_rules! onion_failure_log {
+			( $error_code_textual: expr, $error_code: expr, $reported_name: expr, $reported_value: expr ) => {
+				log_trace!(self, "{}({}) {}({})", $error_code_textual, $error_code, $reported_name, $reported_value);
+			};
+			( $error_code_textual: expr, $error_code: expr ) => {
+				log_trace!(self, "{}({})", $error_code_textual, $error_code);
+			};
+		}
+
+		const PERM: u16 = 0x4000;
+		const UPDATE: u16 = 0x1000;
+
+		let mut res = None;
+		let mut htlc_msat = payment_data.htlc_msat;
+		let mut outgoing_cltv_value = payment_data.block_height;
+
+		// Handle packed channel/node updates for passing back for the route handler
+		Self::construct_onion_keys_callback(&self.secp_ctx, &route, &session_priv, |shared_secret, _, _, route_hop| {
+			if res.is_some() { return; }
+
+			let incoming_htlc_msat = htlc_msat;
+			let amt_to_forward = htlc_msat - route_hop.fee_msat;
+			htlc_msat = amt_to_forward;
+			outgoing_cltv_value += route_hop.cltv_expiry_delta;
+
+			let ammag = ChannelManager::gen_ammag_from_shared_secret(&shared_secret);
+
+			let mut decryption_tmp = Vec::with_capacity(packet_decrypted.len());
+			decryption_tmp.resize(packet_decrypted.len(), 0);
+			let mut chacha = ChaCha20::new(&ammag, &[0u8; 8]);
+			chacha.process(&packet_decrypted, &mut decryption_tmp[..]);
+			packet_decrypted = decryption_tmp;
+
+			let is_from_final_node = route.hops.last().unwrap().pubkey == route_hop.pubkey;
+
+			match msgs::DecodedOnionErrorPacket::read(&mut Cursor::new(&packet_decrypted)) {
+				Err(_e) => {
+					res = Some((None, false));
+				},
+				Ok(ref err_packet) if err_packet.failuremsg.len() < 2 => {
+					res = Some((None, false));
+					// can't blaim anybody
+				},
+				Ok(ref err_packet) if err_packet.failuremsg.len() >= 2 => {
+					let um = ChannelManager::gen_um_from_shared_secret(&shared_secret);
+
+					let mut hmac = Hmac::new(Sha256::new(), &um);
+					hmac.input(&err_packet.encode()[32..]);
+					let mut calc_tag = [0u8; 32];
+					hmac.raw_result(&mut calc_tag);
+
+					if crypto::util::fixed_time_eq(&calc_tag, &err_packet.hmac) {
+						let error_code = byte_utils::slice_to_be16(&err_packet.failuremsg[0..2]);
+
+						match error_code & 0xff {
+							1|2|3 => {
+							// either from an intermediate or final node
+							//   invalid_realm(PERM|1),
+							//   temporary_node_failure(NODE|2)
+							//   permanent_node_failure(PERM|NODE|2)
+							//   required_node_feature_mssing(PERM|NODE|3)
+							res = Some((Some(msgs::HTLCFailChannelUpdate::NodeFailure {
+								node_id: route_hop.pubkey,
+								is_permanent: error_code & PERM == PERM,
+							}), !(error_code & PERM == PERM && is_from_final_node)));
+							// node returning invalid_realm is removed from network_map,
+							// although NODE flag is not set, TODO: or remove channel only?
+							// retry payment when removed node is not a final node
+							return;
+							},
+							_ => {}
+						}
+
+						if is_from_final_node {
+							let payment_retryable = match error_code {
+								c if c == PERM|15 => false, // unknown_payment_hash
+								c if c == PERM|16 => false, // incorrect_payment_amount
+								17 => true, // final_expiry_too_soon
+								18 if err_packet.failuremsg.len() == 6 => { // final_incorrect_cltv_expiry
+									let _reported_cltv_expiry = byte_utils::slice_to_be16(&err_packet.failuremsg[2..2+4]);
+									true
+								},
+								19 if err_packet.failuremsg.len() == 6 => { // final_incorrect_htlc_amount
+									let _reported_incoming_htlc_msat = byte_utils::slice_to_be16(&err_packet.failuremsg[2..2+4]);
+									true
+								},
+								_ => {
+									// A final node has sent us either an invalid code or an error_code that
+									// MUST be sent from the processing node, or the formmat of failuremsg
+									// does not coform to the spec.
+									// Remove it from the network map and don't may retry payment
+									res = Some((Some(msgs::HTLCFailChannelUpdate::NodeFailure {
+										node_id: route_hop.pubkey,
+										is_permanent: true,
+									}), false));
+									return;
+								}
+							};
+							debug_assert_eq!(payment_retryable, error_code&PERM != PERM);
+							res = Some((None, payment_retryable));
+							return;
+						}
+
+						// now, error_code should be only from the intermediate nodes
+						match error_code {
+							_c if error_code & PERM == PERM => {
+								res = Some((Some(msgs::HTLCFailChannelUpdate::ChannelClosed {
+									short_channel_id: route_hop.short_channel_id,
+									is_permanent: true,
+								}), false));
+							},
+							_c if error_code & UPDATE == UPDATE => {
+								let mut pos = 2;
+								pos += match error_code {
+									c if c == UPDATE|7 => 0, // temporary_channel_failure
+									c if c == UPDATE|11 => 8, // amount_below_minimum
+									c if c == UPDATE|12 => 8, // fee_insufficient
+									c if c == UPDATE|13 => 4, // incorrect_cltv_expiry
+									c if c == UPDATE|20 => 2, // channel_disabled
+									c if c == UPDATE|21 => 0, // expiry_too_far
+									_ =>  {
+										// node sending unknown code
+										res = Some((Some(msgs::HTLCFailChannelUpdate::NodeFailure {
+											node_id: route_hop.pubkey,
+											is_permanent: true,
+										}), false));
+										return;
+									}
+								};
+
+								if err_packet.failuremsg.len() >= pos+2 {
+									let update_len = byte_utils::slice_to_be16(&err_packet.failuremsg[pos+2..pos+4]) as usize;
+									if err_packet.failuremsg.len() >= pos+4 + update_len {
+										if let Ok(chan_update) = msgs::ChannelUpdate::read(&mut Cursor::new(&err_packet.failuremsg[pos+4..pos+4+update_len])) {
+											if chan_update.contents.timestamp <= route_hop.channel_update_timestamp {
+												res = Some((None, true));
+												return;
+											}
+											// if channel_update should NOT have caused the failure:
+											// MAY treat the channel_update as invalid.
+											let is_chan_update_invalid = match error_code {
+												c if c == UPDATE|11 => { // amount_below_minimum
+													let reported_htlc_msat = byte_utils::slice_to_be16(&err_packet.failuremsg[2..2+8]);
+													onion_failure_log!("amount_below_minimum", UPDATE|11, "htlc_msat", reported_htlc_msat);
+													incoming_htlc_msat > chan_update.contents.htlc_minimum_msat
+												},
+												c if c == UPDATE|12 => { // fee_insufficient
+													let reported_htlc_msat = byte_utils::slice_to_be16(&err_packet.failuremsg[2..2+8]);
+													let new_fee =  amt_to_forward.checked_mul(chan_update.contents.fee_proportional_millionths as u64).and_then(|prop_fee| { (prop_fee / 1000000).checked_add(chan_update.contents.fee_base_msat as u64) });
+													onion_failure_log!("fee_insufficient", UPDATE|12, "htlc_msat", reported_htlc_msat);
+													new_fee.is_none() || incoming_htlc_msat >= new_fee.unwrap() && incoming_htlc_msat >= amt_to_forward + new_fee.unwrap()
+												}
+												c if c == UPDATE|13 => { // incorrect_cltv_expiry
+													let reported_cltv_expiry = byte_utils::slice_to_be16(&err_packet.failuremsg[2..2+4]);
+													onion_failure_log!("incorrect_cltv_expiry", UPDATE|13, "cltv_expiry", reported_cltv_expiry);
+													route_hop.cltv_expiry_delta as u16 >= chan_update.contents.cltv_expiry_delta
+												},
+												c if c == UPDATE|20 => { // channel_disabled
+													let reported_flags = byte_utils::slice_to_be16(&err_packet.failuremsg[2..2+2]);
+													onion_failure_log!("channel_disabled", UPDATE|20, "flags", reported_flags);
+													chan_update.contents.flags & 0x01 == 0x01
+												},
+												c if c == UPDATE|21 => true, // expiry_too_far
+												_ => { unreachable!(); },
+											};
+
+											let msg = if is_chan_update_invalid { None } else {
+												Some(msgs::HTLCFailChannelUpdate::ChannelUpdateMessage {
+													msg: chan_update,
+												})
+											};
+											res = Some((msg, true));
+											return;
+										}
+									}
+								}
+							},
+							14 => { // expiry_too_soon
+								res = Some((None, true));
+								return;
+							}
+							_ => {
+								// node sending unknown code
+								res = Some((Some(msgs::HTLCFailChannelUpdate::NodeFailure {
+									node_id: route_hop.pubkey,
+									is_permanent: true,
+								}), false));
+								return;
+							}
+						}
+					}
+				},
+				_ => { unreachable!() }
+			}
+		})?;
+		Ok(res.unwrap())
+	}
+
 	fn internal_update_fail_htlc(&self, their_node_id: &PublicKey, msg: &msgs::UpdateFailHTLC) -> Result<Option<msgs::HTLCFailChannelUpdate>, MsgHandleErrInternal> {
+
 		let mut channel_state = self.channel_state.lock().unwrap();
 		let htlc_source = match channel_state.by_id.get_mut(&msg.channel_id) {
 			Some(chan) => {
@@ -1784,63 +2001,15 @@ impl ChannelManager {
 			None => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel", msg.channel_id))
 		}?;
 
-		match htlc_source {
-			&HTLCSource::OutboundRoute { ref route, ref session_priv, .. } => {
-				// Handle packed channel/node updates for passing back for the route handler
-				let mut packet_decrypted = msg.reason.data.clone();
-				let mut res = None;
-				Self::construct_onion_keys_callback(&self.secp_ctx, &route, &session_priv, |shared_secret, _, _, route_hop| {
-					if res.is_some() { return; }
-
-					let ammag = ChannelManager::gen_ammag_from_shared_secret(&shared_secret);
-
-					let mut decryption_tmp = Vec::with_capacity(packet_decrypted.len());
-					decryption_tmp.resize(packet_decrypted.len(), 0);
-					let mut chacha = ChaCha20::new(&ammag, &[0u8; 8]);
-					chacha.process(&packet_decrypted, &mut decryption_tmp[..]);
-					packet_decrypted = decryption_tmp;
-
-					if let Ok(err_packet) = msgs::DecodedOnionErrorPacket::read(&mut Cursor::new(&packet_decrypted)) {
-						if err_packet.failuremsg.len() >= 2 {
-							let um = ChannelManager::gen_um_from_shared_secret(&shared_secret);
-
-							let mut hmac = Hmac::new(Sha256::new(), &um);
-							hmac.input(&err_packet.encode()[32..]);
-							let mut calc_tag = [0u8; 32];
-							hmac.raw_result(&mut calc_tag);
-							if crypto::util::fixed_time_eq(&calc_tag, &err_packet.hmac) {
-								const UNKNOWN_CHAN: u16 = 0x4000|10;
-								const TEMP_CHAN_FAILURE: u16 = 0x4000|7;
-								match byte_utils::slice_to_be16(&err_packet.failuremsg[0..2]) {
-									TEMP_CHAN_FAILURE => {
-										if err_packet.failuremsg.len() >= 4 {
-											let update_len = byte_utils::slice_to_be16(&err_packet.failuremsg[2..4]) as usize;
-											if err_packet.failuremsg.len() >= 4 + update_len {
-												if let Ok(chan_update) = msgs::ChannelUpdate::read(&mut Cursor::new(&err_packet.failuremsg[4..4 + update_len])) {
-													res = Some(msgs::HTLCFailChannelUpdate::ChannelUpdateMessage {
-														msg: chan_update,
-													});
-												}
-											}
-										}
-									},
-									UNKNOWN_CHAN => {
-										// No such next-hop. We know this came from the
-										// current node as the HMAC validated.
-										res = Some(msgs::HTLCFailChannelUpdate::ChannelClosed {
-											short_channel_id: route_hop.short_channel_id,
-											is_permanent: true,
-										});
-									},
-									_ => {}, //TODO: Enumerate all of these!
-								}
-							}
-						}
-					}
-				}).unwrap();
-				Ok(res)
-			},
-			_ => { Ok(None) },
+		// we are the origin node and update route information
+		// also determine if the payment is retryable
+		if let &HTLCSource::OutboundRoute { ref route, ref session_priv, ref payment_data} = htlc_source {
+			let (channel_update, _payment_retry) = self.process_onion_failure(route, msg.reason.data.clone(), session_priv, payment_data).unwrap();
+			Ok(channel_update)
+			// TODO: include pyament_retry info in PaymentFailed event that will be
+			// fired when receiving revoke_and_ack
+		} else {
+			Ok(None)
 		}
 	}
 

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -485,7 +485,19 @@ pub enum HTLCFailChannelUpdate {
 	ChannelClosed {
 		/// The short_channel_id which has now closed.
 		short_channel_id: u64,
+		/// when this true, this channel should be permanently removed from the
+		/// consideration. Otherwise, this channel can be restored as new channel_update is received
+		is_permanent: bool,
 	},
+	/// We received an error which indicated only that a node has failed
+	NodeFailure {
+		/// The node_id that has failed.
+		node_id: PublicKey,
+		/// when this true, node should be permanently removed from the
+		/// consideration. Otherwise, the channels connected to this node can be
+		/// restored as new channel_update is received
+		is_permanent: bool,
+	}
 }
 
 /// A trait to describe an object which can receive channel messages.

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -529,7 +529,7 @@ pub trait ChannelMessageHandler : events::EventsProvider + Send + Sync {
 	/// Handle an incoming update_fulfill_htlc message from the given peer.
 	fn handle_update_fulfill_htlc(&self, their_node_id: &PublicKey, msg: &UpdateFulfillHTLC) -> Result<(), HandleError>;
 	/// Handle an incoming update_fail_htlc message from the given peer.
-	fn handle_update_fail_htlc(&self, their_node_id: &PublicKey, msg: &UpdateFailHTLC) -> Result<Option<HTLCFailChannelUpdate>, HandleError>;
+	fn handle_update_fail_htlc(&self, their_node_id: &PublicKey, msg: &UpdateFailHTLC) -> Result<(), HandleError>;
 	/// Handle an incoming update_fail_malformed_htlc message from the given peer.
 	fn handle_update_fail_malformed_htlc(&self, their_node_id: &PublicKey, msg: &UpdateFailMalformedHTLC) -> Result<(), HandleError>;
 	/// Handle an incoming commitment_signed message from the given peer.

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -615,10 +615,7 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 											},
 											131 => {
 												let msg = try_potential_decodeerror!(msgs::UpdateFailHTLC::read(&mut reader));
-												let chan_update = try_potential_handleerror!(self.message_handler.chan_handler.handle_update_fail_htlc(&peer.their_node_id.unwrap(), &msg));
-												if let Some(update) = chan_update {
-													self.message_handler.route_handler.handle_htlc_fail_channel_update(&update);
-												}
+												try_potential_handleerror!(self.message_handler.chan_handler.handle_update_fail_htlc(&peer.their_node_id.unwrap(), &msg));
 											},
 											135 => {
 												let msg = try_potential_decodeerror!(msgs::UpdateFailMalformedHTLC::read(&mut reader));
@@ -904,6 +901,10 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 								Self::do_attempt_write_data(&mut (*descriptor).clone(), peer);
 							}
 						}
+						continue;
+					},
+					Event::RouteUpdate { ref update } => {
+						self.message_handler.route_handler.handle_htlc_fail_channel_update(update);
 						continue;
 					},
 					Event::HandleError { ref node_id, ref action } => {

--- a/src/ln/router.rs
+++ b/src/ln/router.rs
@@ -349,11 +349,16 @@ impl RoutingMessageHandler for Router {
 			&msgs::HTLCFailChannelUpdate::ChannelUpdateMessage { ref msg } => {
 				let _ = self.handle_channel_update(msg);
 			},
-			&msgs::HTLCFailChannelUpdate::ChannelClosed { ref short_channel_id } => {
+			&msgs::HTLCFailChannelUpdate::ChannelClosed { ref short_channel_id, is_permanent:_ } => {
 				let mut network = self.network_map.write().unwrap();
 				if let Some(chan) = network.channels.remove(short_channel_id) {
 					Self::remove_channel_in_nodes(&mut network.nodes, &chan, *short_channel_id);
 				}
+			},
+			&msgs::HTLCFailChannelUpdate::NodeFailure { ref node_id, is_permanent:_ } => {
+				//let mut network = self.network_map.write().unwrap();
+				//TODO: check _blamed_upstream_node
+				self.mark_node_bad(node_id, false);
 			},
 		}
 	}

--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -75,6 +75,10 @@ pub enum Event {
 	PaymentFailed {
 		/// The hash which was given to ChannelManager::send_payment.
 		payment_hash: [u8; 32],
+		/// Inindicates if the payment can be retried.
+		retryable: bool,
+		/// Error code from Onion failure message
+		error_code: Option<u16>,
 	},
 	/// Used to indicate that ChannelManager::process_pending_htlc_forwards should be called at a
 	/// time in the future.
@@ -161,6 +165,13 @@ pub enum Event {
 		node_id: PublicKey,
 		/// The action which should be taken.
 		action: Option<msgs::ErrorAction>
+	},
+
+	/// Used to indicate a change should be made into network map
+	///
+	RouteUpdate {
+		/// The channel/node update which should be sent to router
+		update: msgs::HTLCFailChannelUpdate,
 	}
 }
 

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -110,7 +110,7 @@ impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
 	fn handle_update_fulfill_htlc(&self, _their_node_id: &PublicKey, _msg: &msgs::UpdateFulfillHTLC) -> Result<(), HandleError> {
 		Err(HandleError { err: "", action: None })
 	}
-	fn handle_update_fail_htlc(&self, _their_node_id: &PublicKey, _msg: &msgs::UpdateFailHTLC) -> Result<Option<msgs::HTLCFailChannelUpdate>, HandleError> {
+	fn handle_update_fail_htlc(&self, _their_node_id: &PublicKey, _msg: &msgs::UpdateFailHTLC) -> Result<(), HandleError> {
 		Err(HandleError { err: "", action: None })
 	}
 	fn handle_update_fail_malformed_htlc(&self, _their_node_id: &PublicKey, _msg: &msgs::UpdateFailMalformedHTLC) -> Result<(), HandleError> {


### PR DESCRIPTION
Partial patch for #146 
Some additions of returning errors and fix in failure message (additional parameters for UPDATE).
Moving on to work on handling returned failure codes (and looping them back to the router).
