### PR TITLE
bolt5: Test ignorance of invalid tx

### DIFF
--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -1530,7 +1530,6 @@ impl ChannelMonitor {
 			}
 		}
 
-
 		let redeemscript = chan_utils::get_revokeable_redeemscript(&local_tx.revocation_key, self.their_to_self_delay.unwrap(), &local_tx.delayed_payment_key);
 		let revokeable_p2wsh = redeemscript.to_v0_p2wsh();
 		for (idx, output) in local_tx.tx.output.iter().enumerate() {


### PR DESCRIPTION
Hmmmm in fact a too zealous /useless test, because all invalid txn should be discarded at chain layer.
Or we may want more tx validity checks in block_connected if ChainWatchInterface isn't a full node ? (but seems anyway a layer violation)