### PR TITLE
Make minimum channel opening confirmations configurable

### DIFF
--- a/fuzz/fuzz_targets/chanmon_fail_consistency.rs
+++ b/fuzz/fuzz_targets/chanmon_fail_consistency.rs
@@ -148,7 +148,7 @@ pub fn do_test(data: &[u8]) {
 			let mut config = UserConfig::new();
 			config.channel_options.fee_proportional_millionths = 0;
 			config.channel_options.announced_channel = true;
-			config.channel_limits.min_dust_limit_satoshis = 0;
+			config.peer_channel_config_limits.min_dust_limit_satoshis = 0;
 			(ChannelManager::new(Network::Bitcoin, fee_est.clone(), monitor.clone(), watch.clone(), broadcast.clone(), Arc::clone(&logger), keys_manager.clone(), config).unwrap(),
 			monitor)
 		} }

--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -350,7 +350,7 @@ pub fn do_test(data: &[u8], logger: &Arc<Logger>) {
 	let mut config = UserConfig::new();
 	config.channel_options.fee_proportional_millionths =  slice_to_be32(get_slice!(4));
 	config.channel_options.announced_channel = get_slice!(1)[0] != 0;
-	config.channel_limits.min_dust_limit_satoshis = 0;
+	config.peer_channel_config_limits.min_dust_limit_satoshis = 0;
 	let channelmanager = ChannelManager::new(Network::Bitcoin, fee_est.clone(), monitor.clone(), watch.clone(), broadcast.clone(), Arc::clone(&logger), keys_manager.clone(), config).unwrap();
 	let router = Arc::new(Router::new(PublicKey::from_secret_key(&Secp256k1::signing_only(), &keys_manager.get_node_secret()), watch.clone(), Arc::clone(&logger)));
 

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -410,13 +410,6 @@ impl Channel {
 		1000 // TODO
 	}
 
-	fn derive_minimum_depth(_channel_value_satoshis_msat: u64, _value_to_self_msat: u64) -> u32 {
-		// Note that in order to comply with BOLT 7 announcement_signatures requirements this must
-		// be at least 6.
-		const CONF_TARGET: u32 = 12; //TODO: Should be much higher
-		CONF_TARGET
-	}
-
 	// Constructors:
 	pub fn new_outbound(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, channel_value_satoshis: u64, push_msat: u64, user_id: u64, logger: Arc<Logger>, config: &UserConfig) -> Result<Channel, APIError> {
 		let chan_keys = keys_provider.get_channel_keys(false);
@@ -565,32 +558,32 @@ impl Channel {
 		}
 
 		// Now check against optional parameters as set by config...
-		if msg.funding_satoshis < config.channel_limits.min_funding_satoshis {
+		if msg.funding_satoshis < config.peer_channel_config_limits.min_funding_satoshis {
 			return Err(ChannelError::Close("funding satoshis is less than the user specified limit"));
 		}
-		if msg.htlc_minimum_msat > config.channel_limits.max_htlc_minimum_msat {
+		if msg.htlc_minimum_msat > config.peer_channel_config_limits.max_htlc_minimum_msat {
 			return Err(ChannelError::Close("htlc minimum msat is higher than the user specified limit"));
 		}
-		if msg.max_htlc_value_in_flight_msat < config.channel_limits.min_max_htlc_value_in_flight_msat {
+		if msg.max_htlc_value_in_flight_msat < config.peer_channel_config_limits.min_max_htlc_value_in_flight_msat {
 			return Err(ChannelError::Close("max htlc value in flight msat is less than the user specified limit"));
 		}
-		if msg.channel_reserve_satoshis > config.channel_limits.max_channel_reserve_satoshis {
+		if msg.channel_reserve_satoshis > config.peer_channel_config_limits.max_channel_reserve_satoshis {
 			return Err(ChannelError::Close("channel reserve satoshis is higher than the user specified limit"));
 		}
-		if msg.max_accepted_htlcs < config.channel_limits.min_max_accepted_htlcs {
+		if msg.max_accepted_htlcs < config.peer_channel_config_limits.min_max_accepted_htlcs {
 			return Err(ChannelError::Close("max accepted htlcs is less than the user specified limit"));
 		}
-		if msg.dust_limit_satoshis < config.channel_limits.min_dust_limit_satoshis {
+		if msg.dust_limit_satoshis < config.peer_channel_config_limits.min_dust_limit_satoshis {
 			return Err(ChannelError::Close("dust limit satoshis is less than the user specified limit"));
 		}
-		if msg.dust_limit_satoshis > config.channel_limits.max_dust_limit_satoshis {
+		if msg.dust_limit_satoshis > config.peer_channel_config_limits.max_dust_limit_satoshis {
 			return Err(ChannelError::Close("dust limit satoshis is greater than the user specified limit"));
 		}
 
 		// Convert things into internal flags and prep our state:
 
 		let their_announce = if (msg.channel_flags & 1) == 1 { true } else { false };
-		if config.channel_limits.force_announced_channel_preference {
+		if config.peer_channel_config_limits.force_announced_channel_preference {
 			if local_config.announced_channel != their_announce {
 				return Err(ChannelError::Close("Peer tried to open channel but their announcement preference is different from ours"));
 			}
@@ -687,7 +680,7 @@ impl Channel {
 			our_htlc_minimum_msat: Channel::derive_our_htlc_minimum_msat(msg.feerate_per_kw as u64),
 			their_to_self_delay: msg.to_self_delay,
 			their_max_accepted_htlcs: msg.max_accepted_htlcs,
-			minimum_depth: Channel::derive_minimum_depth(msg.funding_satoshis*1000, msg.push_msat),
+			minimum_depth: config.own_inbound_channel_config.minimum_depth,
 
 			their_funding_pubkey: Some(msg.funding_pubkey),
 			their_revocation_basepoint: Some(msg.revocation_basepoint),
@@ -1383,25 +1376,25 @@ impl Channel {
 		}
 
 		// Now check against optional parameters as set by config...
-		if msg.htlc_minimum_msat > config.channel_limits.max_htlc_minimum_msat {
+		if msg.htlc_minimum_msat > config.peer_channel_config_limits.max_htlc_minimum_msat {
 			return Err(ChannelError::Close("htlc minimum msat is higher than the user specified limit"));
 		}
-		if msg.max_htlc_value_in_flight_msat < config.channel_limits.min_max_htlc_value_in_flight_msat {
+		if msg.max_htlc_value_in_flight_msat < config.peer_channel_config_limits.min_max_htlc_value_in_flight_msat {
 			return Err(ChannelError::Close("max htlc value in flight msat is less than the user specified limit"));
 		}
-		if msg.channel_reserve_satoshis > config.channel_limits.max_channel_reserve_satoshis {
+		if msg.channel_reserve_satoshis > config.peer_channel_config_limits.max_channel_reserve_satoshis {
 			return Err(ChannelError::Close("channel reserve satoshis is higher than the user specified limit"));
 		}
-		if msg.max_accepted_htlcs < config.channel_limits.min_max_accepted_htlcs {
+		if msg.max_accepted_htlcs < config.peer_channel_config_limits.min_max_accepted_htlcs {
 			return Err(ChannelError::Close("max accepted htlcs is less than the user specified limit"));
 		}
-		if msg.dust_limit_satoshis < config.channel_limits.min_dust_limit_satoshis {
+		if msg.dust_limit_satoshis < config.peer_channel_config_limits.min_dust_limit_satoshis {
 			return Err(ChannelError::Close("dust limit satoshis is less than the user specified limit"));
 		}
-		if msg.dust_limit_satoshis > config.channel_limits.max_dust_limit_satoshis {
+		if msg.dust_limit_satoshis > config.peer_channel_config_limits.max_dust_limit_satoshis {
 			return Err(ChannelError::Close("dust limit satoshis is greater than the user specified limit"));
 		}
-		if msg.minimum_depth > config.channel_limits.max_minimum_depth {
+		if msg.minimum_depth > config.peer_channel_config_limits.max_minimum_depth {
 			return Err(ChannelError::Close("We consider the minimum depth to be unreasonably large"));
 		}
 

--- a/src/ln/functional_test_utils.rs
+++ b/src/ln/functional_test_utils.rs
@@ -824,7 +824,7 @@ pub fn create_network(node_count: usize) -> Vec<Node> {
 		let chan_monitor = Arc::new(test_utils::TestChannelMonitor::new(chain_monitor.clone(), tx_broadcaster.clone(), logger.clone()));
 		let mut config = UserConfig::new();
 		config.channel_options.announced_channel = true;
-		config.channel_limits.force_announced_channel_preference = false;
+		config.peer_channel_config_limits.force_announced_channel_preference = false;
 		let node = ChannelManager::new(Network::Testnet, feeest.clone(), chan_monitor.clone(), chain_monitor.clone(), tx_broadcaster.clone(), Arc::clone(&logger), keys_manager.clone(), config).unwrap();
 		let router = Router::new(PublicKey::from_secret_key(&secp_ctx, &keys_manager.get_node_secret()), chain_monitor.clone(), Arc::clone(&logger));
 		nodes.push(Node { chain_monitor, tx_broadcaster, chan_monitor, node, router, keys_manager, node_seed: seed,

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -4,8 +4,10 @@
 /// Top-level config which holds ChannelHandshakeLimits and ChannelConfig.
 #[derive(Clone, Debug)]
 pub struct UserConfig {
+	/// Channel config that we propose on receiving a channel opening request
+	pub own_inbound_channel_config: ChannelHandshakeConfig,
 	/// Limits applied during channel creation.
-	pub channel_limits: ChannelHandshakeLimits,
+	pub peer_channel_config_limits: ChannelHandshakeLimits,
 	/// Channel config which affects behavior during channel lifetime.
 	pub channel_options: ChannelConfig,
 }
@@ -14,8 +16,25 @@ impl UserConfig {
 	/// Provides sane defaults for most configurations (but with 0 relay fees!)
 	pub fn new() -> Self{
 		UserConfig {
-			channel_limits: ChannelHandshakeLimits::new(),
+			own_inbound_channel_config: ChannelHandshakeConfig::new(),
+			peer_channel_config_limits: ChannelHandshakeLimits::new(),
 			channel_options: ChannelConfig::new(),
+		}
+	}
+}
+
+/// Configuration we want to opening channels
+#[derive(Clone, Debug)]
+pub struct ChannelHandshakeConfig {
+	/// Confirmations we will wait for before considering the channel locked in
+	pub minimum_depth: u32,
+}
+
+impl ChannelHandshakeConfig {
+	/// Provides sane defaults for `ChannelHandshakeConfig`
+	pub fn new() -> ChannelHandshakeConfig {
+		ChannelHandshakeConfig {
+			minimum_depth: 6,
 		}
 	}
 }


### PR DESCRIPTION
This also changes the default confirmations needed to open a channel from 12 to 6 since c-lightning will not accept values bigger than 10.

Ideally the user could provide a function `Fn(channel_value_satoshis_msat: u64, value_to_self_msat: u64) -> u32`, but providing a constant seems to be the more pragmatic solution for now.