### PR TITLE
Fail channel when BADONION is not set

### DIFF
--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -2194,8 +2194,8 @@ impl ChannelManager {
 					//TODO: here and below MsgHandleErrInternal, #153 case
 					return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!", msg.channel_id));
 				}
-				if (msg.failure_code & 0x8000) != 0 {
-					return Err(MsgHandleErrInternal::send_err_msg_close_chan("Got update_fail_malformed_htlc with BADONION set", msg.channel_id));
+				if (msg.failure_code & 0x8000) == 0 {
+					return Err(MsgHandleErrInternal::send_err_msg_close_chan("Got update_fail_malformed_htlc with BADONION not set", msg.channel_id));
 				}
 				chan.update_fail_malformed_htlc(&msg, HTLCFailReason::Reason { failure_code: msg.failure_code, data: Vec::new() })
 					.map_err(|e| MsgHandleErrInternal::from_chan_maybe_close(e, msg.channel_id))?;


### PR DESCRIPTION
when update_fail_malformed_htlc is received. 

> if the BADONION bit in failure_code is not set for update_fail_malformed_htlc:
> MUST fail the channel.

found while testing for onion_error handling (#146, which is close to being finished!)

There is another condition in the spec
> if the sha256_of_onion in update_fail_malformed_htlc doesn't match the onion it sent:
> MAY retry or choose an alternate error response.
, which is not clear as to what 'alternate error response' should be used. And `retry' for random bit error?
