### PR TITLE
Fix deprecation warnings for missing `dyn`s

### DIFF
--- a/src/chain/chaininterface.rs
+++ b/src/chain/chaininterface.rs
@@ -47,7 +47,7 @@ pub trait ChainWatchInterface: Sync + Send {
 
 	/// Register the given listener to receive events. Only a weak pointer is provided and the
 	/// registration should be freed once that pointer expires.
-	fn register_listener(&self, listener: Weak<ChainListener>);
+	fn register_listener(&self, listener: Weak<dyn ChainListener>);
 	//TODO: unregister
 
 	/// Gets the script and value in satoshis for a given unspent transaction output given a
@@ -203,9 +203,9 @@ impl ChainWatchedUtil {
 pub struct ChainWatchInterfaceUtil {
 	network: Network,
 	watched: Mutex<ChainWatchedUtil>,
-	listeners: Mutex<Vec<Weak<ChainListener>>>,
+	listeners: Mutex<Vec<Weak<dyn ChainListener>>>,
 	reentered: AtomicUsize,
-	logger: Arc<Logger>,
+	logger: Arc<dyn Logger>,
 }
 
 /// Register listener
@@ -231,7 +231,7 @@ impl ChainWatchInterface for ChainWatchInterfaceUtil {
 		}
 	}
 
-	fn register_listener(&self, listener: Weak<ChainListener>) {
+	fn register_listener(&self, listener: Weak<dyn ChainListener>) {
 		let mut vec = self.listeners.lock().unwrap();
 		vec.push(listener);
 	}
@@ -246,7 +246,7 @@ impl ChainWatchInterface for ChainWatchInterfaceUtil {
 
 impl ChainWatchInterfaceUtil {
 	/// Creates a new ChainWatchInterfaceUtil for the given network
-	pub fn new(network: Network, logger: Arc<Logger>) -> ChainWatchInterfaceUtil {
+	pub fn new(network: Network, logger: Arc<dyn Logger>) -> ChainWatchInterfaceUtil {
 		ChainWatchInterfaceUtil {
 			network: network,
 			watched: Mutex::new(ChainWatchedUtil::new()),

--- a/src/chain/keysinterface.rs
+++ b/src/chain/keysinterface.rs
@@ -131,13 +131,13 @@ pub struct KeysManager {
 	channel_id_master_key: ExtendedPrivKey,
 	channel_id_child_index: AtomicUsize,
 
-	logger: Arc<Logger>,
+	logger: Arc<dyn Logger>,
 }
 
 impl KeysManager {
 	/// Constructs a KeysManager from a 32-byte seed. If the seed is in some way biased (eg your
 	/// RNG is busted) this may panic.
-	pub fn new(seed: &[u8; 32], network: Network, logger: Arc<Logger>) -> KeysManager {
+	pub fn new(seed: &[u8; 32], network: Network, logger: Arc<dyn Logger>) -> KeysManager {
 		let secp_ctx = Secp256k1::signing_only();
 		match ExtendedPrivKey::new_master(network.clone(), seed) {
 			Ok(master_key) => {

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -314,10 +314,10 @@ const ERR: () = "You need at least 32 bit pointers (well, usize, but we'll assum
 pub struct ChannelManager {
 	default_configuration: UserConfig,
 	genesis_hash: Sha256dHash,
-	fee_estimator: Arc<FeeEstimator>,
-	monitor: Arc<ManyChannelMonitor>,
-	chain_monitor: Arc<ChainWatchInterface>,
-	tx_broadcaster: Arc<BroadcasterInterface>,
+	fee_estimator: Arc<dyn FeeEstimator>,
+	monitor: Arc<dyn ManyChannelMonitor>,
+	chain_monitor: Arc<dyn ChainWatchInterface>,
+	tx_broadcaster: Arc<dyn BroadcasterInterface>,
 
 	#[cfg(test)]
 	pub(super) latest_block_height: AtomicUsize,
@@ -338,9 +338,9 @@ pub struct ChannelManager {
 	/// Taken first everywhere where we are making changes before any other locks.
 	total_consistency_lock: RwLock<()>,
 
-	keys_manager: Arc<KeysInterface>,
+	keys_manager: Arc<dyn KeysInterface>,
 
-	logger: Arc<Logger>,
+	logger: Arc<dyn Logger>,
 }
 
 /// The minimum number of blocks between an inbound HTLC's CLTV and the corresponding outbound
@@ -531,7 +531,7 @@ impl ChannelManager {
 	/// Non-proportional fees are fixed according to our risk using the provided fee estimator.
 	///
 	/// panics if channel_value_satoshis is >= `MAX_FUNDING_SATOSHIS`!
-	pub fn new(network: Network, feeest: Arc<FeeEstimator>, monitor: Arc<ManyChannelMonitor>, chain_monitor: Arc<ChainWatchInterface>, tx_broadcaster: Arc<BroadcasterInterface>, logger: Arc<Logger>,keys_manager: Arc<KeysInterface>, config: UserConfig) -> Result<Arc<ChannelManager>, secp256k1::Error> {
+	pub fn new(network: Network, feeest: Arc<dyn FeeEstimator>, monitor: Arc<dyn ManyChannelMonitor>, chain_monitor: Arc<dyn ChainWatchInterface>, tx_broadcaster: Arc<dyn BroadcasterInterface>, logger: Arc<dyn Logger>,keys_manager: Arc<dyn KeysInterface>, config: UserConfig) -> Result<Arc<ChannelManager>, secp256k1::Error> {
 		let secp_ctx = Secp256k1::new();
 
 		let res = Arc::new(ChannelManager {
@@ -2959,29 +2959,29 @@ impl Writeable for ChannelManager {
 pub struct ChannelManagerReadArgs<'a> {
 	/// The keys provider which will give us relevant keys. Some keys will be loaded during
 	/// deserialization.
-	pub keys_manager: Arc<KeysInterface>,
+	pub keys_manager: Arc<dyn KeysInterface>,
 
 	/// The fee_estimator for use in the ChannelManager in the future.
 	///
 	/// No calls to the FeeEstimator will be made during deserialization.
-	pub fee_estimator: Arc<FeeEstimator>,
+	pub fee_estimator: Arc<dyn FeeEstimator>,
 	/// The ManyChannelMonitor for use in the ChannelManager in the future.
 	///
 	/// No calls to the ManyChannelMonitor will be made during deserialization. It is assumed that
 	/// you have deserialized ChannelMonitors separately and will add them to your
 	/// ManyChannelMonitor after deserializing this ChannelManager.
-	pub monitor: Arc<ManyChannelMonitor>,
+	pub monitor: Arc<dyn ManyChannelMonitor>,
 	/// The ChainWatchInterface for use in the ChannelManager in the future.
 	///
 	/// No calls to the ChainWatchInterface will be made during deserialization.
-	pub chain_monitor: Arc<ChainWatchInterface>,
+	pub chain_monitor: Arc<dyn ChainWatchInterface>,
 	/// The BroadcasterInterface which will be used in the ChannelManager in the future and may be
 	/// used to broadcast the latest local commitment transactions of channels which must be
 	/// force-closed during deserialization.
-	pub tx_broadcaster: Arc<BroadcasterInterface>,
+	pub tx_broadcaster: Arc<dyn BroadcasterInterface>,
 	/// The Logger for use in the ChannelManager and which may be used to log information during
 	/// deserialization.
-	pub logger: Arc<Logger>,
+	pub logger: Arc<dyn Logger>,
 	/// Default settings used for new channels. Any existing channels will continue to use the
 	/// runtime settings which were stored when the ChannelManager was serialized.
 	pub default_config: UserConfig,

--- a/src/ln/onion_utils.rs
+++ b/src/ln/onion_utils.rs
@@ -268,7 +268,7 @@ pub(super) fn build_first_hop_failure_packet(shared_secret: &[u8], failure_type:
 /// Process failure we got back from upstream on a payment we sent (implying htlc_source is an
 /// OutboundRoute).
 /// Returns update, a boolean indicating that the payment itself failed, and the error code.
-pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T>, logger: &Arc<Logger>, htlc_source: &HTLCSource, mut packet_decrypted: Vec<u8>) -> (Option<msgs::HTLCFailChannelUpdate>, bool, Option<u16>) {
+pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T>, logger: &Arc<dyn Logger>, htlc_source: &HTLCSource, mut packet_decrypted: Vec<u8>) -> (Option<msgs::HTLCFailChannelUpdate>, bool, Option<u16>) {
 	if let &HTLCSource::OutboundRoute { ref route, ref session_priv, ref first_hop_htlc_msat } = htlc_source {
 		let mut res = None;
 		let mut htlc_msat = *first_hop_htlc_msat;

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -24,10 +24,10 @@ use std::{cmp,error,hash,fmt};
 pub struct MessageHandler {
 	/// A message handler which handles messages specific to channels. Usually this is just a
 	/// ChannelManager object.
-	pub chan_handler: Arc<msgs::ChannelMessageHandler>,
+	pub chan_handler: Arc<dyn msgs::ChannelMessageHandler>,
 	/// A message handler which handles messages updating our knowledge of the network channel
 	/// graph. Usually this is just a Router object.
-	pub route_handler: Arc<msgs::RoutingMessageHandler>,
+	pub route_handler: Arc<dyn msgs::RoutingMessageHandler>,
 }
 
 /// Provides an object which can be used to send data to and which uniquely identifies a connection
@@ -158,7 +158,7 @@ pub struct PeerManager<Descriptor: SocketDescriptor> {
 	peers: Mutex<PeerHolder<Descriptor>>,
 	our_node_secret: SecretKey,
 	initial_syncs_sent: AtomicUsize,
-	logger: Arc<Logger>,
+	logger: Arc<dyn Logger>,
 }
 
 struct VecWriter(Vec<u8>);
@@ -188,7 +188,7 @@ const INITIAL_SYNCS_TO_SEND: usize = 5;
 /// PeerIds may repeat, but only after disconnect_event() has been called.
 impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 	/// Constructs a new PeerManager with the given message handlers and node_id secret key
-	pub fn new(message_handler: MessageHandler, our_node_secret: SecretKey, logger: Arc<Logger>) -> PeerManager<Descriptor> {
+	pub fn new(message_handler: MessageHandler, our_node_secret: SecretKey, logger: Arc<dyn Logger>) -> PeerManager<Descriptor> {
 		PeerManager {
 			message_handler: message_handler,
 			peers: Mutex::new(PeerHolder {

--- a/src/ln/router.rs
+++ b/src/ln/router.rs
@@ -351,8 +351,8 @@ pub struct RouteHint {
 pub struct Router {
 	secp_ctx: Secp256k1<secp256k1::VerifyOnly>,
 	network_map: RwLock<NetworkMap>,
-	chain_monitor: Arc<ChainWatchInterface>,
-	logger: Arc<Logger>,
+	chain_monitor: Arc<dyn ChainWatchInterface>,
+	logger: Arc<dyn Logger>,
 }
 
 const SERIALIZATION_VERSION: u8 = 1;
@@ -377,10 +377,10 @@ pub struct RouterReadArgs {
 	/// The ChainWatchInterface for use in the Router in the future.
 	///
 	/// No calls to the ChainWatchInterface will be made during deserialization.
-	pub chain_monitor: Arc<ChainWatchInterface>,
+	pub chain_monitor: Arc<dyn ChainWatchInterface>,
 	/// The Logger for use in the ChannelManager and which may be used to log information during
 	/// deserialization.
-	pub logger: Arc<Logger>,
+	pub logger: Arc<dyn Logger>,
 }
 
 impl<R: ::std::io::Read> ReadableArgs<R, RouterReadArgs> for Router {
@@ -742,7 +742,7 @@ struct DummyDirectionalChannelInfo {
 
 impl Router {
 	/// Creates a new router with the given node_id to be used as the source for get_route()
-	pub fn new(our_pubkey: PublicKey, chain_monitor: Arc<ChainWatchInterface>, logger: Arc<Logger>) -> Router {
+	pub fn new(our_pubkey: PublicKey, chain_monitor: Arc<dyn ChainWatchInterface>, logger: Arc<dyn Logger>) -> Router {
 		let mut nodes = BTreeMap::new();
 		nodes.insert(our_pubkey.clone(), NodeInfo {
 			channels: Vec::new(),

--- a/src/util/logger.rs
+++ b/src/util/logger.rs
@@ -121,7 +121,7 @@ pub trait Logger: Sync + Send {
 	fn log(&self, record: &Record);
 }
 
-pub(crate) struct LogHolder<'a> { pub(crate) logger: &'a Arc<Logger> }
+pub(crate) struct LogHolder<'a> { pub(crate) logger: &'a Arc<dyn Logger> }
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Referring to trait objects as `TraitName` instead of `dyn TraitName` is deprecated.