### PR TITLE
Add PaymentFailReason enum for fail_htlc_backwards

### DIFF
--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -15,7 +15,7 @@ use crypto::digest::Digest;
 use lightning::chain::chaininterface::{BroadcasterInterface,ConfirmationTarget,ChainListener,FeeEstimator,ChainWatchInterfaceUtil};
 use lightning::chain::transaction::OutPoint;
 use lightning::ln::channelmonitor;
-use lightning::ln::channelmanager::ChannelManager;
+use lightning::ln::channelmanager::{ChannelManager, PaymentFailReason};
 use lightning::ln::peer_handler::{MessageHandler,PeerManager,SocketDescriptor};
 use lightning::ln::router::Router;
 use lightning::util::events::{EventsProvider,Event};
@@ -337,7 +337,7 @@ pub fn do_test(data: &[u8], logger: &Arc<Logger>) {
 					// fulfill this HTLC, but if they are, we can just take the first byte and
 					// place that anywhere in our preimage.
 					if &payment[1..] != &[0; 31] {
-						channelmanager.fail_htlc_backwards(&payment);
+						channelmanager.fail_htlc_backwards(&payment, PaymentFailReason::PreimageUnknown);
 					} else {
 						let mut payment_preimage = [0; 32];
 						payment_preimage[0] = payment[0];
@@ -347,7 +347,7 @@ pub fn do_test(data: &[u8], logger: &Arc<Logger>) {
 			},
 			9 => {
 				for payment in payments_received.drain(..) {
-					channelmanager.fail_htlc_backwards(&payment);
+					channelmanager.fail_htlc_backwards(&payment, PaymentFailReason::PreimageUnknown);
 				}
 			},
 			10 => {

--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -50,8 +50,11 @@ pub enum Event {
 	},
 	/// Indicates we've received money! Just gotta dig out that payment preimage and feed it to
 	/// ChannelManager::claim_funds to get it....
-	/// Note that if the preimage is not known, you must call ChannelManager::fail_htlc_backwards
-	/// to free up resources for this HTLC.
+	/// Note that if the preimage is not known or the amount paid is incorrect, you must call 
+	/// ChannelManager::fail_htlc_backwards with PaymentFailReason::PreimageUnknown or 
+	/// PaymentFailReason::AmountMismatch, respectively, to free up resources for this HTLC.
+	/// The amount paid should be considered 'incorrect' when it is less than or more than twice the
+	/// amount expected. 
 	PaymentReceived {
 		/// The hash for which the preimage should be handed to the ChannelManager.
 		payment_hash: [u8; 32],


### PR DESCRIPTION
to indicate failure reason after a PaymentReceived event.

and set onion error code to unknown_payment_hash or incorrect_payment_amount.

The test will come with the sequel of #219.