### PR TITLE
Migrate ChannelMonitor writing/reading to new serialization framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ features = ["bitcoinconsensus"]
 
 [dev-dependencies]
 hex = "0.3"
+
+[profile.dev]
+opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Matt Corallo"]
 license = "Apache-2.0"
 repository = "https://github.com/rust-bitcoin/rust-lightning/"

--- a/fuzz/fuzz_targets/chanmon_deser_target.rs
+++ b/fuzz/fuzz_targets/chanmon_deser_target.rs
@@ -5,12 +5,15 @@ extern crate lightning;
 
 use lightning::ln::channelmonitor;
 use lightning::util::reset_rng_state;
+use lightning::util::ser::Readable;
+
+use std::io::Cursor;
 
 #[inline]
 pub fn do_test(data: &[u8]) {
 	reset_rng_state();
-	if let Some(monitor) = channelmonitor::ChannelMonitor::deserialize(data) {
-		assert!(channelmonitor::ChannelMonitor::deserialize(&monitor.serialize_for_disk()[..]).unwrap() == monitor);
+	if let Ok(monitor) = channelmonitor::ChannelMonitor::read(&mut Cursor::new(data)) {
+		assert!(channelmonitor::ChannelMonitor::read(&mut Cursor::new(&monitor.serialize_for_disk()[..])).unwrap() == monitor);
 		monitor.serialize_for_watchtower();
 	}
 }

--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -125,15 +125,12 @@ pub fn do_test(data: &[u8]) {
 			match <($MsgType)>::read(&mut reader) {
 				Ok(msg) => msg,
 				Err(e) => match e {
-					msgs::DecodeError::UnknownRealmByte => return,
+					msgs::DecodeError::UnknownVersion => return,
 					msgs::DecodeError::UnknownRequiredFeature => return,
-					msgs::DecodeError::BadPublicKey => return,
-					msgs::DecodeError::BadSignature => return,
-					msgs::DecodeError::BadText => return,
+					msgs::DecodeError::InvalidValue => return,
 					msgs::DecodeError::ExtraAddressesPerType => return,
 					msgs::DecodeError::BadLengthDescriptor => return,
 					msgs::DecodeError::ShortRead => panic!("We picked the length..."),
-					msgs::DecodeError::InvalidValue => panic!("Should not happen with p2p message decoding"),
 					msgs::DecodeError::Io(e) => panic!(format!("{}", e)),
 				}
 			}

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -806,7 +806,7 @@ impl ChannelManager {
 			match msgs::OnionHopData::read(&mut Cursor::new(&decoded[..])) {
 				Err(err) => {
 					let error_code = match err {
-						msgs::DecodeError::UnknownRealmByte => 0x4000 | 1,
+						msgs::DecodeError::UnknownVersion => 0x4000 | 1, // unknown realm byte
 						_ => 0x2000 | 2, // Should never happen
 					};
 					return_err!("Unable to decode our hop data", error_code, &[0;0]);

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -374,14 +374,12 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 										Ok(x) => x,
 										Err(e) => {
 											match e {
-												msgs::DecodeError::UnknownRealmByte => return Err(PeerHandleError{ no_connection_possible: false }),
+												msgs::DecodeError::UnknownVersion => return Err(PeerHandleError{ no_connection_possible: false }),
 												msgs::DecodeError::UnknownRequiredFeature => {
 													log_debug!(self, "Got a channel/node announcement with an known required feature flag, you may want to udpate!");
 													continue;
 												},
-												msgs::DecodeError::BadPublicKey => return Err(PeerHandleError{ no_connection_possible: false }),
-												msgs::DecodeError::BadSignature => return Err(PeerHandleError{ no_connection_possible: false }),
-												msgs::DecodeError::BadText => return Err(PeerHandleError{ no_connection_possible: false }),
+												msgs::DecodeError::InvalidValue => return Err(PeerHandleError{ no_connection_possible: false }),
 												msgs::DecodeError::ShortRead => return Err(PeerHandleError{ no_connection_possible: false }),
 												msgs::DecodeError::ExtraAddressesPerType => {
 													log_debug!(self, "Error decoding message, ignoring due to lnd spec incompatibility. See https://github.com/lightningnetwork/lnd/issues/1407");
@@ -389,7 +387,6 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 												},
 												msgs::DecodeError::BadLengthDescriptor => return Err(PeerHandleError{ no_connection_possible: false }),
 												msgs::DecodeError::Io(_) => return Err(PeerHandleError{ no_connection_possible: false }),
-												msgs::DecodeError::InvalidValue => panic!("should not happen with message decoding"),
 											}
 										}
 									};

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -295,7 +295,7 @@ impl<R: Read> Readable<R> for PublicKey {
 		let buf: [u8; 33] = Readable::read(r)?;
 		match PublicKey::from_slice(&Secp256k1::without_caps(), &buf) {
 			Ok(key) => Ok(key),
-			Err(_) => return Err(DecodeError::BadPublicKey),
+			Err(_) => return Err(DecodeError::InvalidValue),
 		}
 	}
 }
@@ -324,7 +324,7 @@ impl<R: Read> Readable<R> for Signature {
 		let buf: [u8; 64] = Readable::read(r)?;
 		match Signature::from_compact(&Secp256k1::without_caps(), &buf) {
 			Ok(sig) => Ok(sig),
-			Err(_) => return Err(DecodeError::BadSignature),
+			Err(_) => return Err(DecodeError::InvalidValue),
 		}
 	}
 }

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -6,7 +6,7 @@ use ln::msgs;
 use ln::msgs::{HandleError};
 use util::events;
 use util::logger::{Logger, Level, Record};
-use util::ser::Readable;
+use util::ser::{Readable, Writer};
 
 use bitcoin::blockdata::transaction::Transaction;
 
@@ -14,6 +14,17 @@ use secp256k1::PublicKey;
 
 use std::sync::{Arc,Mutex};
 use std::{mem};
+
+struct VecWriter(Vec<u8>);
+impl Writer for VecWriter {
+	fn write_all(&mut self, buf: &[u8]) -> Result<(), ::std::io::Error> {
+		self.0.extend_from_slice(buf);
+		Ok(())
+	}
+	fn size_hint(&mut self, size: usize) {
+		self.0.reserve_exact(size);
+	}
+}
 
 pub struct TestFeeEstimator {
 	pub sat_per_kw: u64,
@@ -40,8 +51,11 @@ impl channelmonitor::ManyChannelMonitor for TestChannelMonitor {
 	fn add_update_monitor(&self, funding_txo: OutPoint, monitor: channelmonitor::ChannelMonitor) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
 		// At every point where we get a monitor update, we should be able to send a useful monitor
 		// to a watchtower and disk...
-		assert!(channelmonitor::ChannelMonitor::read(&mut ::std::io::Cursor::new(&monitor.serialize_for_disk()[..])).unwrap() == monitor);
-		monitor.serialize_for_watchtower(); // This at least shouldn't crash...
+		let mut w = VecWriter(Vec::new());
+		monitor.write_for_disk(&mut w).unwrap();
+		assert!(channelmonitor::ChannelMonitor::read(&mut ::std::io::Cursor::new(&w.0)).unwrap() == monitor);
+		w.0.clear();
+		monitor.write_for_watchtower(&mut w).unwrap(); // This at least shouldn't crash...
 		self.added_monitors.lock().unwrap().push((funding_txo, monitor.clone()));
 		self.simple_monitor.add_update_monitor(funding_txo, monitor)
 	}

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -6,6 +6,7 @@ use ln::msgs;
 use ln::msgs::{HandleError};
 use util::events;
 use util::logger::{Logger, Level, Record};
+use util::ser::Readable;
 
 use bitcoin::blockdata::transaction::Transaction;
 
@@ -39,7 +40,7 @@ impl channelmonitor::ManyChannelMonitor for TestChannelMonitor {
 	fn add_update_monitor(&self, funding_txo: OutPoint, monitor: channelmonitor::ChannelMonitor) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
 		// At every point where we get a monitor update, we should be able to send a useful monitor
 		// to a watchtower and disk...
-		assert!(channelmonitor::ChannelMonitor::deserialize(&monitor.serialize_for_disk()[..]).unwrap() == monitor);
+		assert!(channelmonitor::ChannelMonitor::read(&mut ::std::io::Cursor::new(&monitor.serialize_for_disk()[..])).unwrap() == monitor);
 		monitor.serialize_for_watchtower(); // This at least shouldn't crash...
 		self.added_monitors.lock().unwrap().push((funding_txo, monitor.clone()));
 		self.simple_monitor.add_update_monitor(funding_txo, monitor)


### PR DESCRIPTION
Ok, I really half-assed this one. I wanted to get the API changes out of the way, but internally the functions still do all their own logic, which is dumb, especially considering the serialization framework has a bunch of logic prepped for ChannelMonitors already. Anyway, I assume @yuntai will want to take this over from here and I'll leave it at that.