### PR TITLE
Add registration of commitment tx's outputs from check_spend_remote_transaction

### DIFF
--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -76,7 +76,7 @@ struct DummyChainWatcher {
 }
 
 impl ChainWatchInterface for DummyChainWatcher {
-	fn install_watch_script(&self, _script_pub_key: &Script) { }
+	fn install_watch_tx(&self, _txid: &Sha256dHash, _script_pub_key: &Script) { }
 	fn install_watch_outpoint(&self, _outpoint: (Sha256dHash, u32), _out_script: &Script) { }
 	fn watch_all_txn(&self) { }
 	fn register_listener(&self, _listener: Weak<ChainListener>) { }

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -3337,7 +3337,8 @@ mod tests {
 			nodes[1].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone()] }, 1);
 			{
 				let mut node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
-				assert_eq!(node_txn.len(), 2);
+				assert_eq!(node_txn.len(), 3);
+				assert_eq!(node_txn.pop().unwrap(), node_txn[0]); // An outpoint registration will result in a 2nd block_connected
 				assert_eq!(node_txn[0].input.len(), 1);
 
 				let mut funding_tx_map = HashMap::new();

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -97,7 +97,7 @@ impl<Key : Send + cmp::Eq + hash::Hash + 'static> SimpleManyChannelMonitor<Key> 
 		match &monitor.funding_txo {
 			&None => self.chain_monitor.watch_all_txn(),
 			&Some((ref outpoint, ref script)) => {
-				self.chain_monitor.install_watch_script(script);
+				self.chain_monitor.install_watch_tx(&outpoint.txid, script);
 				self.chain_monitor.install_watch_outpoint((outpoint.txid, outpoint.index as u32), script);
 			},
 		}


### PR DESCRIPTION
Partial fulfilling of #137, simplest design of second suggestion ? Need to be tested when ChannelMonitor logic'll be completed.