### PR TITLE
Time out incoming HTLCs when we reach cltv_expiry (+ test)

### DIFF
--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -57,6 +57,9 @@ pub enum Event {
 	/// PaymentFailReason::AmountMismatch, respectively, to free up resources for this HTLC.
 	/// The amount paid should be considered 'incorrect' when it is less than or more than twice
 	/// the amount expected.
+	/// If you fail to call either ChannelManager::claim_funds of
+	/// ChannelManager::fail_htlc_backwards within the HTLC's timeout, the HTLC will be
+	/// automatically failed with PaymentFailReason::PreimageUnknown.
 	PaymentReceived {
 		/// The hash for which the preimage should be handed to the ChannelManager.
 		payment_hash: [u8; 32],


### PR DESCRIPTION
We only do this for incoming HTLCs directly as we rely on channel
closure and HTLC-Timeout broadcast to fail any HTLCs which we
relayed onwards where our next-hop doesn't update_fail in time.

Partially addresses #215. Note that the failing of inbound HTLCs which we forwarded based on the confirming of downstream HTLC-Timeout transactions is not yet implemented, but that will be the rest of #215.