### PR TITLE
Handle initial_routing_sync requests from peers in their Init messages (issue 148)

### DIFF
--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -3,7 +3,7 @@ use chain::chaininterface::ConfirmationTarget;
 use chain::transaction::OutPoint;
 use ln::channelmonitor;
 use ln::msgs;
-use ln::msgs::{HandleError};
+use ln::msgs::{HandleError, InitSyncTracker};
 use util::events;
 use util::logger::{Logger, Level, Record};
 use util::ser::{ReadableArgs, Writer};
@@ -157,7 +157,6 @@ impl TestRoutingMessageHandler {
 		TestRoutingMessageHandler {}
 	}
 }
-
 impl msgs::RoutingMessageHandler for TestRoutingMessageHandler {
 	fn handle_node_announcement(&self, _msg: &msgs::NodeAnnouncement) -> Result<bool, HandleError> {
 		Err(HandleError { err: "", action: None })
@@ -169,6 +168,12 @@ impl msgs::RoutingMessageHandler for TestRoutingMessageHandler {
 		Err(HandleError { err: "", action: None })
 	}
 	fn handle_htlc_fail_channel_update(&self, _update: &msgs::HTLCFailChannelUpdate) {}
+	fn get_next_channel_announcements(&self, _starting_point: &mut InitSyncTracker, _batch_amount: u8)->(Vec<(msgs::ChannelAnnouncement, msgs::ChannelUpdate,msgs::ChannelUpdate)>){
+		Vec::new()
+	}
+	fn get_next_node_announcements(&self, _starting_point: &mut InitSyncTracker, _batch_amount: u8)->(Vec<msgs::NodeAnnouncement>){
+		Vec::new()
+	}
 }
 
 pub struct TestLogger {


### PR DESCRIPTION
I have made an initial outline for #148.
Although the code currently sits in router, I am thinking of doing it the same way as router and channelmanger is linked to peer_handler. 

There is two ways we can do this, one through a new independent trait,  which means that peer_handler will have two ref to router. 
Or we replace MessageHandler.route_handler with a trait that incorporates RoutingMessagerHandler and NetworkAPI.  