### PR TITLE
Fix pre-noise outbound peer disconnect panic found by fuzzer

### DIFF
--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -209,15 +209,17 @@ impl<'a> MoneyLossDetector<'a> {
 
 impl<'a> Drop for MoneyLossDetector<'a> {
 	fn drop(&mut self) {
-		// Disconnect all peers
-		for (idx, peer) in self.peers.borrow().iter().enumerate() {
-			if *peer {
-				self.handler.disconnect_event(&Peer{id: idx as u8, peers_connected: &self.peers});
+		if !::std::thread::panicking() {
+			// Disconnect all peers
+			for (idx, peer) in self.peers.borrow().iter().enumerate() {
+				if *peer {
+					self.handler.disconnect_event(&Peer{id: idx as u8, peers_connected: &self.peers});
+				}
 			}
-		}
 
-		// Force all channels onto the chain (and time out claim txn)
-		self.manager.force_close_all_channels();
+			// Force all channels onto the chain (and time out claim txn)
+			self.manager.force_close_all_channels();
+		}
 	}
 }
 

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -2703,6 +2703,7 @@ impl ChannelMessageHandler for ChannelManager {
 			let short_to_id = channel_state.short_to_id;
 			let pending_msg_events = channel_state.pending_msg_events;
 			if no_connection_possible {
+				log_debug!(self, "Failing all channels with {} due to no_connection_possible", log_pubkey!(their_node_id));
 				channel_state.by_id.retain(|_, chan| {
 					if chan.get_their_node_id() == *their_node_id {
 						if let Some(short_id) = chan.get_short_channel_id() {
@@ -2720,6 +2721,7 @@ impl ChannelMessageHandler for ChannelManager {
 					}
 				});
 			} else {
+				log_debug!(self, "Marking channels with {} disconnected and generating channel_updates", log_pubkey!(their_node_id));
 				channel_state.by_id.retain(|_, chan| {
 					if chan.get_their_node_id() == *their_node_id {
 						//TODO: mark channel disabled (and maybe announce such after a timeout).
@@ -2750,6 +2752,8 @@ impl ChannelMessageHandler for ChannelManager {
 	}
 
 	fn peer_connected(&self, their_node_id: &PublicKey) {
+		log_debug!(self, "Generating channel_reestablish events for {}", log_pubkey!(their_node_id));
+
 		let _ = self.total_consistency_lock.read().unwrap();
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = channel_state_lock.borrow_parts();

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -359,6 +359,9 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 
 							macro_rules! try_potential_handleerror {
 								($thing: expr) => {
+									try_potential_handleerror!($thing, false);
+								};
+								($thing: expr, $pre_noise: expr) => {
 									match $thing {
 										Ok(x) => x,
 										Err(e) => {
@@ -367,6 +370,9 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 													msgs::ErrorAction::DisconnectPeer { msg: _ } => {
 														//TODO: Try to push msg
 														log_trace!(self, "Got Err handling message, disconnecting peer because {}", e.err);
+														if $pre_noise {
+															peer.their_node_id = None; // Unset so that we don't generate a peer_disconnected event
+														}
 														return Err(PeerHandleError{ no_connection_possible: false });
 													},
 													msgs::ErrorAction::IgnoreError => {
@@ -432,12 +438,12 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 							let next_step = peer.channel_encryptor.get_noise_step();
 							match next_step {
 								NextNoiseStep::ActOne => {
-									let act_two = try_potential_handleerror!(peer.channel_encryptor.process_act_one_with_key(&peer.pending_read_buffer[..], &self.our_node_secret)).to_vec();
+									let act_two = try_potential_handleerror!(peer.channel_encryptor.process_act_one_with_key(&peer.pending_read_buffer[..], &self.our_node_secret), true).to_vec();
 									peer.pending_outbound_buffer.push_back(act_two);
 									peer.pending_read_buffer = [0; 66].to_vec(); // act three is 66 bytes long
 								},
 								NextNoiseStep::ActTwo => {
-									let act_three = try_potential_handleerror!(peer.channel_encryptor.process_act_two(&peer.pending_read_buffer[..], &self.our_node_secret)).to_vec();
+									let act_three = try_potential_handleerror!(peer.channel_encryptor.process_act_two(&peer.pending_read_buffer[..], &self.our_node_secret), true).to_vec();
 									peer.pending_outbound_buffer.push_back(act_three);
 									peer.pending_read_buffer = [0; 18].to_vec(); // Message length header is 18 bytes
 									peer.pending_read_is_header = true;
@@ -454,7 +460,7 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 									}, 16);
 								},
 								NextNoiseStep::ActThree => {
-									let their_node_id = try_potential_handleerror!(peer.channel_encryptor.process_act_three(&peer.pending_read_buffer[..]));
+									let their_node_id = try_potential_handleerror!(peer.channel_encryptor.process_act_three(&peer.pending_read_buffer[..]), true);
 									peer.pending_read_buffer = [0; 18].to_vec(); // Message length header is 18 bytes
 									peer.pending_read_is_header = true;
 									peer.their_node_id = Some(their_node_id);


### PR DESCRIPTION
If we make an outbound connection to a peer who we are already
connected to, and the outbound connection fails
pre-noise-completion, we will remove the original peer connection
from our node_id_to_descriptor map.

The fuzzer managed to find this by crashing in Channel's assertions
that we don't do a get_channel_reestablish() when the Channel isn't
already marked disconnected.