### PR TITLE
Move a ton of Channel functions to ChannelError from HandleError

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -1894,7 +1894,8 @@ impl Channel {
 				return Err(HandleError{err: "Got a revoke commitment secret which didn't correspond to their current pubkey", action: None});
 			}
 		}
-		self.channel_monitor.provide_secret(self.cur_remote_commitment_transaction_number + 1, msg.per_commitment_secret)?;
+		self.channel_monitor.provide_secret(self.cur_remote_commitment_transaction_number + 1, msg.per_commitment_secret)
+			.map_err(|e| HandleError{err: e.0, action: None})?;
 		self.channel_monitor.provide_their_next_revocation_point(Some((self.cur_remote_commitment_transaction_number - 1, msg.next_per_commitment_point)));
 
 		// Update state now that we've passed all the can-fail calls...

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -4471,7 +4471,7 @@ mod tests {
 
 	#[test]
 	fn test_update_fee_that_funder_cannot_afford() {
-		let mut nodes = create_network(2);
+		let nodes = create_network(2);
 		let channel_value = 1888;
 		let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 700000);
 		let channel_id = chan.2;
@@ -4506,7 +4506,7 @@ mod tests {
 
 		let update2_msg = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
 
-		nodes[1].node.handle_update_fee(&nodes[0].node.get_our_node_id(), &update2_msg.update_fee.unwrap());
+		nodes[1].node.handle_update_fee(&nodes[0].node.get_our_node_id(), &update2_msg.update_fee.unwrap()).unwrap();
 
 		//While producing the commitment_signed response after handling a received update_fee request the
 		//check to see if the funder, who sent the update_fee request, can afford the new fee (funder_balance >= fee+channel_reserve)


### PR DESCRIPTION
This is a big patch, but its all very mechanical, everything here
should be pretty obvious, and it all has to happen at once due to a
few common utility functions all having the same return type.

Note that this exposes a race in channel closure where we may
access a channel via some non-peer-specific mechanism like
forwarding an HTLC or sending a payment during the time between
the channel gave us a Close error and expected us to never call it
again and the time we actually removed it from the channel_state
set outside of the internal_* handler.

Refactor of channelmanager message handlers for that incoming....