### PR TITLE
Add optional user specified channel limits of bolt 2 

### DIFF
--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -24,6 +24,7 @@ use lightning::util::events::{EventsProvider,Event};
 use lightning::util::reset_rng_state;
 use lightning::util::logger::Logger;
 use lightning::util::sha2::Sha256;
+use lightning::util::configurations::UserConfig;
 
 mod utils;
 
@@ -283,7 +284,10 @@ pub fn do_test(data: &[u8], logger: &Arc<Logger>) {
 	let monitor = channelmonitor::SimpleManyChannelMonitor::new(watch.clone(), broadcast.clone());
 
 	let keys_manager = Arc::new(KeyProvider { node_secret: our_network_key.clone() });
-	let channelmanager = ChannelManager::new(slice_to_be32(get_slice!(4)), get_slice!(1)[0] != 0, Network::Bitcoin, fee_est.clone(), monitor.clone(), watch.clone(), broadcast.clone(), Arc::clone(&logger), keys_manager.clone()).unwrap();
+	let mut config = UserConfig::new();
+	config.channel_options.fee_proportional_millionths =  slice_to_be32(get_slice!(4));
+	config.channel_options.announced_channel = (get_slice!(1)[0] != 0);
+	let channelmanager = ChannelManager::new(Network::Bitcoin, fee_est.clone(), monitor.clone(), watch.clone(), broadcast.clone(), Arc::clone(&logger),keys_manager.clone(), config).unwrap();
 	let router = Arc::new(Router::new(PublicKey::from_secret_key(&secp_ctx, &keys_manager.get_node_secret()), watch.clone(), Arc::clone(&logger)));
 
 	let peers = RefCell::new([false; 256]);

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -28,6 +28,7 @@ use util::ser::{Readable, ReadableArgs, Writeable, Writer, WriterWriteAdaptor};
 use util::sha2::Sha256;
 use util::logger::Logger;
 use util::errors::APIError;
+use util::configurations::{UserConfig,ChannelConfig};
 
 use std;
 use std::default::Default;
@@ -225,18 +226,20 @@ const MULTI_STATE_FLAGS: u32 = (BOTH_SIDES_SHUTDOWN_MASK | ChannelState::PeerDis
 
 const INITIAL_COMMITMENT_NUMBER: u64 = (1 << 48) - 1;
 
+
 // TODO: We should refactor this to be an Inbound/OutboundChannel until initial setup handshaking
 // has been completed, and then turn into a Channel to get compiler-time enforcement of things like
 // calling channel_id() before we're set up or things like get_outbound_funding_signed on an
 // inbound channel.
 pub(super) struct Channel {
+	config :  ChannelConfig,
+
 	user_id: u64,
 
 	channel_id: [u8; 32],
 	channel_state: u32,
 	channel_outbound: bool,
 	secp_ctx: Secp256k1<secp256k1::All>,
-	announce_publicly: bool,
 	channel_value_satoshis: u64,
 
 	local_keys: ChannelKeys,
@@ -391,7 +394,6 @@ impl Channel {
 	}
 
 	/// Returns a minimum channel reserve value **they** need to maintain
-	///
 	/// Guaranteed to return a value no larger than channel_value_satoshis
 	fn get_our_channel_reserve_satoshis(channel_value_satoshis: u64) -> u64 {
 		let (q, _) = channel_value_satoshis.overflowing_div(100);
@@ -399,7 +401,14 @@ impl Channel {
 	}
 
 	fn derive_our_dust_limit_satoshis(at_open_background_feerate: u64) -> u64 {
-		at_open_background_feerate * B_OUTPUT_PLUS_SPENDING_INPUT_WEIGHT / 1000 //TODO
+		#[cfg(test)]
+		{
+			547
+		}
+		#[cfg(not(test))]
+		{
+			at_open_background_feerate * B_OUTPUT_PLUS_SPENDING_INPUT_WEIGHT / 1000 //TODO
+		}
 	}
 
 	fn derive_our_htlc_minimum_msat(_at_open_channel_feerate_per_kw: u64) -> u64 {
@@ -419,13 +428,12 @@ impl Channel {
 	}
 
 	// Constructors:
-	pub fn new_outbound(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, channel_value_satoshis: u64, push_msat: u64, announce_publicly: bool, user_id: u64, logger: Arc<Logger>) -> Result<Channel, APIError> {
+	pub fn new_outbound(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, channel_value_satoshis: u64, push_msat: u64, user_id: u64, logger: Arc<Logger>, config: &UserConfig) -> Result<Channel, APIError> {
 		let chan_keys = keys_provider.get_channel_keys(false);
 
 		if channel_value_satoshis >= MAX_FUNDING_SATOSHIS {
 			return Err(APIError::APIMisuseError{err: "funding value > 2^24"});
 		}
-
 		if push_msat > channel_value_satoshis * 1000 {
 			return Err(APIError::APIMisuseError{err: "push value > channel value"});
 		}
@@ -445,12 +453,12 @@ impl Channel {
 
 		Ok(Channel {
 			user_id: user_id,
+			config: config.channel_options.clone(),
 
 			channel_id: rng::rand_u832(),
 			channel_state: ChannelState::OurInitSent as u32,
 			channel_outbound: true,
 			secp_ctx: secp_ctx,
-			announce_publicly: announce_publicly,
 			channel_value_satoshis: channel_value_satoshis,
 
 			local_keys: chan_keys,
@@ -529,8 +537,10 @@ impl Channel {
 
 	/// Creates a new channel from a remote sides' request for one.
 	/// Assumes chain_hash has already been checked and corresponds with what we expect!
-	pub fn new_from_req(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, msg: &msgs::OpenChannel, user_id: u64, require_announce: bool, allow_announce: bool, logger: Arc<Logger>) -> Result<Channel, ChannelError> {
+	pub fn new_from_req(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, msg: &msgs::OpenChannel, user_id: u64, logger: Arc<Logger>, config : &UserConfig) -> Result<Channel, ChannelError> {
 		let chan_keys = keys_provider.get_channel_keys(true);
+		let mut local_config = (*config).channel_options.clone();
+
 
 		// Check sanity of message fields:
 		if msg.funding_satoshis >= MAX_FUNDING_SATOSHIS {
@@ -562,23 +572,48 @@ impl Channel {
 		if msg.max_accepted_htlcs > 483 {
 			return Err(ChannelError::Close("max_accpted_htlcs > 483"));
 		}
+		//optional parameter checking
+		// MAY fail the channel if
+		if msg.funding_satoshis < config.channel_limits.min_funding_satoshis {
+			return Err(ChannelError::Close("funding satoshis is less than the user specified limit"));
+		}
+		if msg.htlc_minimum_msat > config.channel_limits.max_htlc_minimum_msat {
+			return Err(ChannelError::Close("htlc minimum msat is higher than the user specified limit"));
+		}
+		if msg.max_htlc_value_in_flight_msat < config.channel_limits.min_max_htlc_value_in_flight_msat {
+			return Err(ChannelError::Close("max htlc value in flight msat is less than the user specified limit"));
+		}
+		if msg.channel_reserve_satoshis > config.channel_limits.max_channel_reserve_satoshis {
+			return Err(ChannelError::Close("channel reserve satoshis is higher than the user specified limit"));
+		}
+		if msg.max_accepted_htlcs < config.channel_limits.min_max_accepted_htlcs {
+			return Err(ChannelError::Close("max accepted htlcs is less than the user specified limit"));
+		}
+		if msg.dust_limit_satoshis < config.channel_limits.min_dust_limit_satoshis {
+			println!("{:?}", msg.dust_limit_satoshis);
+			return Err(ChannelError::Close("dust limit satoshis is less than the user specified limit"));
+		}
+		if msg.dust_limit_satoshis > config.channel_limits.max_dust_limit_satoshis {
+			return Err(ChannelError::Close("dust limit satoshis is greater than the user specified limit"));
+		}
 
 		// Convert things into internal flags and prep our state:
 
 		let their_announce = if (msg.channel_flags & 1) == 1 { true } else { false };
-		if require_announce && !their_announce {
-			return Err(ChannelError::Close("Peer tried to open unannounced channel, but we require public ones"));
+		if config.channel_limits.force_announced_channel_preference{
+			if local_config.announced_channel != their_announce {
+				return Err(ChannelError::Close("Peer tried to open channel but their announcement preference is different from ours"));
+			}
 		}
-		if !allow_announce && their_announce {
-			return Err(ChannelError::Close("Peer tried to open announced channel, but we require private ones"));
-		}
+		//we either accept their preference or the preferences match
+		local_config.announced_channel = their_announce;
 
 		let background_feerate = fee_estimator.get_est_sat_per_1000_weight(ConfirmationTarget::Background);
 
 		let our_dust_limit_satoshis = Channel::derive_our_dust_limit_satoshis(background_feerate);
 		let our_channel_reserve_satoshis = Channel::get_our_channel_reserve_satoshis(msg.funding_satoshis);
 		if our_channel_reserve_satoshis < our_dust_limit_satoshis {
-			return Err(ChannelError::Close("Suitalbe channel reserve not found. aborting"));
+			return Err(ChannelError::Close("Suitable channel reserve not found. aborting"));
 		}
 		if msg.channel_reserve_satoshis < our_dust_limit_satoshis {
 			return Err(ChannelError::Close("channel_reserve_satoshis too small"));
@@ -609,12 +644,12 @@ impl Channel {
 
 		let mut chan = Channel {
 			user_id: user_id,
+			config: local_config,
 
 			channel_id: msg.temporary_channel_id,
 			channel_state: (ChannelState::OurInitSent as u32) | (ChannelState::TheirInitSent as u32),
 			channel_outbound: false,
 			secp_ctx: secp_ctx,
-			announce_publicly: their_announce,
 
 			local_keys: chan_keys,
 			shutdown_pubkey: keys_provider.get_shutdown_pubkey(),
@@ -1264,7 +1299,7 @@ impl Channel {
 
 	// Message handlers:
 
-	pub fn accept_channel(&mut self, msg: &msgs::AcceptChannel) -> Result<(), ChannelError> {
+	pub fn accept_channel(&mut self, msg: &msgs::AcceptChannel, config : &UserConfig) -> Result<(), ChannelError> {
 		// Check sanity of message fields:
 		if !self.channel_outbound {
 			return Err(ChannelError::Close("Got an accept_channel message from an inbound peer"));
@@ -1302,16 +1337,10 @@ impl Channel {
 		if msg.max_accepted_htlcs > 483 {
 			return Err(ChannelError::Close("max_accpted_htlcs > 483"));
 		}
-
-		// TODO: Optional additional constraints mentioned in the spec
-		// MAY fail the channel if
-		// funding_satoshi is too small
-		// htlc_minimum_msat too large
-		// max_htlc_value_in_flight_msat too small
-		// channel_reserve_satoshis too large
-		// max_accepted_htlcs too small
-		// dust_limit_satoshis too small
-
+		//Optional user definined limits
+		if msg.minimum_depth > config.channel_limits.minimum_depth {
+			return Err(ChannelError::Close("We consider the minimum depth to be unreasonably large"));
+		}
 		self.channel_monitor.set_their_base_keys(&msg.htlc_basepoint, &msg.delayed_payment_basepoint);
 
 		self.their_dust_limit_satoshis = msg.dust_limit_satoshis;
@@ -2575,6 +2604,10 @@ impl Channel {
 		self.channel_value_satoshis
 	}
 
+	pub fn get_fee_proportional_millionths(&self) -> u32{
+		self.config.fee_proportional_millionths
+	}
+
 	#[cfg(test)]
 	pub fn get_feerate(&self) -> u64 {
 		self.feerate_per_kw
@@ -2628,7 +2661,7 @@ impl Channel {
 	}
 
 	pub fn should_announce(&self) -> bool {
-		self.announce_publicly
+		self.config.announced_channel
 	}
 
 	pub fn is_outbound(&self) -> bool {
@@ -2827,7 +2860,7 @@ impl Channel {
 			delayed_payment_basepoint: PublicKey::from_secret_key(&self.secp_ctx, &self.local_keys.delayed_payment_base_key),
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, &self.local_keys.htlc_base_key),
 			first_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &local_commitment_secret),
-			channel_flags: if self.announce_publicly {1} else {0},
+			channel_flags: if self.config.announced_channel {1} else {0},
 			shutdown_scriptpubkey: None,
 		}
 	}
@@ -2931,7 +2964,7 @@ impl Channel {
 	/// Note that the "channel must be funded" requirement is stricter than BOLT 7 requires - see
 	/// https://github.com/lightningnetwork/lightning-rfc/issues/468
 	pub fn get_channel_announcement(&self, our_node_id: PublicKey, chain_hash: Sha256dHash) -> Result<(msgs::UnsignedChannelAnnouncement, Signature), ChannelError> {
-		if !self.announce_publicly {
+		if !self.config.announced_channel {
 			return Err(ChannelError::Ignore("Channel is not available for public announcements"));
 		}
 		if self.channel_state & (ChannelState::ChannelFunded as u32) == 0 {
@@ -3307,11 +3340,11 @@ impl Writeable for Channel {
 		writer.write_all(&[MIN_SERIALIZATION_VERSION; 1])?;
 
 		self.user_id.write(writer)?;
+		self.config.write(writer)?;
 
 		self.channel_id.write(writer)?;
 		(self.channel_state | ChannelState::PeerDisconnected as u32).write(writer)?;
 		self.channel_outbound.write(writer)?;
-		self.announce_publicly.write(writer)?;
 		self.channel_value_satoshis.write(writer)?;
 
 		self.local_keys.write(writer)?;
@@ -3509,11 +3542,10 @@ impl<R : ::std::io::Read> ReadableArgs<R, Arc<Logger>> for Channel {
 		}
 
 		let user_id = Readable::read(reader)?;
-
+		let config : ChannelConfig = Readable::read(reader)?;
 		let channel_id = Readable::read(reader)?;
 		let channel_state = Readable::read(reader)?;
 		let channel_outbound = Readable::read(reader)?;
-		let announce_publicly = Readable::read(reader)?;
 		let channel_value_satoshis = Readable::read(reader)?;
 
 		let local_keys = Readable::read(reader)?;
@@ -3676,12 +3708,11 @@ impl<R : ::std::io::Read> ReadableArgs<R, Arc<Logger>> for Channel {
 
 		Ok(Channel {
 			user_id,
-
+			config,
 			channel_id,
 			channel_state,
 			channel_outbound,
 			secp_ctx: Secp256k1::new(),
-			announce_publicly,
 			channel_value_satoshis,
 
 			local_keys,
@@ -3813,6 +3844,7 @@ mod tests {
 
 	#[test]
 	fn outbound_commitment_test() {
+		use util::configurations::UserConfig;
 		// Test vectors from BOLT 3 Appendix C:
 		let feeest = TestFeeEstimator{fee_est: 15000};
 		let logger : Arc<Logger> = Arc::new(test_utils::TestLogger::new());
@@ -3833,7 +3865,9 @@ mod tests {
 		let keys_provider: Arc<KeysInterface> = Arc::new(Keys { chan_keys });
 
 		let their_node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap());
-		let mut chan = Channel::new_outbound(&feeest, &keys_provider, their_node_id, 10000000, 100000, false, 42, Arc::clone(&logger)).unwrap(); // Nothing uses their network key in this test
+		let mut config = UserConfig::new();
+		config.channel_options.announced_channel= false;
+		let mut chan = Channel::new_outbound(&feeest, &keys_provider, their_node_id, 10000000, 100000, 42, Arc::clone(&logger),&config).unwrap(); // Nothing uses their network key in this test
 		chan.their_to_self_delay = 144;
 		chan.our_dust_limit_satoshis = 546;
 

--- a/src/util/configurations.rs
+++ b/src/util/configurations.rs
@@ -1,0 +1,98 @@
+//! This is the config struct used by the channel and channel_manager for channel specific settings and channel handshake limits
+//! ChannelHandshakeLimits sets the limits of certain variables that if they are exceeded the channel will be denied.
+//! ChannelConfig is used by the channel to control its own properties, it contains defaults for a new channel but these can by changed by update messages or channel creation.
+//! Changing the ChannelConfig of channel_manager after a channel was created will not change the settings in already created channels
+
+/// This is the main user config
+/// It wraps the ChannelHandshakeLimits struct and ChannelConfig struct into a single one for channel manager.
+#[derive(Clone, Debug)]
+pub struct UserConfig{
+	/// optional user specified channel limits, this hold information regarding handshakes of channels.
+	pub channel_limits : ChannelHandshakeLimits,
+	/// channel specific options and settings egis channel announced or not
+	pub channel_options : ChannelConfig,
+}
+
+impl UserConfig {
+	///default constructor, calls default ChannelOptions and default ChannelLimits constructors
+    pub fn new() -> Self{
+        UserConfig {
+            channel_limits : ChannelHandshakeLimits::new(),
+			channel_options : ChannelConfig::new(),
+        }
+    }
+}
+
+/// This struct contains all the optional channel limits. If these limits are breached the new channel will be denied
+/// If the user wants to check a value, the value needs to be filled in, as by default most are not checked
+#[derive(Copy, Clone, Debug)]
+pub struct ChannelHandshakeLimits{
+	/// minimum allowed satoshis when a channel is funded, this is supplied by the sender.
+	pub min_funding_satoshis :u64,
+	/// maximum allowed smallest HTLC that will be accepted by us.
+	pub max_htlc_minimum_msat : u64,
+	/// min allowed cap on outstanding HTLC. This is used to limit exposure to HTLCs.
+	pub min_max_htlc_value_in_flight_msat : u64,
+	/// max allowed satoshis that may be used as a direct payment by the peer.
+	pub max_channel_reserve_satoshis : u64,
+	/// min allowed max outstanding HTLC that can be offered.
+	pub min_max_accepted_htlcs : u16,
+	/// min allowed threshold below which outputs should not be generated.
+	/// These outputs are either commitment or HTLC transactions.
+	/// HTLCs below this amount plus HTLC transaction fees are not enforceable on-chain.
+	/// This reflects the reality that tiny outputs are not considered standard transactions and will not propagate through the Bitcoin network
+	pub min_dust_limit_satoshis : u64,
+	/// max allowed threshold above which outputs should not be generated. Bolt 2 mentions channel_reserve_satoshis as upper limit, but this can be a lower limit
+	pub max_dust_limit_satoshis : u64,
+	/// minimum depth to a number of blocks that is considered reasonable to avoid double-spending of the funding transaction
+	pub minimum_depth : u32,
+	/// do we force the incoming channel to match our announced channel preference
+	pub force_announced_channel_preference : bool,
+}
+
+impl ChannelHandshakeLimits {
+//creating max and min possible values because if they are not set, means we should not check them.
+///default constructor creates limits so that they are not tested for
+///min_dust_limit_satoshis is set to the network default of 546
+	pub fn new() -> Self{
+		ChannelHandshakeLimits {
+			min_funding_satoshis : 0,
+			max_htlc_minimum_msat : <u64>::max_value(),
+			min_max_htlc_value_in_flight_msat : 0,
+			max_channel_reserve_satoshis : <u64>::max_value(),
+			min_max_accepted_htlcs : 0,
+			min_dust_limit_satoshis : 546,
+			max_dust_limit_satoshis : <u64>::max_value(),
+			minimum_depth : <u32>::max_value(),
+			force_announced_channel_preference : false,
+		}
+	}
+}
+
+/// This struct contains all the custom channel options.
+#[derive(Copy, Clone, Debug)]
+pub struct ChannelConfig{
+	/// Amount (in millionths of a satoshi) the channel will charge per transferred satoshi.
+	/// This must be updated as the channel updates and can change in runtime.
+	pub fee_proportional_millionths : u32,
+	//TODO enforce non-mutability when config can change at runtime
+	///Is this channel publicly announced channel or not.
+	///This cannot change after channel creation.
+	pub announced_channel : bool,
+}
+impl ChannelConfig {
+	/// creating a struct with default values.
+	/// fee_proportional_millionths should be changed and updated afterwords
+	pub fn new() -> Self{
+		ChannelConfig {
+			fee_proportional_millionths : 0,
+			announced_channel : true,
+		}
+	}
+}
+
+//Add write and readable traits to channelconfig
+impl_writeable!(ChannelConfig, 8+1, {
+	fee_proportional_millionths,
+	announced_channel
+});

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -28,3 +28,6 @@ pub use self::rng::reset_rng_state;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
+
+//config struct that is used to store defaults for channel handshake limits and channel settings
+pub mod configurations;


### PR DESCRIPTION
Added a config struct to use when passing configurations into the channel. 

Before accepting a channel the channel will test optional limits as specified by BOLT 2.
The default values of these test are set to not test the limits, but the user can supply other values. 
