### PR TITLE
Add bolt 2 spec checks for funding messages

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1300,6 +1300,9 @@ impl Channel {
 		if self.channel_outbound {
 			return Err(HandleError{err: "Received funding_created for an outbound channel?", action: Some(msgs::ErrorAction::SendErrorMessage {msg: msgs::ErrorMessage {channel_id: self.channel_id, data: "Received funding_created for an outbound channel?".to_string()}})});
 		}
+		if self.channel_id != msg.temporary_channel_id {
+			return Err(HandleError{err: "temporary channel id in funding_created does not match open_channel message", action: Some(msgs::ErrorAction::SendErrorMessage {msg: msgs::ErrorMessage {channel_id: self.channel_id, data: "temporary channel id in funding_created does not match open_channel message".to_string()}})});
+		}
 		if self.channel_state != (ChannelState::OurInitSent as u32 | ChannelState::TheirInitSent as u32) {
 			// BOLT 2 says that if we disconnect before we send funding_signed we SHOULD NOT
 			// remember the channel, so its safe to just send an error_message here and drop the

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1355,6 +1355,9 @@ impl Channel {
 				self.cur_local_commitment_transaction_number != INITIAL_COMMITMENT_NUMBER {
 			panic!("Should not have advanced channel commitment tx numbers prior to funding_created");
 		}
+		if self.channel_monitor.funding_txo.unwrap().funding_txo.to_channel_id() != msg.channel_id {
+			return Err(HandleError{err: "Received incorrect channel_id in funding_signed message", action: None});
+		}
 
 		let funding_script = self.get_funding_redeemscript();
 

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1355,7 +1355,7 @@ impl Channel {
 				self.cur_local_commitment_transaction_number != INITIAL_COMMITMENT_NUMBER {
 			panic!("Should not have advanced channel commitment tx numbers prior to funding_created");
 		}
-		if self.channel_monitor.funding_txo.unwrap().funding_txo.to_channel_id() != msg.channel_id {
+		if self.channel_monitor.funding_txo.clone().unwrap().0.to_channel_id() != msg.channel_id {
 			return Err(HandleError{err: "Received incorrect channel_id in funding_signed message", action: None});
 		}
 

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -163,7 +163,7 @@ const SERIALIZATION_VERSION: u8 = 1;
 const MIN_SERIALIZATION_VERSION: u8 = 1;
 
 pub struct ChannelMonitor {
-	funding_txo: Option<(OutPoint, Script)>,
+	pub funding_txo: Option<(OutPoint, Script)>,
 	commitment_transaction_number_obscure_factor: u64,
 
 	key_storage: KeyStorage,


### PR DESCRIPTION
I added additional checks for the funding_created, funding_signed and funding_locked messages. 
This is to ensure 100% coverage of BOLT2 spec. I added tests for the channel id, to ensure the received channel id is correct.  

This is in relation to #129 
