### PR TITLE
Fix simple to_local revoked output claim and rebase #184

### DIFF
--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -2284,7 +2284,7 @@ mod tests {
 	use rand::{thread_rng,Rng};
 
 	use std::cell::RefCell;
-	use std::collections::HashMap;
+	use std::collections::{BTreeSet, HashMap};
 	use std::default::Default;
 	use std::rc::Rc;
 	use std::sync::{Arc, Mutex};
@@ -3494,6 +3494,74 @@ mod tests {
 		get_announce_close_broadcast_events(&nodes, 0, 1);
 	}
 
+	#[test]
+	fn claim_htlc_outputs_shared_tx() {
+		// Node revoked old state, htlcs haven't time out yet, claim them in shared justice tx
+		let nodes = create_network(2);
+
+		// Create some new channel:
+		let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+		// Rebalance the network to generate htlc in the two directions
+		send_payment(&nodes[0], &vec!(&nodes[1])[..], 8000000);
+		// node[0] is gonna to revoke an old state thus node[1] should be able to claim both offered/received HTLC outputs on top of commitment tx
+		let payment_preimage_1 = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
+		let _payment_preimage_2 = route_payment(&nodes[1], &vec!(&nodes[0])[..], 3000000).0;
+
+		// Get the will-be-revoked local txn from node[0]
+		let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
+		assert_eq!(revoked_local_txn.len(), 2); // commitment tx + 1 HTLC-Timeout tx
+		assert_eq!(revoked_local_txn[0].input.len(), 1);
+		assert_eq!(revoked_local_txn[0].input[0].previous_output.txid, chan_1.3.txid());
+		assert_eq!(revoked_local_txn[1].input.len(), 1);
+		assert_eq!(revoked_local_txn[1].input[0].previous_output.txid, revoked_local_txn[0].txid());
+		assert_eq!(revoked_local_txn[1].input[0].witness.last().unwrap().len(), 133); // HTLC-Timeout
+
+		//Revoke the old state
+		claim_payment(&nodes[0], &vec!(&nodes[1])[..], payment_preimage_1);
+
+		{
+			let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+
+			nodes[0].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone()] }, 1);
+
+			nodes[1].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone()] }, 1);
+			let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
+			assert_eq!(node_txn.len(), 4);
+
+			let mut revoked_tx_map = HashMap::new();
+			revoked_tx_map.insert(revoked_local_txn[0].txid(), revoked_local_txn[0].clone());
+
+			assert_eq!(node_txn[0].input.len(), 3); // Claim the revoked output + both revoked HTLC outputs
+			node_txn[0].verify(&revoked_tx_map).unwrap();
+			assert_eq!(node_txn[0], node_txn[3]); // justice tx is duplicated due to block re-scanning
+
+			let mut witness_lens = BTreeSet::new();
+			witness_lens.insert(node_txn[0].input[0].witness.last().unwrap().len());
+			witness_lens.insert(node_txn[0].input[1].witness.last().unwrap().len());
+			witness_lens.insert(node_txn[0].input[2].witness.last().unwrap().len());
+			assert_eq!(witness_lens.len(), 3);
+			assert_eq!(*witness_lens.iter().skip(0).next().unwrap(), 77); // revoked to_local
+			assert_eq!(*witness_lens.iter().skip(1).next().unwrap(), 133); // revoked offered HTLC
+			assert_eq!(*witness_lens.iter().skip(2).next().unwrap(), 138); // revoked received HTLC
+
+			// Next nodes[1] broadcasts its current local tx state:
+			assert_eq!(node_txn[1].input.len(), 1);
+			assert_eq!(node_txn[1].input[0].previous_output.txid, chan_1.3.txid()); //Spending funding tx unique txouput, tx broadcasted by ChannelManager
+
+			assert_eq!(node_txn[2].input.len(), 1);
+			let witness_script = node_txn[2].clone().input[0].witness.pop().unwrap();
+			assert_eq!(witness_script.len(), 133); //Spending an offered htlc output
+			assert_eq!(node_txn[2].input[0].previous_output.txid, node_txn[1].txid());
+			assert_ne!(node_txn[2].input[0].previous_output.txid, node_txn[0].input[0].previous_output.txid);
+			assert_ne!(node_txn[2].input[0].previous_output.txid, node_txn[0].input[1].previous_output.txid);
+		}
+		get_announce_close_broadcast_events(&nodes, 0, 1);
+		assert_eq!(nodes[0].node.list_channels().len(), 0);
+		assert_eq!(nodes[1].node.list_channels().len(), 0);
+	}
+
+	#[test]
 	fn test_htlc_ignore_latest_remote_commitment() {
 		// Test that HTLC transactions spending the latest remote commitment transaction are simply
 		// ignored if we cannot claim them. This originally tickled an invalid unwrap().

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -856,7 +856,7 @@ impl ChannelMonitor {
 						};
 						let sighash_parts = bip143::SighashComponents::new(&single_htlc_tx);
 						sign_input!(sighash_parts, single_htlc_tx.input[0], Some(idx), htlc.amount_msat / 1000);
-						txn_to_broadcast.push(single_htlc_tx); // TODO: This is not yet tested in ChannelManager!
+						txn_to_broadcast.push(single_htlc_tx);
 					}
 				}
 			}

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -759,7 +759,7 @@ impl ChannelMonitor {
 					ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &per_commitment_point, &htlc_base_key)))
 				},
 			};
-			let delayed_key = ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key), &self.delayed_payment_base_key));
+			let delayed_key = ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key), &self.their_delayed_payment_base_key.unwrap()));
 			let a_htlc_key = match self.their_htlc_base_key {
 				None => return (txn_to_broadcast, (commitment_txid, watch_outputs)),
 				Some(their_htlc_base_key) => ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, &PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key), &their_htlc_base_key)),


### PR DESCRIPTION
In review of #184 the tests looked funky and it turned out we were incorrectly claiming revoked to_local outputs. FIrst commit fixes it, then follows a rebase of #184 with the fixes required separated out so its easier to review the differences (I'll squash them before merge).