### PR TITLE
Bump bitcoin_hashes to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ max_level_debug = []
 
 [dependencies]
 bitcoin = "0.16"
-bitcoin_hashes = "0.2"
+bitcoin_hashes = "0.3"
 rand = "0.4"
 secp256k1 = "0.12"
 


### PR DESCRIPTION
This should just make us compatible with rust-lightning-invoice.