### PR TITLE
Implement claiming of revoked HTLC transactions by ChannelMonitor

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -570,7 +570,7 @@ impl Channel {
 		                                              &PublicKey::from_secret_key(&secp_ctx, &chan_keys.delayed_payment_base_key),
 		                                              &chan_keys.htlc_base_key,
 		                                              BREAKDOWN_TIMEOUT, our_channel_monitor_claim_script);
-		channel_monitor.set_their_htlc_base_key(&msg.htlc_basepoint);
+		channel_monitor.set_their_base_keys(&msg.htlc_basepoint, &msg.delayed_payment_basepoint);
 		channel_monitor.set_their_to_self_delay(msg.to_self_delay);
 
 		let mut chan = Channel {
@@ -1236,7 +1236,7 @@ impl Channel {
 		// max_accepted_htlcs too small
 		// dust_limit_satoshis too small
 
-		self.channel_monitor.set_their_htlc_base_key(&msg.htlc_basepoint);
+		self.channel_monitor.set_their_base_keys(&msg.htlc_basepoint, &msg.delayed_payment_basepoint);
 
 		self.their_dust_limit_satoshis = msg.dust_limit_satoshis;
 		self.their_max_htlc_value_in_flight_msat = cmp::min(msg.max_htlc_value_in_flight_msat, self.channel_value_satoshis * 1000);

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -924,8 +924,7 @@ impl ChannelMonitor {
 	/// Attempts to claim a remote commitment transaction's outputs using the revocation key and
 	/// data in remote_claimable_outpoints. Will directly claim any HTLC outputs which expire at a
 	/// height > height + CLTV_SHARED_CLAIM_BUFFER. In any case, will install monitoring for
-	/// HTLC-Success/HTLC-Timeout transactions, and claim them using the revocation key (if
-	/// applicable) as well.
+	/// HTLC-Success/HTLC-Timeout transactions.
 	fn check_spend_remote_transaction(&self, tx: &Transaction, height: u32) -> (Vec<Transaction>, (Sha256dHash, Vec<TxOut>)) {
 		// Most secp and related errors trying to create keys means we have no hope of constructing
 		// a spend transaction...so we return no transactions to broadcast
@@ -1205,11 +1204,95 @@ impl ChannelMonitor {
 					txn_to_broadcast.push(spend_tx);
 				}
 			}
-		} else {
-			//TODO: For each input check if its in our remote_commitment_txn_on_chain map!
 		}
 
 		(txn_to_broadcast, (commitment_txid, watch_outputs))
+	}
+
+	/// Attempst to claim a remote HTLC-Success/HTLC-Timeout s outputs using the revocation key
+	fn check_spend_remote_htlc(&self, tx: &Transaction, commitment_number: u64) -> Vec<Transaction> {
+		let mut txn_to_broadcast = Vec::new();
+
+		let htlc_txid = tx.txid(); //TODO: This is gonna be a performance bottleneck for watchtowers!
+
+		macro_rules! ignore_error {
+			( $thing : expr ) => {
+				match $thing {
+					Ok(a) => a,
+					Err(_) => return txn_to_broadcast
+				}
+			};
+		}
+
+		let secret = self.get_secret(commitment_number).unwrap();
+		let per_commitment_key = ignore_error!(SecretKey::from_slice(&self.secp_ctx, &secret));
+		let revocation_pubkey = match self.key_storage {
+			KeyStorage::PrivMode { ref revocation_base_key, .. } => {
+				let per_commitment_point = PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key);
+				ignore_error!(chan_utils::derive_public_revocation_key(&self.secp_ctx, &per_commitment_point, &PublicKey::from_secret_key(&self.secp_ctx, &revocation_base_key)))
+			},
+			KeyStorage::SigsMode { ref revocation_base_key, .. } => {
+				let per_commitment_point = PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key);
+				ignore_error!(chan_utils::derive_public_revocation_key(&self.secp_ctx, &per_commitment_point, &revocation_base_key))
+			},
+		};
+		let delayed_key = match self.their_delayed_payment_base_key {
+			None => return txn_to_broadcast,
+			Some(their_delayed_payment_base_key) => ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key), &their_delayed_payment_base_key)),
+		};
+		let redeemscript = chan_utils::get_revokeable_redeemscript(&revocation_pubkey, self.their_to_self_delay.unwrap(), &delayed_key);
+		let revokeable_p2wsh = redeemscript.to_v0_p2wsh();
+
+		let mut inputs = Vec::new();
+		let mut amount = 0;
+
+		if tx.output[0].script_pubkey == revokeable_p2wsh { //HTLC transactions have one txin, one txout
+			inputs.push(TxIn {
+				previous_output: BitcoinOutPoint {
+					txid: htlc_txid,
+					vout: 0,
+				},
+				script_sig: Script::new(),
+				sequence: 0xfffffffd,
+				witness: Vec::new(),
+			});
+			amount = tx.output[0].value;
+		}
+
+		if !inputs.is_empty() {
+			let outputs = vec!(TxOut {
+				script_pubkey: self.destination_script.clone(),
+				value: amount, //TODO: - fee
+			});
+
+			let mut spend_tx = Transaction {
+				version: 2,
+				lock_time: 0,
+				input: inputs,
+				output: outputs,
+			};
+
+
+			let sighash_parts = bip143::SighashComponents::new(&spend_tx);
+
+			let sig = match self.key_storage {
+				KeyStorage::PrivMode { ref revocation_base_key, .. } => {
+					let sighash = ignore_error!(Message::from_slice(&sighash_parts.sighash_all(&spend_tx.input[0], &redeemscript, amount)[..]));
+					let revocation_key = ignore_error!(chan_utils::derive_private_revocation_key(&self.secp_ctx, &per_commitment_key, &revocation_base_key));
+					self.secp_ctx.sign(&sighash, &revocation_key)
+				}
+				KeyStorage::SigsMode { .. } => {
+					unimplemented!();
+				}
+			};
+			spend_tx.input[0].witness.push(sig.serialize_der(&self.secp_ctx).to_vec());
+			spend_tx.input[0].witness[0].push(SigHashType::All as u8);
+			spend_tx.input[0].witness.push(vec!(1));
+			spend_tx.input[0].witness.push(redeemscript.into_bytes());
+
+			txn_to_broadcast.push(spend_tx);
+		}
+		txn_to_broadcast
 	}
 
 	fn broadcast_by_local_state(&self, local_tx: &LocalSignedTx) -> Vec<Transaction> {
@@ -1273,18 +1356,25 @@ impl ChannelMonitor {
 	fn block_connected(&self, txn_matched: &[&Transaction], height: u32, broadcaster: &BroadcasterInterface)-> Vec<(Sha256dHash, Vec<TxOut>)> {
 		let mut watch_outputs = Vec::new();
 		for tx in txn_matched {
+			let mut txn: Vec<Transaction> = Vec::new();
 			for txin in tx.input.iter() {
 				if self.funding_txo.is_none() || (txin.previous_output.txid == self.funding_txo.as_ref().unwrap().0.txid && txin.previous_output.vout == self.funding_txo.as_ref().unwrap().0.index as u32) {
-					let (mut txn, new_outputs) = self.check_spend_remote_transaction(tx, height);
+					let (remote_txn, new_outputs) = self.check_spend_remote_transaction(tx, height);
+					txn = remote_txn;
 					if !new_outputs.1.is_empty() {
 						watch_outputs.push(new_outputs);
 					}
 					if txn.is_empty() {
 						txn = self.check_spend_local_transaction(tx, height);
 					}
-					for tx in txn.iter() {
-						broadcaster.broadcast_transaction(tx);
+				} else {
+					let remote_commitment_txn_on_chain = self.remote_commitment_txn_on_chain.lock().unwrap();
+					for commitment_number in remote_commitment_txn_on_chain.get(&txin.previous_output.txid) {
+						txn =  self.check_spend_remote_htlc(tx, *commitment_number);
 					}
+				}
+				for tx in txn.iter() {
+					broadcaster.broadcast_transaction(tx);
 				}
 			}
 		}


### PR DESCRIPTION
Still working on others parts of #137. Implement claiming of revoked HTLC-Success/HTLC-timeout transactions in check_spend_remote_transaction that as I understand the TODO was all about ?
Will add/finish test in ChannelManager with others commits tomorrow.