### PR TITLE
Add overflow-checks in profile.dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,4 @@ hex = "0.3"
 
 [profile.dev]
 opt-level = 1
+overflow-checks=true


### PR DESCRIPTION
We already have warnings in case of overflow but seems to be free in term of compilation time, so I think it's better to severe it.

Didn't find others codegen flags which could be useful at travis build