### PR TITLE
Fix crash on no-witness tx in ChannelMonitor found by fuzzer

### DIFF
--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -7,7 +7,7 @@ use bitcoin::blockdata::block::BlockHeader;
 use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::blockdata::script::{Builder, Script};
 use bitcoin::blockdata::opcodes;
-use bitcoin::consensus::encode::{deserialize, serialize};
+use bitcoin::consensus::encode::deserialize;
 use bitcoin::network::constants::Network;
 use bitcoin::util::hash::{BitcoinHash, Sha256dHash, Hash160};
 

--- a/fuzz/fuzz_targets/utils/test_logger.rs
+++ b/fuzz/fuzz_targets/utils/test_logger.rs
@@ -4,7 +4,9 @@ pub struct TestLogger {}
 
 impl Logger for TestLogger {
 	fn log(&self, record: &Record) {
-		#[cfg(any(test, not(feature = "fuzztarget")))]
+		#[cfg(test)]
 		println!("{:<5} [{} : {}, {}] {}", record.level.to_string(), record.module_path, record.file, record.line, record.args);
+		#[cfg(not(test))]
+		let _ = format!("{}", record.args);
 	}
 }

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -1386,7 +1386,7 @@ impl ChannelMonitor {
 
 	/// Generate a spendable output event when closing_transaction get registered onchain.
 	fn check_spend_closing_transaction(&self, tx: &Transaction) -> Option<SpendableOutputDescriptor> {
-		if tx.input[0].sequence == 0xFFFFFFFF && tx.input[0].witness.last().unwrap().len() == 71 {
+		if tx.input[0].sequence == 0xFFFFFFFF && !tx.input[0].witness.is_empty() && tx.input[0].witness.last().unwrap().len() == 71 {
 			match self.key_storage {
 				KeyStorage::PrivMode { ref shutdown_pubkey, .. } =>  {
 					let our_channel_close_key_hash = Hash160::from_data(&shutdown_pubkey.serialize());


### PR DESCRIPTION
Tehnically we can't currently hit this, but a theoretical future
watchtower could, and full_stack_target crashes on it (on, I presume, a txid collision).