### PR TITLE
Introduce a Channel-specific Err type and return it in a few places

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -2648,15 +2648,15 @@ impl Channel {
 	/// closing).
 	/// Note that the "channel must be funded" requirement is stricter than BOLT 7 requires - see
 	/// https://github.com/lightningnetwork/lightning-rfc/issues/468
-	pub fn get_channel_announcement(&self, our_node_id: PublicKey, chain_hash: Sha256dHash) -> Result<(msgs::UnsignedChannelAnnouncement, Signature), HandleError> {
+	pub fn get_channel_announcement(&self, our_node_id: PublicKey, chain_hash: Sha256dHash) -> Result<(msgs::UnsignedChannelAnnouncement, Signature), ChannelError> {
 		if !self.announce_publicly {
-			return Err(HandleError{err: "Channel is not available for public announcements", action: Some(msgs::ErrorAction::IgnoreError)});
+			return Err(ChannelError::Ignore("Channel is not available for public announcements"));
 		}
 		if self.channel_state & (ChannelState::ChannelFunded as u32) == 0 {
-			return Err(HandleError{err: "Cannot get a ChannelAnnouncement until the channel funding has been locked", action: Some(msgs::ErrorAction::IgnoreError)});
+			return Err(ChannelError::Ignore("Cannot get a ChannelAnnouncement until the channel funding has been locked"));
 		}
 		if (self.channel_state & (ChannelState::LocalShutdownSent as u32 | ChannelState::ShutdownComplete as u32)) != 0 {
-			return Err(HandleError{err: "Cannot get a ChannelAnnouncement once the channel is closing", action: Some(msgs::ErrorAction::IgnoreError)});
+			return Err(ChannelError::Ignore("Cannot get a ChannelAnnouncement once the channel is closing"));
 		}
 
 		let were_node_one = our_node_id.serialize()[..] < self.their_node_id.serialize()[..];

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1973,7 +1973,8 @@ impl ChannelManager {
 					if chan.get_their_node_id() != *their_node_id {
 						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!", msg.channel_id));
 					}
-					let (funding_locked, revoke_and_ack, commitment_update, channel_monitor) = chan.channel_reestablish(msg).map_err(|e| MsgHandleErrInternal::from_maybe_close(e))?;
+					let (funding_locked, revoke_and_ack, commitment_update, channel_monitor) = chan.channel_reestablish(msg)
+						.map_err(|e| MsgHandleErrInternal::from_chan_maybe_close(e, msg.channel_id))?;
 					(Ok((funding_locked, revoke_and_ack, commitment_update)), channel_monitor)
 				},
 				None => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel", msg.channel_id))

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1525,7 +1525,8 @@ impl ChannelManager {
 						//TODO: see issue #153, need a consistent behavior on obnoxious behavior from random node
 						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!", msg.temporary_channel_id));
 					}
-					chan.accept_channel(&msg).map_err(|e| MsgHandleErrInternal::from_maybe_close(e))?;
+					chan.accept_channel(&msg)
+						.map_err(|e| MsgHandleErrInternal::from_chan_maybe_close(e, msg.temporary_channel_id))?;
 					(chan.get_value_satoshis(), chan.get_funding_redeemscript().to_v0_p2wsh(), chan.get_user_id())
 				},
 				//TODO: same as above

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1616,7 +1616,8 @@ impl ChannelManager {
 					//TODO: here and below MsgHandleErrInternal, #153 case
 					return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!", msg.channel_id));
 				}
-				chan.funding_locked(&msg).map_err(|e| MsgHandleErrInternal::from_maybe_close(e))?;
+				chan.funding_locked(&msg)
+					.map_err(|e| MsgHandleErrInternal::from_chan_maybe_close(e, msg.channel_id))?;
 				return Ok(self.get_announcement_sigs(chan));
 			},
 			None => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel", msg.channel_id))

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1939,7 +1939,7 @@ impl ChannelManager {
 
 					let our_node_id = self.get_our_node_id();
 					let (announcement, our_bitcoin_sig) = chan.get_channel_announcement(our_node_id.clone(), self.genesis_hash.clone())
-						.map_err(|e| MsgHandleErrInternal::from_maybe_close(e))?;
+						.map_err(|e| MsgHandleErrInternal::from_chan_maybe_close(e, msg.channel_id))?;
 
 					let were_node_one = announcement.node_id_1 == our_node_id;
 					let msghash = Message::from_slice(&Sha256dHash::from_data(&announcement.encode()[..])[..]).unwrap();


### PR DESCRIPTION
This is way simpler than writing out the whole ErrorAction mess and we can just convert it as appropriate in ChannelManager. This may make #153 a bit easier to address - by using an intermediate Err type we can just say "fail this channel, but ChannelManager can figure out if we should ban/disconnect/etc based on whether we have other channels with this peer". It also has no Options for actions, which steps us forward on #129 for BOLT 2 as we migrate to it.