### PR TITLE
Handle sizeable push msat (fix #195) + handle two first per_commitment_point + keys interface tests

### DIFF
--- a/src/chain/keysinterface.rs
+++ b/src/chain/keysinterface.rs
@@ -50,6 +50,8 @@ pub enum SpendableOutputDescriptor {
 		witness_script: Script,
 		/// nSequence input must commit to self_delay to satisfy script's OP_CSV
 		to_self_delay: u16,
+		/// The output which is referenced by the given outpoint
+		output: TxOut,
 	}
 }
 

--- a/src/chain/keysinterface.rs
+++ b/src/chain/keysinterface.rs
@@ -37,20 +37,33 @@ pub enum SpendableOutputDescriptor {
 		/// The output which is referenced by the given outpoint
 		output: TxOut,
 	},
-	/// Outpoint commits to a P2WSH, should be spend by the following witness :
+	/// Outpoint commits to a P2WSH
+	/// P2WSH should be spend by the following witness :
 	/// <local_delayedsig> 0 <witnessScript>
 	/// With input nSequence set to_self_delay.
-	/// Outputs from a HTLC-Success/Timeout tx
-	DynamicOutput {
+	/// Outputs from a HTLC-Success/Timeout tx/commitment tx
+	DynamicOutputP2WSH {
 		/// Outpoint spendable by user wallet
 		outpoint: OutPoint,
-		/// local_delayedkey = delayed_payment_basepoint_secret + SHA256(per_commitment_point || delayed_payment_basepoint)
-		local_delayedkey: SecretKey,
-		/// witness redeemScript encumbering output
+		/// local_delayedkey = delayed_payment_basepoint_secret + SHA256(per_commitment_point || delayed_payment_basepoint) OR
+		key: SecretKey,
+		/// witness redeemScript encumbering output.
 		witness_script: Script,
 		/// nSequence input must commit to self_delay to satisfy script's OP_CSV
 		to_self_delay: u16,
 		/// The output which is referenced by the given outpoint
+		output: TxOut,
+	},
+	/// Outpoint commits to a P2WPKH
+	/// P2WPKH should be spend by the following witness :
+	/// <local_sig> <local_pubkey>
+	/// Outputs to_remote from a commitment tx
+	DynamicOutputP2WPKH {
+		/// Outpoint spendable by user wallet
+		outpoint: OutPoint,
+		/// localkey = payment_basepoint_secret + SHA256(per_commitment_point || payment_basepoint
+		key: SecretKey,
+		/// The output which is reference by the given outpoint
 		output: TxOut,
 	}
 }

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -436,7 +436,7 @@ impl Channel {
 
 		let secp_ctx = Secp256k1::new();
 		let channel_monitor = ChannelMonitor::new(&chan_keys.revocation_base_key, &chan_keys.delayed_payment_base_key,
-		                                          &chan_keys.htlc_base_key, &chan_keys.payment_base_key, BREAKDOWN_TIMEOUT,
+		                                          &chan_keys.htlc_base_key, &chan_keys.payment_base_key, &keys_provider.get_shutdown_pubkey(), BREAKDOWN_TIMEOUT,
 		                                          keys_provider.get_destination_script(), logger.clone());
 
 		Ok(Channel {
@@ -624,7 +624,7 @@ impl Channel {
 
 		let secp_ctx = Secp256k1::new();
 		let mut channel_monitor = ChannelMonitor::new(&chan_keys.revocation_base_key, &chan_keys.delayed_payment_base_key,
-		                                              &chan_keys.htlc_base_key, &chan_keys.payment_base_key, BREAKDOWN_TIMEOUT,
+		                                              &chan_keys.htlc_base_key, &chan_keys.payment_base_key, &keys_provider.get_shutdown_pubkey(), BREAKDOWN_TIMEOUT,
 		                                              keys_provider.get_destination_script(), logger.clone());
 		channel_monitor.set_their_base_keys(&msg.htlc_basepoint, &msg.delayed_payment_basepoint);
 		channel_monitor.provide_their_next_revocation_point(Some((INITIAL_COMMITMENT_NUMBER, msg.first_per_commitment_point)));

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -436,7 +436,7 @@ impl Channel {
 
 		let secp_ctx = Secp256k1::new();
 		let channel_monitor = ChannelMonitor::new(&chan_keys.revocation_base_key, &chan_keys.delayed_payment_base_key,
-		                                          &chan_keys.htlc_base_key, BREAKDOWN_TIMEOUT,
+		                                          &chan_keys.htlc_base_key, &chan_keys.payment_base_key, BREAKDOWN_TIMEOUT,
 		                                          keys_provider.get_destination_script(), logger.clone());
 
 		Ok(Channel {
@@ -624,7 +624,7 @@ impl Channel {
 
 		let secp_ctx = Secp256k1::new();
 		let mut channel_monitor = ChannelMonitor::new(&chan_keys.revocation_base_key, &chan_keys.delayed_payment_base_key,
-		                                              &chan_keys.htlc_base_key, BREAKDOWN_TIMEOUT,
+		                                              &chan_keys.htlc_base_key, &chan_keys.payment_base_key, BREAKDOWN_TIMEOUT,
 		                                              keys_provider.get_destination_script(), logger.clone());
 		channel_monitor.set_their_base_keys(&msg.htlc_basepoint, &msg.delayed_payment_basepoint);
 		channel_monitor.provide_their_next_revocation_point(Some((INITIAL_COMMITMENT_NUMBER, msg.first_per_commitment_point)));

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -7813,4 +7813,99 @@ mod tests {
 		let spend_tx = check_static_output!(events, nodes, 0, 0, 1, 1);
 		check_spends!(spend_tx, node_txn[0].clone());
 	}
+
+	#[test]
+	fn test_static_spendable_outputs_justice_tx_revoked_htlc_timeout_tx() {
+		let nodes = create_network(2);
+
+		// Create some initial channels
+		let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+		let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
+		let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
+		assert_eq!(revoked_local_txn[0].input.len(), 1);
+		assert_eq!(revoked_local_txn[0].input[0].previous_output.txid, chan_1.3.txid());
+
+		claim_payment(&nodes[0], &vec!(&nodes[1])[..], payment_preimage);
+
+		let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		// A will generate HTLC-Timeout from revoked commitment tx
+		nodes[0].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone()] }, 1);
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+		let revoked_htlc_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(revoked_htlc_txn.len(), 2);
+		assert_eq!(revoked_htlc_txn[0].input.len(), 1);
+		assert_eq!(revoked_htlc_txn[0].input[0].witness.last().unwrap().len(), 133);
+		check_spends!(revoked_htlc_txn[0], revoked_local_txn[0].clone());
+
+		// B will generate justice tx from A's revoked commitment/HTLC tx
+		nodes[1].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone(), revoked_htlc_txn[0].clone()] }, 1);
+		let events = nodes[1].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+
+		let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 4);
+		assert_eq!(node_txn[3].input.len(), 1);
+		check_spends!(node_txn[3], revoked_htlc_txn[0].clone());
+
+		let events = nodes[1].chan_monitor.simple_monitor.get_and_clear_pending_events();
+		// Check B's ChannelMonitor was able to generate the right spendable output descriptor
+		let spend_tx = check_static_output!(events, nodes, 1, 1, 1, 1);
+		check_spends!(spend_tx, node_txn[3].clone());
+	}
+
+	#[test]
+	fn test_static_spendable_outputs_justice_tx_revoked_htlc_success_tx() {
+		let nodes = create_network(2);
+
+		// Create some initial channels
+		let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+		let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
+		let revoked_local_txn = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
+		assert_eq!(revoked_local_txn[0].input.len(), 1);
+		assert_eq!(revoked_local_txn[0].input[0].previous_output.txid, chan_1.3.txid());
+
+		claim_payment(&nodes[0], &vec!(&nodes[1])[..], payment_preimage);
+
+		let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		// B will generate HTLC-Success from revoked commitment tx
+		nodes[1].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone()] }, 1);
+		let events = nodes[1].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+		let revoked_htlc_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
+
+		assert_eq!(revoked_htlc_txn.len(), 2);
+		assert_eq!(revoked_htlc_txn[0].input.len(), 1);
+		assert_eq!(revoked_htlc_txn[0].input[0].witness.last().unwrap().len(), 138);
+		check_spends!(revoked_htlc_txn[0], revoked_local_txn[0].clone());
+
+		// A will generate justice tx from B's revoked commitment/HTLC tx
+		nodes[0].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![revoked_local_txn[0].clone(), revoked_htlc_txn[0].clone()] }, 1);
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+
+		let node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 4);
+		assert_eq!(node_txn[3].input.len(), 1);
+		check_spends!(node_txn[3], revoked_htlc_txn[0].clone());
+
+		let events = nodes[0].chan_monitor.simple_monitor.get_and_clear_pending_events();
+		// Check A's ChannelMonitor was able to generate the right spendable output descriptor
+		let spend_tx = check_static_output!(events, nodes, 1, 2, 1, 0);
+		check_spends!(spend_tx, node_txn[3].clone());
+	}
 }

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -7908,4 +7908,75 @@ mod tests {
 		let spend_tx = check_static_output!(events, nodes, 1, 2, 1, 0);
 		check_spends!(spend_tx, node_txn[3].clone());
 	}
+
+	#[test]
+	fn test_dynamic_spendable_outputs_local_htlc_success_tx() {
+		let nodes = create_network(2);
+
+		// Create some initial channels
+		let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+		let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 9000000).0;
+		let local_txn = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
+		assert_eq!(local_txn[0].input.len(), 1);
+		check_spends!(local_txn[0], chan_1.3.clone());
+
+		// Give B knowledge of preimage to be able to generate a local HTLC-Success Tx
+		nodes[1].node.claim_funds(payment_preimage);
+		check_added_monitors!(nodes[1], 1);
+		let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		nodes[1].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![local_txn[0].clone()] }, 1);
+		let events = nodes[1].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::UpdateHTLCs { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+		match events[1] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexepected event"),
+		}
+		let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn[0].input.len(), 1);
+		assert_eq!(node_txn[0].input[0].witness.last().unwrap().len(), 138);
+		check_spends!(node_txn[0], local_txn[0].clone());
+
+		// Verify that B is able to spend its own HTLC-Success tx thanks to spendable output event given back by its ChannelMonitor
+		let spend_txn = check_dynamic_output_p2wsh!(nodes[1]);
+		assert_eq!(spend_txn.len(), 1);
+		check_spends!(spend_txn[0], node_txn[0].clone());
+	}
+
+	#[test]
+	fn test_dynamic_spendable_outputs_local_htlc_timeout_tx() {
+		let nodes = create_network(2);
+
+		// Create some initial channels
+		let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+
+		route_payment(&nodes[0], &vec!(&nodes[1])[..], 9000000).0;
+		let local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
+		assert_eq!(local_txn[0].input.len(), 1);
+		check_spends!(local_txn[0], chan_1.3.clone());
+
+		// Timeout HTLC on A's chain and so it can generate a HTLC-Timeout tx
+		let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		nodes[0].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![local_txn[0].clone()] }, 200);
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexepected event"),
+		}
+		let node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn[0].input.len(), 1);
+		assert_eq!(node_txn[0].input[0].witness.last().unwrap().len(), 133);
+		check_spends!(node_txn[0], local_txn[0].clone());
+
+		// Verify that A is able to spend its own HTLC-Timeout tx thanks to spendable output event given back by its ChannelMonitor
+		let spend_txn = check_dynamic_output_p2wsh!(nodes[0]);
+		assert_eq!(spend_txn.len(), 4);
+		assert_eq!(spend_txn[0], spend_txn[2]);
+		assert_eq!(spend_txn[1], spend_txn[3]);
+		check_spends!(spend_txn[0], local_txn[0].clone());
+		check_spends!(spend_txn[1], node_txn[0].clone());
+	}
 }

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -7711,6 +7711,38 @@ mod tests {
 	}
 
 	#[test]
+	fn test_claim_on_remote_sizeable_push_msat() {
+		// Same test as precedent, just test on remote commitment tx, as per_commitment_point registration changes following you're funder/fundee and
+		// to_remote output is encumbered by a P2WPKH
+
+		let nodes = create_network(2);
+
+		let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000);
+		nodes[0].node.force_close_channel(&chan.2);
+		let events = nodes[0].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+		let node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 1);
+		check_spends!(node_txn[0], chan.3.clone());
+		assert_eq!(node_txn[0].output.len(), 2); // We can't force trimming of to_remote output as channel_reserve_satoshis block us to do so at channel opening
+
+		let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		nodes[1].chain_monitor.block_connected_with_filtering(&Block { header, txdata: vec![node_txn[0].clone()] }, 0);
+		let events = nodes[1].node.get_and_clear_pending_msg_events();
+		match events[0] {
+			MessageSendEvent::BroadcastChannelUpdate { .. } => {},
+			_ => panic!("Unexpected event"),
+		}
+		let spend_txn = check_dynamic_output_p2wpkh!(nodes[1]);
+		assert_eq!(spend_txn.len(), 2);
+		assert_eq!(spend_txn[0], spend_txn[1]);
+		check_spends!(spend_txn[0], node_txn[0].clone());
+	}
+
+	#[test]
 	fn test_static_spendable_outputs_preimage_tx() {
 		let nodes = create_network(2);
 

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -1239,7 +1239,8 @@ impl ChannelMonitor {
 								outpoint: BitcoinOutPoint { txid: $father_tx.txid(), vout: $vout },
 								local_delayedkey,
 								witness_script: chan_utils::get_revokeable_redeemscript(&local_tx.revocation_key, self.our_to_self_delay, &local_tx.delayed_payment_key),
-								to_self_delay: self.our_to_self_delay
+								to_self_delay: self.our_to_self_delay,
+								output: $father_tx.output[$vout as usize].clone(),
 							});
 						}
 					}

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -219,6 +219,7 @@ enum KeyStorage {
 		revocation_base_key: SecretKey,
 		htlc_base_key: SecretKey,
 		delayed_payment_base_key: SecretKey,
+		payment_base_key: SecretKey,
 		prev_latest_per_commitment_point: Option<PublicKey>,
 		latest_per_commitment_point: Option<PublicKey>,
 	},
@@ -338,7 +339,7 @@ impl PartialEq for ChannelMonitor {
 }
 
 impl ChannelMonitor {
-	pub(super) fn new(revocation_base_key: &SecretKey, delayed_payment_base_key: &SecretKey, htlc_base_key: &SecretKey, our_to_self_delay: u16, destination_script: Script, logger: Arc<Logger>) -> ChannelMonitor {
+	pub(super) fn new(revocation_base_key: &SecretKey, delayed_payment_base_key: &SecretKey, htlc_base_key: &SecretKey, payment_base_key: &SecretKey, our_to_self_delay: u16, destination_script: Script, logger: Arc<Logger>) -> ChannelMonitor {
 		ChannelMonitor {
 			funding_txo: None,
 			commitment_transaction_number_obscure_factor: 0,
@@ -347,6 +348,7 @@ impl ChannelMonitor {
 				revocation_base_key: revocation_base_key.clone(),
 				htlc_base_key: htlc_base_key.clone(),
 				delayed_payment_base_key: delayed_payment_base_key.clone(),
+				payment_base_key: payment_base_key.clone(),
 				prev_latest_per_commitment_point: None,
 				latest_per_commitment_point: None,
 			},
@@ -510,11 +512,12 @@ impl ChannelMonitor {
 			feerate_per_kw,
 			htlc_outputs,
 		});
-		self.key_storage = if let KeyStorage::PrivMode { ref revocation_base_key, ref htlc_base_key, ref delayed_payment_base_key, prev_latest_per_commitment_point: _, ref latest_per_commitment_point } = self.key_storage {
+		self.key_storage = if let KeyStorage::PrivMode { ref revocation_base_key, ref htlc_base_key, ref delayed_payment_base_key, ref payment_base_key, ref latest_per_commitment_point, .. } = self.key_storage {
 			KeyStorage::PrivMode {
 				revocation_base_key: *revocation_base_key,
 				htlc_base_key: *htlc_base_key,
 				delayed_payment_base_key: *delayed_payment_base_key,
+				payment_base_key: *payment_base_key,
 				prev_latest_per_commitment_point: *latest_per_commitment_point,
 				latest_per_commitment_point: Some(local_keys.per_commitment_point),
 			}
@@ -640,11 +643,12 @@ impl ChannelMonitor {
 		U48(self.commitment_transaction_number_obscure_factor).write(writer)?;
 
 		match self.key_storage {
-			KeyStorage::PrivMode { ref revocation_base_key, ref htlc_base_key, ref delayed_payment_base_key, ref prev_latest_per_commitment_point, ref latest_per_commitment_point } => {
+			KeyStorage::PrivMode { ref revocation_base_key, ref htlc_base_key, ref delayed_payment_base_key, ref payment_base_key, ref prev_latest_per_commitment_point, ref latest_per_commitment_point } => {
 				writer.write_all(&[0; 1])?;
 				writer.write_all(&revocation_base_key[..])?;
 				writer.write_all(&htlc_base_key[..])?;
 				writer.write_all(&delayed_payment_base_key[..])?;
+				writer.write_all(&payment_base_key[..])?;
 				if let Some(ref prev_latest_per_commitment_point) = *prev_latest_per_commitment_point {
 					writer.write_all(&[1; 1])?;
 					writer.write_all(&prev_latest_per_commitment_point.serialize())?;
@@ -909,7 +913,23 @@ impl ChannelMonitor {
 					htlc_idxs.push(None);
 					values.push(outp.value);
 					total_value += outp.value;
-					break; // There can only be one of these
+				} else if outp.script_pubkey.is_v0_p2wpkh() {
+					match self.key_storage {
+						KeyStorage::PrivMode { ref payment_base_key, .. } => {
+							let per_commitment_point = PublicKey::from_secret_key(&self.secp_ctx, &per_commitment_key);
+							if let Ok(local_key) = chan_utils::derive_private_key(&self.secp_ctx, &per_commitment_point, &payment_base_key) {
+								spendable_outputs.push(SpendableOutputDescriptor::DynamicOutputP2WPKH {
+									outpoint: BitcoinOutPoint { txid: commitment_txid, vout: idx as u32 },
+									key: local_key,
+									output: outp.clone(),
+								});
+							}
+						}
+						KeyStorage::SigsMode { .. } => {
+							//TODO: we need to ensure an offline client will generate the event when it
+							// cames back online after only the watchtower saw the transaction
+						}
+					}
 				}
 			}
 
@@ -1046,6 +1066,28 @@ impl ChannelMonitor {
 						None => return (txn_to_broadcast, (commitment_txid, watch_outputs), spendable_outputs),
 						Some(their_htlc_base_key) => ignore_error!(chan_utils::derive_public_key(&self.secp_ctx, revocation_point, &their_htlc_base_key)),
 					};
+
+
+					for (idx, outp) in tx.output.iter().enumerate() {
+						if outp.script_pubkey.is_v0_p2wpkh() {
+							match self.key_storage {
+								KeyStorage::PrivMode { ref payment_base_key, .. } => {
+									if let Ok(local_key) = chan_utils::derive_private_key(&self.secp_ctx, &revocation_point, &payment_base_key) {
+										spendable_outputs.push(SpendableOutputDescriptor::DynamicOutputP2WPKH {
+											outpoint: BitcoinOutPoint { txid: commitment_txid, vout: idx as u32 },
+											key: local_key,
+											output: outp.clone(),
+										});
+									}
+								}
+								KeyStorage::SigsMode { .. } => {
+									//TODO: we need to ensure an offline client will generate the event when it
+									// cames back online after only the watchtower saw the transaction
+								}
+							}
+							break; // Only to_remote ouput is claimable
+						}
+					}
 
 					let mut total_value = 0;
 					let mut values = Vec::new();
@@ -1238,9 +1280,9 @@ impl ChannelMonitor {
 				if let Some(ref per_commitment_point) = *per_commitment_point {
 					if let Some(ref delayed_payment_base_key) = *delayed_payment_base_key {
 						if let Ok(local_delayedkey) = chan_utils::derive_private_key(&self.secp_ctx, per_commitment_point, delayed_payment_base_key) {
-							spendable_outputs.push(SpendableOutputDescriptor::DynamicOutput {
+							spendable_outputs.push(SpendableOutputDescriptor::DynamicOutputP2WSH {
 								outpoint: BitcoinOutPoint { txid: $father_tx.txid(), vout: $vout },
-								local_delayedkey,
+								key: local_delayedkey,
 								witness_script: chan_utils::get_revokeable_redeemscript(&local_tx.revocation_key, self.our_to_self_delay, &local_tx.delayed_payment_key),
 								to_self_delay: self.our_to_self_delay,
 								output: $father_tx.output[$vout as usize].clone(),
@@ -1308,7 +1350,7 @@ impl ChannelMonitor {
 		if let &Some(ref local_tx) = &self.current_local_signed_commitment_tx {
 			if local_tx.txid == commitment_txid {
 				match self.key_storage {
-					KeyStorage::PrivMode { revocation_base_key: _, htlc_base_key: _, ref delayed_payment_base_key, prev_latest_per_commitment_point: _, ref latest_per_commitment_point } => {
+					KeyStorage::PrivMode { ref delayed_payment_base_key, ref latest_per_commitment_point, .. } => {
 						return self.broadcast_by_local_state(local_tx, latest_per_commitment_point, &Some(*delayed_payment_base_key));
 					},
 					KeyStorage::SigsMode { .. } => {
@@ -1320,7 +1362,7 @@ impl ChannelMonitor {
 		if let &Some(ref local_tx) = &self.prev_local_signed_commitment_tx {
 			if local_tx.txid == commitment_txid {
 				match self.key_storage {
-					KeyStorage::PrivMode { revocation_base_key: _, htlc_base_key: _, ref delayed_payment_base_key, ref prev_latest_per_commitment_point, .. } => {
+					KeyStorage::PrivMode { ref delayed_payment_base_key, ref prev_latest_per_commitment_point, .. } => {
 						return self.broadcast_by_local_state(local_tx, prev_latest_per_commitment_point, &Some(*delayed_payment_base_key));
 					},
 					KeyStorage::SigsMode { .. } => {
@@ -1392,7 +1434,7 @@ impl ChannelMonitor {
 			if self.would_broadcast_at_height(height) {
 				broadcaster.broadcast_transaction(&cur_local_tx.tx);
 				match self.key_storage {
-					KeyStorage::PrivMode { revocation_base_key: _, htlc_base_key: _, ref delayed_payment_base_key, prev_latest_per_commitment_point: _, ref latest_per_commitment_point } => {
+					KeyStorage::PrivMode { ref delayed_payment_base_key, ref latest_per_commitment_point, .. } => {
 						let (txs, mut outputs) = self.broadcast_by_local_state(&cur_local_tx, latest_per_commitment_point, &Some(*delayed_payment_base_key));
 						spendable_outputs.append(&mut outputs);
 						for tx in txs {
@@ -1480,6 +1522,7 @@ impl<R: ::std::io::Read> ReadableArgs<R, Arc<Logger>> for (Sha256dHash, ChannelM
 				let revocation_base_key = Readable::read(reader)?;
 				let htlc_base_key = Readable::read(reader)?;
 				let delayed_payment_base_key = Readable::read(reader)?;
+				let payment_base_key = Readable::read(reader)?;
 				let prev_latest_per_commitment_point = match <u8 as Readable<R>>::read(reader)? {
 					0 => None,
 					1 => Some(Readable::read(reader)?),
@@ -1494,6 +1537,7 @@ impl<R: ::std::io::Read> ReadableArgs<R, Arc<Logger>> for (Sha256dHash, ChannelM
 					revocation_base_key,
 					htlc_base_key,
 					delayed_payment_base_key,
+					payment_base_key,
 					prev_latest_per_commitment_point,
 					latest_per_commitment_point,
 				}
@@ -1723,7 +1767,7 @@ mod tests {
 
 		{
 			// insert_secret correct sequence
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1769,7 +1813,7 @@ mod tests {
 
 		{
 			// insert_secret #1 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1785,7 +1829,7 @@ mod tests {
 
 		{
 			// insert_secret #2 incorrect (#1 derived from incorrect)
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1811,7 +1855,7 @@ mod tests {
 
 		{
 			// insert_secret #3 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1837,7 +1881,7 @@ mod tests {
 
 		{
 			// insert_secret #4 incorrect (1,2,3 derived from incorrect)
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1883,7 +1927,7 @@ mod tests {
 
 		{
 			// insert_secret #5 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1919,7 +1963,7 @@ mod tests {
 
 		{
 			// insert_secret #6 incorrect (5 derived from incorrect)
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -1965,7 +2009,7 @@ mod tests {
 
 		{
 			// insert_secret #7 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -2011,7 +2055,7 @@ mod tests {
 
 		{
 			// insert_secret #8 incorrect
-			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+			monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 			secrets.clear();
 
 			secrets.push([0; 32]);
@@ -2130,7 +2174,7 @@ mod tests {
 
 		// Prune with one old state and a local commitment tx holding a few overlaps with the
 		// old state.
-		let mut monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
+		let mut monitor = ChannelMonitor::new(&SecretKey::from_slice(&secp_ctx, &[42; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[43; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), &SecretKey::from_slice(&secp_ctx, &[44; 32]).unwrap(), 0, Script::new(), logger.clone());
 		monitor.set_their_to_self_delay(10);
 
 		monitor.provide_latest_local_commitment_tx_info(dummy_tx.clone(), dummy_keys!(), 0, preimages_to_local_htlcs!(preimages[0..10]));


### PR DESCRIPTION
Thanks to have pointed to me #195, I think I spotted a case which wasn't covered by SpendableOuput event generation, to_local output on local commitment tx in broadcast_by_state.
Should fix #195, at funding_created, we sign local_commitment_tx and give it to both channel_manager and channel_monitor.