### PR TITLE
Fix XXXs that slipped into router and handle HTLCFailCHannelUpdates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - 1.22.0
+  - 1.29.2
 cache: cargo
 
 before_install:
@@ -12,4 +13,4 @@ before_install:
 script:
   - cargo build --verbose
   - cargo test --verbose
-  - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi
+  - if [ "$(rustup show | grep default | grep 1.29.2)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi


### PR DESCRIPTION
I usually use XXXs to indicate TODOs pre-commit/merge, but things are kinda in a rush for 0.0.6...oh well.