### PR TITLE
Fix channel_reestablish exchanging in case of lost messages

### DIFF
--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -224,6 +224,7 @@ pub struct FundingSigned {
 }
 
 /// A funding_locked message to be sent or received from a peer
+#[derive(Clone)]
 pub struct FundingLocked {
 	pub(crate) channel_id: [u8; 32],
 	pub(crate) next_per_commitment_point: PublicKey,

--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -60,6 +60,8 @@ pub enum Event {
 	},
 	/// Indicates an outbound payment we made succeeded (ie it made it all the way to its target
 	/// and we got back the payment preimage for it).
+	/// Note that duplicative PaymentSent Events may be generated - it is your responsibility to
+	/// deduplicate them by payment_preimage (which MUST be unique)!
 	PaymentSent {
 		/// The preimage to the hash given to ChannelManager::send_payment.
 		/// Note that this serves as a payment receipt, if you wish to have such a thing, you must
@@ -68,6 +70,8 @@ pub enum Event {
 	},
 	/// Indicates an outbound payment we made failed. Probably some intermediary node dropped
 	/// something. You may wish to retry with a different route.
+	/// Note that duplicative PaymentFailed Events may be generated - it is your responsibility to
+	/// deduplicate them by payment_hash (which MUST be unique)!
 	PaymentFailed {
 		/// The hash which was given to ChannelManager::send_payment.
 		payment_hash: [u8; 32],


### PR DESCRIPTION
This uses some new storage in HTLC state enums to reproduce the
various updates in a CommitmentUpdate group which is obviously
required to re-send a commitment_update after pending unreceived
updates were dropped.

Does not yet handle dropped update_fee updates properly.