### PR TITLE
Migrate to rust-bitcoin 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ max_level_info = []
 max_level_debug = []
 
 [dependencies]
-bitcoin = "0.16"
+bitcoin = "0.17"
 bitcoin_hashes = "0.3"
 rand = "0.4"
 secp256k1 = "0.12"
 
 [dev-dependencies.bitcoin]
-version = "0.16"
+version = "0.17"
 features = ["bitcoinconsensus"]
 
 [dev-dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,8 +18,8 @@ libfuzzer_fuzz = ["libfuzzer-sys"]
 [dependencies]
 afl = { version = "0.4", optional = true }
 lightning = { path = "..", features = ["fuzztarget"] }
-bitcoin = { version = "0.16", features = ["fuzztarget"] }
-bitcoin_hashes = { version = "0.2", features=["fuzztarget"] }
+bitcoin = { version = "0.17", features = ["fuzztarget"] }
+bitcoin_hashes = { version = "0.3", features=["fuzztarget"] }
 hex = "0.3"
 honggfuzz = { version = "0.5", optional = true }
 secp256k1 = { version = "0.12", features=["fuzztarget"] }

--- a/fuzz/fuzz_targets/chanmon_deser_target.rs
+++ b/fuzz/fuzz_targets/chanmon_deser_target.rs
@@ -2,9 +2,10 @@
 // To modify it, modify msg_target_template.txt and run gen_target.sh instead.
 
 extern crate bitcoin;
+extern crate bitcoin_hashes;
 extern crate lightning;
 
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 
 use lightning::ln::channelmonitor;
 use lightning::util::reset_rng_state;

--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -18,12 +18,13 @@ use bitcoin::blockdata::script::{Builder, Script};
 use bitcoin::blockdata::opcodes;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::network::constants::Network;
-use bitcoin::util::hash::{BitcoinHash, Sha256dHash};
+use bitcoin::util::hash::BitcoinHash;
 
 use bitcoin_hashes::Hash as TraitImport;
 use bitcoin_hashes::HashEngine as TraitImportEngine;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::hash160::Hash as Hash160;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 
 use lightning::chain::chaininterface::{BroadcasterInterface,ConfirmationTarget,ChainListener,FeeEstimator,ChainWatchInterfaceUtil};
 use lightning::chain::transaction::OutPoint;

--- a/fuzz/fuzz_targets/router_target.rs
+++ b/fuzz/fuzz_targets/router_target.rs
@@ -1,8 +1,9 @@
 extern crate bitcoin;
+extern crate bitcoin_hashes;
 extern crate lightning;
 extern crate secp256k1;
 
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::blockdata::script::{Script, Builder};
 
 use lightning::chain::chaininterface::{ChainError,ChainWatchInterface, ChainListener};

--- a/src/chain/chaininterface.rs
+++ b/src/chain/chaininterface.rs
@@ -8,7 +8,8 @@ use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::blockdata::script::Script;
 use bitcoin::blockdata::constants::genesis_block;
-use bitcoin::util::hash::{BitcoinHash, Sha256dHash};
+use bitcoin::util::hash::BitcoinHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::network::constants::Network;
 
 use util::logger::Logger;

--- a/src/chain/transaction.rs
+++ b/src/chain/transaction.rs
@@ -1,6 +1,6 @@
 //! Contains simple structs describing parts of transactions on the chain.
 
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
 
 /// A reference to a transaction output.

--- a/src/ln/chan_utils.rs
+++ b/src/ln/chan_utils.rs
@@ -1,12 +1,12 @@
 use bitcoin::blockdata::script::{Script,Builder};
 use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::transaction::{TxIn,TxOut,OutPoint,Transaction};
-use bitcoin::util::hash::{Sha256dHash};
 
 use bitcoin_hashes::{Hash, HashEngine};
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::ripemd160::Hash as Ripemd160;
 use bitcoin_hashes::hash160::Hash as Hash160;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 
 use ln::channelmanager::PaymentHash;
 

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -12,11 +12,12 @@ use bitcoin::blockdata::block::BlockHeader;
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::blockdata::constants::genesis_block;
 use bitcoin::network::constants::Network;
-use bitcoin::util::hash::{BitcoinHash, Sha256dHash};
+use bitcoin::util::hash::BitcoinHash;
 
 use bitcoin_hashes::{Hash, HashEngine};
 use bitcoin_hashes::hmac::{Hmac, HmacEngine};
 use bitcoin_hashes::sha256::Hash as Sha256;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use bitcoin_hashes::cmp::fixed_time_eq;
 
 use secp256k1::key::{SecretKey,PublicKey};
@@ -964,7 +965,7 @@ impl ChannelManager {
 			excess_data: Vec::new(),
 		};
 
-		let msg_hash = Sha256dHash::from_data(&unsigned.encode()[..]);
+		let msg_hash = Sha256dHash::hash(&unsigned.encode()[..]);
 		let sig = self.secp_ctx.sign(&hash_to_message!(&msg_hash[..]), &self.our_network_key);
 
 		Ok(msgs::ChannelUpdate {
@@ -1158,7 +1159,7 @@ impl ChannelManager {
 			Ok(res) => res,
 			Err(_) => return None, // Only in case of state precondition violations eg channel is closing
 		};
-		let msghash = hash_to_message!(&Sha256dHash::from_data(&announcement.encode()[..])[..]);
+		let msghash = hash_to_message!(&Sha256dHash::hash(&announcement.encode()[..])[..]);
 		let our_node_sig = self.secp_ctx.sign(&msghash, &self.our_network_key);
 
 		Some(msgs::AnnouncementSignatures {
@@ -2182,7 +2183,7 @@ impl ChannelManager {
 					try_chan_entry!(self, chan.get_mut().get_channel_announcement(our_node_id.clone(), self.genesis_hash.clone()), channel_state, chan);
 
 				let were_node_one = announcement.node_id_1 == our_node_id;
-				let msghash = hash_to_message!(&Sha256dHash::from_data(&announcement.encode()[..])[..]);
+				let msghash = hash_to_message!(&Sha256dHash::hash(&announcement.encode()[..])[..]);
 				if self.secp_ctx.verify(&msghash, &msg.node_signature, if were_node_one { &announcement.node_id_2 } else { &announcement.node_id_1 }).is_err() ||
 						self.secp_ctx.verify(&msghash, &msg.bitcoin_signature, if were_node_one { &announcement.bitcoin_key_2 } else { &announcement.bitcoin_key_1 }).is_err() {
 					try_chan_entry!(self, Err(ChannelError::Close("Bad announcement_signatures node_signature")), channel_state, chan);

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -17,12 +17,13 @@ use bitcoin::blockdata::transaction::OutPoint as BitcoinOutPoint;
 use bitcoin::blockdata::script::{Script, Builder};
 use bitcoin::blockdata::opcodes;
 use bitcoin::consensus::encode::{self, Decodable, Encodable};
-use bitcoin::util::hash::{BitcoinHash,Sha256dHash};
+use bitcoin::util::hash::BitcoinHash;
 use bitcoin::util::bip143;
 
 use bitcoin_hashes::Hash;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::hash160::Hash as Hash160;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 
 use secp256k1::{Secp256k1,Signature};
 use secp256k1::key::{SecretKey,PublicKey};
@@ -1179,7 +1180,7 @@ impl ChannelMonitor {
 				// on-chain claims, so we can do that at the same time.
 				macro_rules! check_htlc_fails {
 					($txid: expr, $commitment_tx: expr) => {
-						if let Some(ref outpoints) = self.remote_claimable_outpoints.get(&$txid) {
+						if let Some(ref outpoints) = self.remote_claimable_outpoints.get($txid) {
 							for &(ref htlc, ref source_option) in outpoints.iter() {
 								if let &Some(ref source) = source_option {
 									log_trace!(self, "Failing HTLC with payment_hash {} from {} remote commitment tx due to broadcast of revoked remote commitment transaction", log_bytes!(htlc.payment_hash.0), $commitment_tx);
@@ -1243,7 +1244,7 @@ impl ChannelMonitor {
 			// on-chain claims, so we can do that at the same time.
 			macro_rules! check_htlc_fails {
 				($txid: expr, $commitment_tx: expr, $id: tt) => {
-					if let Some(ref latest_outpoints) = self.remote_claimable_outpoints.get(&$txid) {
+					if let Some(ref latest_outpoints) = self.remote_claimable_outpoints.get($txid) {
 						$id: for &(ref htlc, ref source_option) in latest_outpoints.iter() {
 							if let &Some(ref source) = source_option {
 								// Check if the HTLC is present in the commitment transaction that was

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -18,7 +18,7 @@
 use secp256k1::key::PublicKey;
 use secp256k1::Signature;
 use secp256k1;
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::blockdata::script::Script;
 
 use std::error::Error;
@@ -1386,7 +1386,8 @@ mod tests {
 	use ln::channelmanager::{PaymentPreimage, PaymentHash};
 	use util::ser::Writeable;
 
-	use bitcoin::util::hash::Sha256dHash;
+	use bitcoin_hashes::sha256d::Hash as Sha256dHash;
+	use bitcoin_hashes::hex::FromHex;
 	use bitcoin::util::address::Address;
 	use bitcoin::network::constants::Network;
 	use bitcoin::blockdata::script::Builder;
@@ -1712,7 +1713,7 @@ mod tests {
 			htlc_basepoint: pubkey_5,
 			first_per_commitment_point: pubkey_6,
 			channel_flags: if random_bit { 1 << 5 } else { 0 },
-			shutdown_scriptpubkey: if shutdown { OptionalField::Present(Address::p2pkh(&pubkey_1, Network::Testnet).script_pubkey()) } else { OptionalField::Absent }
+			shutdown_scriptpubkey: if shutdown { OptionalField::Present(Address::p2pkh(&::bitcoin::PublicKey{compressed: true, key: pubkey_1}, Network::Testnet).script_pubkey()) } else { OptionalField::Absent }
 		};
 		let encoded_value = open_channel.encode();
 		let mut target_value = Vec::new();
@@ -1765,7 +1766,7 @@ mod tests {
 			delayed_payment_basepoint: pubkey_4,
 			htlc_basepoint: pubkey_5,
 			first_per_commitment_point: pubkey_6,
-			shutdown_scriptpubkey: if shutdown { OptionalField::Present(Address::p2pkh(&pubkey_1, Network::Testnet).script_pubkey()) } else { OptionalField::Absent }
+			shutdown_scriptpubkey: if shutdown { OptionalField::Present(Address::p2pkh(&::bitcoin::PublicKey{compressed: true, key: pubkey_1}, Network::Testnet).script_pubkey()) } else { OptionalField::Absent }
 		};
 		let encoded_value = accept_channel.encode();
 		let mut target_value = hex::decode("020202020202020202020202020202020202020202020202020202020202020212345678901234562334032891223698321446687011447600083a840000034d000c89d4c0bcc0bc031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a").unwrap();
@@ -1830,7 +1831,7 @@ mod tests {
 		let script = Builder::new().push_opcode(opcodes::OP_TRUE).into_script();
 		let shutdown = msgs::Shutdown {
 			channel_id: [2; 32],
-			scriptpubkey: if script_type == 1 { Address::p2pkh(&pubkey_1, Network::Testnet).script_pubkey() } else if script_type == 2 { Address::p2sh(&script, Network::Testnet).script_pubkey() } else if script_type == 3 { Address::p2wpkh(&pubkey_1, Network::Testnet).script_pubkey() } else { Address::p2wsh(&script, Network::Testnet).script_pubkey() },
+			scriptpubkey: if script_type == 1 { Address::p2pkh(&::bitcoin::PublicKey{compressed: true, key: pubkey_1}, Network::Testnet).script_pubkey() } else if script_type == 2 { Address::p2sh(&script, Network::Testnet).script_pubkey() } else if script_type == 3 { Address::p2wpkh(&::bitcoin::PublicKey{compressed: true, key: pubkey_1}, Network::Testnet).script_pubkey() } else { Address::p2wsh(&script, Network::Testnet).script_pubkey() },
 		};
 		let encoded_value = shutdown.encode();
 		let mut target_value = hex::decode("0202020202020202020202020202020202020202020202020202020202020202").unwrap();

--- a/src/util/macro_logger.rs
+++ b/src/util/macro_logger.rs
@@ -1,6 +1,6 @@
 use chain::transaction::OutPoint;
 
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use secp256k1::key::PublicKey;
 
 use ln::router::Route;

--- a/src/util/ser.rs
+++ b/src/util/ser.rs
@@ -8,8 +8,8 @@ use std::hash::Hash;
 
 use secp256k1::Signature;
 use secp256k1::key::{PublicKey, SecretKey};
-use bitcoin::util::hash::Sha256dHash;
 use bitcoin::blockdata::script::Script;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use std::marker::Sized;
 use ln::msgs::DecodeError;
 use ln::channelmanager::{PaymentPreimage, PaymentHash};
@@ -342,14 +342,16 @@ impl<R: Read> Readable<R> for SecretKey {
 
 impl Writeable for Sha256dHash {
 	fn write<W: Writer>(&self, w: &mut W) -> Result<(), ::std::io::Error> {
-		self.as_bytes().write(w)
+		w.write_all(&self[..])
 	}
 }
 
 impl<R: Read> Readable<R> for Sha256dHash {
 	fn read(r: &mut R) -> Result<Self, DecodeError> {
+		use bitcoin_hashes::Hash;
+
 		let buf: [u8; 32] = Readable::read(r)?;
-		Ok(From::from(&buf[..]))
+		Ok(Sha256dHash::from_slice(&buf[..]).unwrap())
 	}
 }
 

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -12,7 +12,7 @@ use util::ser::{ReadableArgs, Writer};
 
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::blockdata::script::Script;
-use bitcoin::util::hash::Sha256dHash;
+use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use bitcoin::network::constants::Network;
 
 use secp256k1::{SecretKey, PublicKey};


### PR DESCRIPTION
This is a minimal invasive migration, with the goal of compile and pass tests.
Preferred use of 0.17 features should follow once this is merged.