### PR TITLE
util: Derive PartialEq for Level

### DIFF
--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 static LOG_LEVEL_NAMES: [&'static str; 6] = ["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"];
 
 /// An enum representing the available verbosity levels of the logger.
-#[derive(Copy, Clone, Eq, Debug, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Level {
 	///Designates logger being silent
 	Off,
@@ -35,13 +35,6 @@ pub enum Level {
 	Debug,
 	/// Designates very low priority, often extremely verbose, information
 	Trace,
-}
-
-impl PartialEq for Level {
-	#[inline]
-	fn eq(&self, other: &Level) -> bool {
-		*self as usize == *other as usize
-	}
 }
 
 impl PartialOrd for Level {


### PR DESCRIPTION
PartialEq, Eq, and Hash should all be derived together wherever possible
to not violate Hash invariants. See the documentation for
std::hash::Hash for more details.