### PR TITLE
Fix reconnect message order on remote updates while waiting on RAA

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -296,6 +296,12 @@ pub(super) struct Channel {
 	cur_local_commitment_transaction_number: u64,
 	cur_remote_commitment_transaction_number: u64,
 	value_to_self_msat: u64, // Excluding all pending_htlcs, excluding fees
+	/// Upon receipt of a channel_reestablish we have to figure out whether to send a
+	/// revoke_and_ack first or a commitment update first. Generally, we prefer to send
+	/// revoke_and_ack first, but if we had a pending commitment update of our own waiting on a
+	/// remote revoke when we received the latest commitment update from the remote we have to make
+	/// sure that commitment update gets resent first.
+	received_commitment_while_awaiting_raa: bool,
 	pending_inbound_htlcs: Vec<InboundHTLCOutput>,
 	pending_outbound_htlcs: Vec<OutboundHTLCOutput>,
 	holding_cell_htlc_updates: Vec<HTLCUpdateAwaitingACK>,
@@ -492,6 +498,8 @@ impl Channel {
 			cur_local_commitment_transaction_number: INITIAL_COMMITMENT_NUMBER,
 			cur_remote_commitment_transaction_number: INITIAL_COMMITMENT_NUMBER,
 			value_to_self_msat: channel_value_satoshis * 1000 - push_msat,
+			received_commitment_while_awaiting_raa: false,
+
 			pending_inbound_htlcs: Vec::new(),
 			pending_outbound_htlcs: Vec::new(),
 			holding_cell_htlc_updates: Vec::new(),
@@ -647,6 +655,8 @@ impl Channel {
 			cur_local_commitment_transaction_number: INITIAL_COMMITMENT_NUMBER,
 			cur_remote_commitment_transaction_number: INITIAL_COMMITMENT_NUMBER,
 			value_to_self_msat: msg.push_msat,
+			received_commitment_while_awaiting_raa: false,
+
 			pending_inbound_htlcs: Vec::new(),
 			pending_outbound_htlcs: Vec::new(),
 			holding_cell_htlc_updates: Vec::new(),
@@ -1696,6 +1706,7 @@ impl Channel {
 
 		self.cur_local_commitment_transaction_number -= 1;
 		self.last_local_commitment_txn = new_local_commitment_txn;
+		self.received_commitment_while_awaiting_raa = (self.channel_state & (ChannelState::AwaitingRemoteRevoke as u32)) != 0;
 
 		let (our_commitment_signed, monitor_update) = if need_our_commitment && (self.channel_state & (ChannelState::AwaitingRemoteRevoke as u32)) == 0 {
 			// If we're AwaitingRemoteRevoke we can't send a new commitment here, but that's ok -
@@ -1831,6 +1842,7 @@ impl Channel {
 		self.their_prev_commitment_point = self.their_cur_commitment_point;
 		self.their_cur_commitment_point = Some(msg.next_per_commitment_point);
 		self.cur_remote_commitment_transaction_number -= 1;
+		self.received_commitment_while_awaiting_raa = false;
 
 		let mut to_forward_infos = Vec::new();
 		let mut revoked_htlcs = Vec::new();
@@ -2120,7 +2132,11 @@ impl Channel {
 			})
 		} else { None };
 
-		let order = RAACommitmentOrder::RevokeAndACKFirst;
+		let order = if self.received_commitment_while_awaiting_raa {
+			RAACommitmentOrder::CommitmentFirst
+		} else {
+			RAACommitmentOrder::RevokeAndACKFirst
+		};
 
 		if msg.next_local_commitment_number == our_next_remote_commitment_number {
 			if required_revoke.is_some() {

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -500,6 +500,18 @@ pub enum HTLCFailChannelUpdate {
 	}
 }
 
+/// For events which result in both a RevokeAndACK and a CommitmentUpdate, by default they should
+/// be sent in the order they appear in the return value, however sometimes the order needs to be
+/// variable at runtime (eg handle_channel_reestablish needs to re-send messages in the order they
+/// were originally sent). In those cases, this enum is also returned.
+#[derive(Clone, PartialEq)]
+pub enum RAACommitmentOrder {
+	/// Send the CommitmentUpdate messages first
+	CommitmentFirst,
+	/// Send the RevokeAndACK message first
+	RevokeAndACKFirst,
+}
+
 /// A trait to describe an object which can receive channel messages.
 ///
 /// Messages MAY be called in parallel when they originate from different their_node_ids, however
@@ -554,7 +566,7 @@ pub trait ChannelMessageHandler : events::EventsProvider + Send + Sync {
 	/// Handle a peer reconnecting, possibly generating channel_reestablish message(s).
 	fn peer_connected(&self, their_node_id: &PublicKey) -> Vec<ChannelReestablish>;
 	/// Handle an incoming channel_reestablish message from the given peer.
-	fn handle_channel_reestablish(&self, their_node_id: &PublicKey, msg: &ChannelReestablish) -> Result<(Option<FundingLocked>, Option<RevokeAndACK>, Option<CommitmentUpdate>), HandleError>;
+	fn handle_channel_reestablish(&self, their_node_id: &PublicKey, msg: &ChannelReestablish) -> Result<(Option<FundingLocked>, Option<RevokeAndACK>, Option<CommitmentUpdate>, RAACommitmentOrder), HandleError>;
 
 	// Error:
 	/// Handle an incoming error message from the given peer.

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -658,30 +658,44 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 											},
 											136 => {
 												let msg = try_potential_decodeerror!(msgs::ChannelReestablish::read(&mut reader));
-												let (funding_locked, revoke_and_ack, commitment_update) = try_potential_handleerror!(self.message_handler.chan_handler.handle_channel_reestablish(&peer.their_node_id.unwrap(), &msg));
+												let (funding_locked, revoke_and_ack, commitment_update, order) = try_potential_handleerror!(self.message_handler.chan_handler.handle_channel_reestablish(&peer.their_node_id.unwrap(), &msg));
 												if let Some(lock_msg) = funding_locked {
 													encode_and_send_msg!(lock_msg, 36);
 												}
-												if let Some(revoke_msg) = revoke_and_ack {
-													encode_and_send_msg!(revoke_msg, 133);
-												}
-												match commitment_update {
-													Some(resps) => {
-														for resp in resps.update_add_htlcs {
-															encode_and_send_msg!(resp, 128);
-														}
-														for resp in resps.update_fulfill_htlcs {
-															encode_and_send_msg!(resp, 130);
-														}
-														for resp in resps.update_fail_htlcs {
-															encode_and_send_msg!(resp, 131);
-														}
-														if let Some(resp) = resps.update_fee {
-															encode_and_send_msg!(resp, 134);
-														}
-														encode_and_send_msg!(resps.commitment_signed, 132);
+												macro_rules! handle_raa { () => {
+													if let Some(revoke_msg) = revoke_and_ack {
+														encode_and_send_msg!(revoke_msg, 133);
+													}
+												} }
+												macro_rules! handle_cu { () => {
+													match commitment_update {
+														Some(resps) => {
+															for resp in resps.update_add_htlcs {
+																encode_and_send_msg!(resp, 128);
+															}
+															for resp in resps.update_fulfill_htlcs {
+																encode_and_send_msg!(resp, 130);
+															}
+															for resp in resps.update_fail_htlcs {
+																encode_and_send_msg!(resp, 131);
+															}
+															if let Some(resp) = resps.update_fee {
+																encode_and_send_msg!(resp, 134);
+															}
+															encode_and_send_msg!(resps.commitment_signed, 132);
+														},
+														None => {},
+													}
+												} }
+												match order {
+													msgs::RAACommitmentOrder::RevokeAndACKFirst => {
+														handle_raa!();
+														handle_cu!();
 													},
-													None => {},
+													msgs::RAACommitmentOrder::CommitmentFirst => {
+														handle_cu!();
+														handle_raa!();
+													},
 												}
 											},
 

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -128,7 +128,7 @@ impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
 	fn handle_announcement_signatures(&self, _their_node_id: &PublicKey, _msg: &msgs::AnnouncementSignatures) -> Result<(), HandleError> {
 		Err(HandleError { err: "", action: None })
 	}
-	fn handle_channel_reestablish(&self, _their_node_id: &PublicKey, _msg: &msgs::ChannelReestablish) -> Result<(Option<msgs::FundingLocked>, Option<msgs::RevokeAndACK>, Option<msgs::CommitmentUpdate>), HandleError> {
+	fn handle_channel_reestablish(&self, _their_node_id: &PublicKey, _msg: &msgs::ChannelReestablish) -> Result<(Option<msgs::FundingLocked>, Option<msgs::RevokeAndACK>, Option<msgs::CommitmentUpdate>, msgs::RAACommitmentOrder), HandleError> {
 		Err(HandleError { err: "", action: None })
 	}
 	fn peer_disconnected(&self, _their_node_id: &PublicKey, _no_connection_possible: bool) {}


### PR DESCRIPTION
Based on #211.

Kinda an annoying-sized patch, but the RAACommitmentOrder stuff is gonna have to happen for #61 anyway.