### PR TITLE
Correct MAX_BUF_SIZE in serialization

### DIFF
--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -13,7 +13,7 @@ use ln::msgs::DecodeError;
 
 use util::byte_utils::{be64_to_array, be32_to_array, be16_to_array, slice_to_be16, slice_to_be32, slice_to_be64};
 
-const MAX_BUF_SIZE: usize = 16 * 1024;
+const MAX_BUF_SIZE: usize = 64 * 1024;
 
 pub struct Writer<W> { writer: W }
 pub struct Reader<R> { reader: R }

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -183,7 +183,7 @@ impl<R, K, V> Readable<R> for HashMap<K, V>
 		let len: u16 = Readable::read(r)?;
 		let mut ret = HashMap::with_capacity(len as usize);
 		for _ in 0..len {
-				ret.insert(K::read(r)?, V::read(r)?);
+			ret.insert(K::read(r)?, V::read(r)?);
 		}
 		Ok(ret)
 	}
@@ -197,7 +197,7 @@ impl<W: Write, T: Writeable<W>> Writeable<W> for Vec<T> {
 		                .checked_mul(mem::size_of::<T>())
 		                .ok_or(DecodeError::BadLengthDescriptor)?;
 		if byte_size > MAX_BUF_SIZE {
-				return Err(DecodeError::BadLengthDescriptor);
+			return Err(DecodeError::BadLengthDescriptor);
 		}
 		(self.len() as u16).write(w)?;
 		// performance with Vec<u8>
@@ -211,16 +211,16 @@ impl<W: Write, T: Writeable<W>> Writeable<W> for Vec<T> {
 impl<R: Read, T: Readable<R>> Readable<R> for Vec<T> {
 	#[inline]
 	fn read(r: &mut Reader<R>) -> Result<Self, DecodeError> {
-			let len: u16 = Readable::read(r)?;
-			let byte_size = (len as usize)
-			                .checked_mul(mem::size_of::<T>())
-			                .ok_or(DecodeError::BadLengthDescriptor)?;
-			if byte_size > MAX_BUF_SIZE {
-					return Err(DecodeError::BadLengthDescriptor);
-			}
-			let mut ret = Vec::with_capacity(len as usize);
-			for _ in 0..len { ret.push(T::read(r)?); }
-			Ok(ret)
+		let len: u16 = Readable::read(r)?;
+		let byte_size = (len as usize)
+		                .checked_mul(mem::size_of::<T>())
+		                .ok_or(DecodeError::BadLengthDescriptor)?;
+		if byte_size > MAX_BUF_SIZE {
+			return Err(DecodeError::BadLengthDescriptor);
+		}
+		let mut ret = Vec::with_capacity(len as usize);
+		for _ in 0..len { ret.push(T::read(r)?); }
+		Ok(ret)
 	}
 }
 


### PR DESCRIPTION
I think this might have been my fault due to faulty review
feedback, but fuzzer caught trivial crash here where you try to
send a ping message larger than 16KB (but smaller than the
max-length 64KB) and you crash as message serialization is unwrap()