### PR TITLE
Further minor misc changes from reconnect work

### DIFF
--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -403,6 +403,13 @@ pub fn do_test(data: &[u8], logger: &Arc<Logger>) {
 			13 => {
 				loss_detector.disconnect_block();
 			},
+			14 => {
+				let mut channels = channelmanager.list_channels();
+				let channel_id = get_slice!(1)[0] as usize;
+				if channel_id >= channels.len() { return; }
+				channels.sort_by(|a, b| { a.channel_id.cmp(&b.channel_id) });
+				channelmanager.force_close_channel(&channels[channel_id].channel_id);
+			},
 			_ => return,
 		}
 		loss_detector.handler.process_events();

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1094,7 +1094,7 @@ impl Channel {
 
 	pub fn get_update_fail_htlc(&mut self, payment_hash_arg: &[u8; 32], err_packet: msgs::OnionErrorPacket) -> Result<Option<msgs::UpdateFailHTLC>, HandleError> {
 		if (self.channel_state & (ChannelState::ChannelFunded as u32)) != (ChannelState::ChannelFunded as u32) {
-			return Err(HandleError{err: "Was asked to fail an HTLC when channel was not in an operational state", action: None});
+			panic!("Was asked to fail an HTLC when channel was not in an operational state");
 		}
 		assert_eq!(self.channel_state & ChannelState::ShutdownComplete as u32, 0);
 

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -2390,12 +2390,13 @@ impl Channel {
 	/// Creates a signed commitment transaction to send to the remote peer.
 	/// Always returns a Channel-failing HandleError::action if an immediately-preceding (read: the
 	/// last call to this Channel) send_htlc returned Ok(Some(_)) and there is an Err.
+	/// May panic if called except immediately after a successful, Ok(Some(_))-returning send_htlc.
 	pub fn send_commitment(&mut self) -> Result<(msgs::CommitmentSigned, ChannelMonitor), HandleError> {
 		if (self.channel_state & (ChannelState::ChannelFunded as u32)) != (ChannelState::ChannelFunded as u32) {
-			return Err(HandleError{err: "Cannot create commitment tx until channel is fully established", action: None});
+			panic!("Cannot create commitment tx until channel is fully established");
 		}
 		if (self.channel_state & (ChannelState::AwaitingRemoteRevoke as u32)) == (ChannelState::AwaitingRemoteRevoke as u32) {
-			return Err(HandleError{err: "Cannot create commitment tx until remote revokes their previous commitment", action: None});
+			panic!("Cannot create commitment tx until remote revokes their previous commitment");
 		}
 		let mut have_updates = false; // TODO initialize with "have we sent a fee update?"
 		for htlc in self.pending_htlcs.iter() {
@@ -2405,7 +2406,7 @@ impl Channel {
 			if have_updates { break; }
 		}
 		if !have_updates {
-			return Err(HandleError{err: "Cannot create commitment tx until we have some updates to send", action: None});
+			panic!("Cannot create commitment tx until we have some updates to send");
 		}
 		self.send_commitment_no_status_check()
 	}

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -985,6 +985,9 @@ impl ChannelManager {
 				if chan.get_their_node_id() != route.hops.first().unwrap().pubkey {
 					return Err(HandleError{err: "Node ID mismatch on first hop!", action: None});
 				}
+				if !chan.is_live() {
+					return Err(HandleError{err: "Peer for first hop currently disconnected!", action: None});
+				}
 				chan.send_htlc_and_commit(htlc_msat, payment_hash, htlc_cltv, onion_packet)?
 			};
 


### PR DESCRIPTION
Sadly I discovered I want to overhaul pending-HTLC tracking before I merge the reconnect stuff, though I've gotten most of that hashed out. Hopefully the pending-HTLC overhaul will also reduce panic!()s in Channel which assert ChannelManager sanity (except for the state-precondition-check ones).