### PR TITLE
BOLT 5 : MUST send a warning regarding lost funds (rogue tx)

### DIFF
--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -1830,7 +1830,10 @@ impl ChannelManager {
 						//TODO: here and below MsgHandleErrInternal, #153 case
 						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!", msg.channel_id));
 					}
-					let (shutdown, closing_signed, dropped_htlcs) = try_chan_entry!(self, chan_entry.get_mut().shutdown(&*self.fee_estimator, &msg), channel_state, chan_entry);
+					let (shutdown, closing_signed, dropped_htlcs, chan_monitor) = try_chan_entry!(self, chan_entry.get_mut().shutdown(&*self.fee_estimator, &msg), channel_state, chan_entry);
+					if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
+						unimplemented!();
+					}
 					if let Some(msg) = shutdown {
 						channel_state.pending_msg_events.push(events::MessageSendEvent::SendShutdown {
 							node_id: their_node_id.clone(),
@@ -1877,7 +1880,10 @@ impl ChannelManager {
 						//TODO: here and below MsgHandleErrInternal, #153 case
 						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!", msg.channel_id));
 					}
-					let (closing_signed, tx) = try_chan_entry!(self, chan_entry.get_mut().closing_signed(&*self.fee_estimator, &msg), channel_state, chan_entry);
+					let (closing_signed, tx, chan_monitor) = try_chan_entry!(self, chan_entry.get_mut().closing_signed(&*self.fee_estimator, &msg), channel_state, chan_entry);
+					if let Err(_e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
+						unimplemented!();
+					}
 					if let Some(msg) = closing_signed {
 						channel_state.pending_msg_events.push(events::MessageSendEvent::SendClosingSigned {
 							node_id: their_node_id.clone(),

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -1144,6 +1144,7 @@ impl ChannelMonitor {
 						if transaction_output_index as usize >= tx.output.len() ||
 								tx.output[transaction_output_index as usize].value != htlc.amount_msat / 1000 ||
 								tx.output[transaction_output_index as usize].script_pubkey != expected_script.to_v0_p2wsh() {
+							log_error!(self, "Per_commitment_data corrupted at HTLC {} for remote commitment {} YOUR LOOSING FUNDS DUE TO DEFAULTING STORAGE SUBSYSTEM !", transaction_output_index, commitment_txid);
 							return (txn_to_broadcast, (commitment_txid, watch_outputs), spendable_outputs, htlc_updated); // Corrupted per_commitment_data, fuck this user
 						}
 						let input = TxIn {
@@ -1359,6 +1360,7 @@ impl ChannelMonitor {
 							if transaction_output_index as usize >= tx.output.len() ||
 									tx.output[transaction_output_index as usize].value != htlc.amount_msat / 1000 ||
 									tx.output[transaction_output_index as usize].script_pubkey != expected_script.to_v0_p2wsh() {
+								log_error!(self, "Per_commitment_data corrupted at HTLC {} for remote commitment tx {} YOUR LOOSING FUNDS DUE TO DEFAULTING STORAGE SUBSYSTEM !", transaction_output_index, commitment_txid);
 								return (txn_to_broadcast, (commitment_txid, watch_outputs), spendable_outputs, htlc_updated); // Corrupted per_commitment_data, fuck this user
 							}
 							if let Some(payment_preimage) = self.payment_preimages.get(&htlc.payment_hash) {


### PR DESCRIPTION
A rogue spending tx could be a revoked local commitment tx, surely
a watchtower cheating us, or a tx build from our private keys.
In any case, that means funds have been lost and users need to
audit their setup/watchtower provider.

Add closing_tx in Storage::Local, as needed to guess if mutual
close is a legit one.

Fix test in consequence.

(Didn't implement rogue htlc tx detection in case of private keys leak, in fact I've a half-commit with a lot of htlcs heuristics but wasn't 100%  sure so don't want to generate false positives, think it's good enough for now)