### PR TITLE
Implement option_upfront_shutdown_script on both sides

### DIFF
--- a/fuzz/fuzz_targets/chanmon_fail_consistency.rs
+++ b/fuzz/fuzz_targets/chanmon_fail_consistency.rs
@@ -36,7 +36,7 @@ use lightning::ln::channelmonitor;
 use lightning::ln::channelmonitor::{ChannelMonitorUpdateErr, HTLCUpdate};
 use lightning::ln::channelmanager::{ChannelManager, PaymentHash, PaymentPreimage};
 use lightning::ln::router::{Route, RouteHop};
-use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, ErrorAction, HandleError, UpdateAddHTLC};
+use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, ErrorAction, HandleError, UpdateAddHTLC, LocalFeatures};
 use lightning::util::{reset_rng_state, fill_bytes, events};
 use lightning::util::logger::Logger;
 use lightning::util::config::UserConfig;
@@ -168,7 +168,7 @@ pub fn do_test(data: &[u8]) {
 				} else { panic!("Wrong event type"); }
 			};
 
-			$dest.handle_open_channel(&$source.get_our_node_id(), &open_channel).unwrap();
+			$dest.handle_open_channel(&$source.get_our_node_id(), LocalFeatures::new(), &open_channel).unwrap();
 			let accept_channel = {
 				let events = $dest.get_and_clear_pending_msg_events();
 				assert_eq!(events.len(), 1);
@@ -177,7 +177,7 @@ pub fn do_test(data: &[u8]) {
 				} else { panic!("Wrong event type"); }
 			};
 
-			$source.handle_accept_channel(&$dest.get_our_node_id(), &accept_channel).unwrap();
+			$source.handle_accept_channel(&$dest.get_our_node_id(), LocalFeatures::new(), &accept_channel).unwrap();
 			{
 				let events = $source.get_and_clear_pending_events();
 				assert_eq!(events.len(), 1);

--- a/src/ln/chanmon_update_fail_tests.rs
+++ b/src/ln/chanmon_update_fail_tests.rs
@@ -18,7 +18,7 @@ use ln::functional_test_utils::*;
 #[test]
 fn test_simple_monitor_permanent_update_fail() {
 	// Test that we handle a simple permanent monitor update failure
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
@@ -48,7 +48,7 @@ fn test_simple_monitor_permanent_update_fail() {
 fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	// Test that we can recover from a simple temporary monitor update failure optionally with
 	// a disconnect in between
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
@@ -147,7 +147,7 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	// * We then walk through more message exchanges to get the original update_add_htlc
 	//   through, swapping message ordering based on disconnect_count & 8 and optionally
 	//   disconnect/reconnecting based on disconnect_count.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
@@ -473,7 +473,7 @@ fn test_monitor_temporary_update_fail_c() {
 #[test]
 fn test_monitor_update_fail_cs() {
 	// Tests handling of a monitor update failure when processing an incoming commitment_signed
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
@@ -552,7 +552,7 @@ fn test_monitor_update_fail_no_rebroadcast() {
 	// Tests handling of a monitor update failure when no message rebroadcasting on
 	// test_restore_channel_monitor() is required. Backported from
 	// chanmon_fail_consistency fuzz tests.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
@@ -594,7 +594,7 @@ fn test_monitor_update_fail_no_rebroadcast() {
 fn test_monitor_update_raa_while_paused() {
 	// Tests handling of an RAA while monitor updating has already been marked failed.
 	// Backported from chanmon_fail_consistency fuzz tests as this used to be broken.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	send_payment(&nodes[0], &[&nodes[1]], 5000000);
@@ -661,7 +661,7 @@ fn test_monitor_update_raa_while_paused() {
 
 fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	// Tests handling of a monitor update failure when processing an incoming RAA
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -914,7 +914,7 @@ fn test_monitor_update_fail_reestablish() {
 	// Simple test for message retransmission after monitor update failure on
 	// channel_reestablish generating a monitor update (which comes from freeing holding cell
 	// HTLCs).
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -992,7 +992,7 @@ fn raa_no_response_awaiting_raa_state() {
 	// due to a previous monitor update failure, we still set AwaitingRemoteRevoke on the channel
 	// in question (assuming it intends to respond with a CS after monitor updating is restored).
 	// Backported from chanmon_fail_consistency fuzz tests as this used to be broken.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
@@ -1105,7 +1105,7 @@ fn claim_while_disconnected_monitor_update_fail() {
 	// Backported from chanmon_fail_consistency fuzz tests as an unmerged version of the handling
 	// code introduced a regression in this test (specifically, this caught a removal of the
 	// channel_reestablish handling ensuring the order was sensical given the messages used).
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Forward a payment for B to claim
@@ -1220,7 +1220,7 @@ fn monitor_failed_no_reestablish_response() {
 	// response to a commitment_signed.
 	// Backported from chanmon_fail_consistency fuzz tests as it caught a long-standing
 	// debug_assert!() failure in channel_reestablish handling.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Route the payment and deliver the initial commitment_signed (with a monitor update failure
@@ -1286,7 +1286,7 @@ fn first_message_on_recv_ordering() {
 	// have no pending response but will want to send a RAA/CS (with the updates for the second
 	// payment applied).
 	// Backported from chanmon_fail_consistency fuzz tests as it caught a bug here.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Route the first payment outbound, holding the last RAA for B until we are set up so that we
@@ -1371,7 +1371,7 @@ fn test_monitor_update_fail_claim() {
 	// update to claim the payment. We then send a payment C->B->A, making the forward of this
 	// payment from B to A fail due to the paused channel. Finally, we restore the channel monitor
 	// updating and claim the payment on B.
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -1441,7 +1441,7 @@ fn test_monitor_update_on_pending_forwards() {
 	// We do this with a simple 3-node network, sending a payment from A to C and one from C to A.
 	// The payment from A to C will be failed by C and pending a back-fail to A, while the payment
 	// from C to A will be pending a forward to A.
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -1505,7 +1505,7 @@ fn monitor_update_claim_fail_no_response() {
 	// to channel being AwaitingRAA).
 	// Backported from chanmon_fail_consistency fuzz tests as an unmerged version of the handling
 	// code was broken.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Forward a payment for B to claim

--- a/src/ln/chanmon_update_fail_tests.rs
+++ b/src/ln/chanmon_update_fail_tests.rs
@@ -6,7 +6,7 @@
 use ln::channelmanager::{RAACommitmentOrder, PaymentPreimage, PaymentHash};
 use ln::channelmonitor::ChannelMonitorUpdateErr;
 use ln::msgs;
-use ln::msgs::ChannelMessageHandler;
+use ln::msgs::{ChannelMessageHandler, LocalFeatures};
 use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsProvider};
 use util::errors::APIError;
 
@@ -19,7 +19,7 @@ use ln::functional_test_utils::*;
 fn test_simple_monitor_permanent_update_fail() {
 	// Test that we handle a simple permanent monitor update failure
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
@@ -49,7 +49,7 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	// Test that we can recover from a simple temporary monitor update failure optionally with
 	// a disconnect in between
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
@@ -148,7 +148,7 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	//   through, swapping message ordering based on disconnect_count & 8 and optionally
 	//   disconnect/reconnecting based on disconnect_count.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
 
@@ -474,7 +474,7 @@ fn test_monitor_temporary_update_fail_c() {
 fn test_monitor_update_fail_cs() {
 	// Tests handling of a monitor update failure when processing an incoming commitment_signed
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -553,7 +553,7 @@ fn test_monitor_update_fail_no_rebroadcast() {
 	// test_restore_channel_monitor() is required. Backported from
 	// chanmon_fail_consistency fuzz tests.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -595,7 +595,7 @@ fn test_monitor_update_raa_while_paused() {
 	// Tests handling of an RAA while monitor updating has already been marked failed.
 	// Backported from chanmon_fail_consistency fuzz tests as this used to be broken.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	send_payment(&nodes[0], &[&nodes[1]], 5000000);
 
@@ -662,8 +662,8 @@ fn test_monitor_update_raa_while_paused() {
 fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	// Tests handling of a monitor update failure when processing an incoming RAA
 	let mut nodes = create_network(3);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance a bit so that we can send backwards from 2 to 1.
 	send_payment(&nodes[0], &[&nodes[1], &nodes[2]], 5000000);
@@ -915,8 +915,8 @@ fn test_monitor_update_fail_reestablish() {
 	// channel_reestablish generating a monitor update (which comes from freeing holding cell
 	// HTLCs).
 	let mut nodes = create_network(3);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 1000000);
 
@@ -993,7 +993,7 @@ fn raa_no_response_awaiting_raa_state() {
 	// in question (assuming it intends to respond with a CS after monitor updating is restored).
 	// Backported from chanmon_fail_consistency fuzz tests as this used to be broken.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
@@ -1106,7 +1106,7 @@ fn claim_while_disconnected_monitor_update_fail() {
 	// code introduced a regression in this test (specifically, this caught a removal of the
 	// channel_reestablish handling ensuring the order was sensical given the messages used).
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Forward a payment for B to claim
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
@@ -1221,7 +1221,7 @@ fn monitor_failed_no_reestablish_response() {
 	// Backported from chanmon_fail_consistency fuzz tests as it caught a long-standing
 	// debug_assert!() failure in channel_reestablish handling.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Route the payment and deliver the initial commitment_signed (with a monitor update failure
 	// on receipt).
@@ -1287,7 +1287,7 @@ fn first_message_on_recv_ordering() {
 	// payment applied).
 	// Backported from chanmon_fail_consistency fuzz tests as it caught a bug here.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Route the first payment outbound, holding the last RAA for B until we are set up so that we
 	// can deliver it and fail the monitor update.
@@ -1372,8 +1372,8 @@ fn test_monitor_update_fail_claim() {
 	// payment from B to A fail due to the paused channel. Finally, we restore the channel monitor
 	// updating and claim the payment on B.
 	let mut nodes = create_network(3);
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance a bit so that we can send backwards from 3 to 2.
 	send_payment(&nodes[0], &[&nodes[1], &nodes[2]], 5000000);
@@ -1442,8 +1442,8 @@ fn test_monitor_update_on_pending_forwards() {
 	// The payment from A to C will be failed by C and pending a back-fail to A, while the payment
 	// from C to A will be pending a forward to A.
 	let mut nodes = create_network(3);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance a bit so that we can send backwards from 3 to 1.
 	send_payment(&nodes[0], &[&nodes[1], &nodes[2]], 5000000);
@@ -1506,7 +1506,7 @@ fn monitor_update_claim_fail_no_response() {
 	// Backported from chanmon_fail_consistency fuzz tests as an unmerged version of the handling
 	// code was broken.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Forward a payment for B to claim
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -16,7 +16,7 @@ use secp256k1::{Secp256k1,Signature};
 use secp256k1;
 
 use ln::msgs;
-use ln::msgs::{DecodeError, OptionalField};
+use ln::msgs::{DecodeError, OptionalField, LocalFeatures};
 use ln::channelmonitor::ChannelMonitor;
 use ln::channelmanager::{PendingHTLCStatus, HTLCSource, HTLCFailReason, HTLCFailureMsg, PendingForwardHTLCInfo, RAACommitmentOrder, PaymentPreimage, PaymentHash};
 use ln::chan_utils::{TxCreationKeys,HTLCOutputInCommitment,HTLC_SUCCESS_TX_WEIGHT,HTLC_TIMEOUT_TX_WEIGHT};
@@ -522,7 +522,7 @@ impl Channel {
 
 	/// Creates a new channel from a remote sides' request for one.
 	/// Assumes chain_hash has already been checked and corresponds with what we expect!
-	pub fn new_from_req(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, msg: &msgs::OpenChannel, user_id: u64, logger: Arc<Logger>, config: &UserConfig) -> Result<Channel, ChannelError> {
+	pub fn new_from_req(fee_estimator: &FeeEstimator, keys_provider: &Arc<KeysInterface>, their_node_id: PublicKey, _their_local_features: LocalFeatures, msg: &msgs::OpenChannel, user_id: u64, logger: Arc<Logger>, config: &UserConfig) -> Result<Channel, ChannelError> {
 		let chan_keys = keys_provider.get_channel_keys(true);
 		let mut local_config = (*config).channel_options.clone();
 
@@ -1341,7 +1341,7 @@ impl Channel {
 
 	// Message handlers:
 
-	pub fn accept_channel(&mut self, msg: &msgs::AcceptChannel, config: &UserConfig) -> Result<(), ChannelError> {
+	pub fn accept_channel(&mut self, msg: &msgs::AcceptChannel, config: &UserConfig, _their_local_features: LocalFeatures) -> Result<(), ChannelError> {
 		// Check sanity of message fields:
 		if !self.channel_outbound {
 			return Err(ChannelError::Close("Got an accept_channel message from an inbound peer"));

--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -3081,7 +3081,7 @@ impl Channel {
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, &self.local_keys.htlc_base_key),
 			first_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &local_commitment_secret),
 			channel_flags: if self.config.announced_channel {1} else {0},
-			shutdown_scriptpubkey: OptionalField::Absent
+			shutdown_scriptpubkey: OptionalField::Present(if self.config.commit_upfront_shutdown_pubkey { self.get_closing_scriptpubkey() } else { Builder::new().into_script() })
 		}
 	}
 
@@ -3113,7 +3113,7 @@ impl Channel {
 			delayed_payment_basepoint: PublicKey::from_secret_key(&self.secp_ctx, &self.local_keys.delayed_payment_base_key),
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, &self.local_keys.htlc_base_key),
 			first_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &local_commitment_secret),
-			shutdown_scriptpubkey: OptionalField::Absent
+			shutdown_scriptpubkey: OptionalField::Present(if self.config.commit_upfront_shutdown_pubkey { self.get_closing_scriptpubkey() } else { Builder::new().into_script() })
 		}
 	}
 

--- a/src/ln/functional_test_utils.rs
+++ b/src/ln/functional_test_utils.rs
@@ -827,7 +827,7 @@ pub fn fail_payment(origin_node: &Node, expected_route: &[&Node], our_payment_ha
 	fail_payment_along_route(origin_node, expected_route, false, our_payment_hash);
 }
 
-pub fn create_network(node_count: usize) -> Vec<Node> {
+pub fn create_network(node_count: usize, node_config: &[Option<UserConfig>]) -> Vec<Node> {
 	let mut nodes = Vec::new();
 	let mut rng = thread_rng();
 	let secp_ctx = Secp256k1::new();
@@ -844,10 +844,10 @@ pub fn create_network(node_count: usize) -> Vec<Node> {
 		rng.fill_bytes(&mut seed);
 		let keys_manager = Arc::new(test_utils::TestKeysInterface::new(&seed, Network::Testnet, Arc::clone(&logger)));
 		let chan_monitor = Arc::new(test_utils::TestChannelMonitor::new(chain_monitor.clone(), tx_broadcaster.clone(), logger.clone(), feeest.clone()));
-		let mut config = UserConfig::new();
-		config.channel_options.announced_channel = true;
-		config.peer_channel_config_limits.force_announced_channel_preference = false;
-		let node = ChannelManager::new(Network::Testnet, feeest.clone(), chan_monitor.clone(), chain_monitor.clone(), tx_broadcaster.clone(), Arc::clone(&logger), keys_manager.clone(), config).unwrap();
+		let mut default_config = UserConfig::new();
+		default_config.channel_options.announced_channel = true;
+		default_config.peer_channel_config_limits.force_announced_channel_preference = false;
+		let node = ChannelManager::new(Network::Testnet, feeest.clone(), chan_monitor.clone(), chain_monitor.clone(), tx_broadcaster.clone(), Arc::clone(&logger), keys_manager.clone(), if node_config[i].is_some() { node_config[i].clone().unwrap() } else { default_config }).unwrap();
 		let router = Router::new(PublicKey::from_secret_key(&secp_ctx, &keys_manager.get_node_secret()), chain_monitor.clone(), Arc::clone(&logger));
 		nodes.push(Node { chain_monitor, tx_broadcaster, chan_monitor, node, router, keys_manager, node_seed: seed,
 			network_payment_count: payment_count.clone(),

--- a/src/ln/functional_test_utils.rs
+++ b/src/ln/functional_test_utils.rs
@@ -7,7 +7,7 @@ use chain::keysinterface::KeysInterface;
 use ln::channelmanager::{ChannelManager,RAACommitmentOrder, PaymentPreimage, PaymentHash};
 use ln::router::{Route, Router};
 use ln::msgs;
-use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler};
+use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler, LocalFeatures};
 use util::test_utils;
 use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsProvider};
 use util::errors::APIError;
@@ -174,8 +174,8 @@ macro_rules! get_feerate {
 
 pub fn create_chan_between_nodes_with_value_init(node_a: &Node, node_b: &Node, channel_value: u64, push_msat: u64) -> Transaction {
 	node_a.node.create_channel(node_b.node.get_our_node_id(), channel_value, push_msat, 42).unwrap();
-	node_b.node.handle_open_channel(&node_a.node.get_our_node_id(), &get_event_msg!(node_a, MessageSendEvent::SendOpenChannel, node_b.node.get_our_node_id())).unwrap();
-	node_a.node.handle_accept_channel(&node_b.node.get_our_node_id(), &get_event_msg!(node_b, MessageSendEvent::SendAcceptChannel, node_a.node.get_our_node_id())).unwrap();
+	node_b.node.handle_open_channel(&node_a.node.get_our_node_id(), LocalFeatures::new(), &get_event_msg!(node_a, MessageSendEvent::SendOpenChannel, node_b.node.get_our_node_id())).unwrap();
+	node_a.node.handle_accept_channel(&node_b.node.get_our_node_id(), LocalFeatures::new(), &get_event_msg!(node_b, MessageSendEvent::SendAcceptChannel, node_a.node.get_our_node_id())).unwrap();
 
 	let chan_id = *node_a.network_chan_count.borrow();
 	let tx;

--- a/src/ln/functional_tests.rs
+++ b/src/ln/functional_tests.rs
@@ -13,7 +13,7 @@ use ln::channel::{ACCEPTED_HTLC_SCRIPT_WEIGHT, OFFERED_HTLC_SCRIPT_WEIGHT};
 use ln::onion_utils;
 use ln::router::{Route, RouteHop};
 use ln::msgs;
-use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler,HTLCFailChannelUpdate};
+use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler,HTLCFailChannelUpdate, LocalFeatures};
 use util::test_utils;
 use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsProvider};
 use util::errors::APIError;
@@ -4861,7 +4861,7 @@ fn bolt2_open_channel_sending_node_checks_part1() { //This test needs to be on i
 	let push_msat=10001;
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), channel_value_satoshis, push_msat, 42).unwrap();
 	let node0_to_1_send_open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
-	nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), &node0_to_1_send_open_channel).unwrap();
+	nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), LocalFeatures::new(), &node0_to_1_send_open_channel).unwrap();
 
 	//Create a second channel with a channel_id collision
 	assert!(nodes[0].node.create_channel(nodes[0].node.get_our_node_id(), channel_value_satoshis, push_msat, 42).is_err());

--- a/src/ln/functional_tests.rs
+++ b/src/ln/functional_tests.rs
@@ -50,7 +50,7 @@ use ln::functional_test_utils::*;
 #[test]
 fn test_async_inbound_update_fee() {
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	// balancing
@@ -160,7 +160,7 @@ fn test_update_fee_unordered_raa() {
 	// Just the intro to the previous test followed by an out-of-order RAA (which caused a
 	// crash in an earlier version of the update_fee patch)
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	// balancing
@@ -210,7 +210,7 @@ fn test_update_fee_unordered_raa() {
 #[test]
 fn test_multi_flight_update_fee() {
 	let nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	// A                                        B
@@ -314,7 +314,7 @@ fn test_multi_flight_update_fee() {
 #[test]
 fn test_update_fee_vanilla() {
 	let nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	let feerate = get_feerate!(nodes[0], channel_id);
@@ -353,7 +353,7 @@ fn test_update_fee_vanilla() {
 fn test_update_fee_that_funder_cannot_afford() {
 	let nodes = create_network(2);
 	let channel_value = 1888;
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 700000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 700000, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	let feerate = 260;
@@ -405,7 +405,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 #[test]
 fn test_update_fee_with_fundee_update_add_htlc() {
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	// balancing
@@ -499,7 +499,7 @@ fn test_update_fee_with_fundee_update_add_htlc() {
 #[test]
 fn test_update_fee() {
 	let nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
 	// A                                        B
@@ -600,7 +600,7 @@ fn test_update_fee() {
 fn pre_funding_lock_shutdown_test() {
 	// Test sending a shutdown prior to funding_locked after funding generation
 	let nodes = create_network(2);
-	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 8000000, 0);
+	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 8000000, 0, LocalFeatures::new(), LocalFeatures::new());
 	let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 	nodes[0].chain_monitor.block_connected_checked(&header, 1, &[&tx; 1], &[1; 1]);
 	nodes[1].chain_monitor.block_connected_checked(&header, 1, &[&tx; 1], &[1; 1]);
@@ -626,8 +626,8 @@ fn pre_funding_lock_shutdown_test() {
 fn updates_shutdown_wait() {
 	// Test sending a shutdown with outstanding updates pending
 	let mut nodes = create_network(3);
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 	let route_1 = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
 	let route_2 = nodes[1].router.get_route(&nodes[0].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
 
@@ -698,8 +698,8 @@ fn updates_shutdown_wait() {
 fn htlc_fail_async_shutdown() {
 	// Test HTLCs fail if shutdown starts even if messages are delivered out-of-order
 	let mut nodes = create_network(3);
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -779,8 +779,8 @@ fn do_test_shutdown_rebroadcast(recv_count: u8) {
 	// Test that shutdown/closing_signed is re-sent on reconnect with a variable number of
 	// messages delivered prior to disconnect
 	let nodes = create_network(3);
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 100000);
 
@@ -934,9 +934,9 @@ fn fake_network_test() {
 	let nodes = create_network(4);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
-	let chan_3 = create_announced_chan_between_nodes(&nodes, 2, 3);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
+	let chan_3 = create_announced_chan_between_nodes(&nodes, 2, 3, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network a bit by relaying one payment through all the channels...
 	send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], 8000000);
@@ -954,7 +954,7 @@ fn fake_network_test() {
 	fail_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3])[..], payment_hash_1);
 
 	// Add a new channel that skips 3
-	let chan_4 = create_announced_chan_between_nodes(&nodes, 1, 3);
+	let chan_4 = create_announced_chan_between_nodes(&nodes, 1, 3, LocalFeatures::new(), LocalFeatures::new());
 
 	send_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 1000000);
 	send_payment(&nodes[2], &vec!(&nodes[3])[..], 1000000);
@@ -1016,7 +1016,7 @@ fn fake_network_test() {
 	claim_payment(&nodes[1], &vec!(&nodes[2], &nodes[3], &nodes[1])[..], payment_preimage_1);
 
 	// Add a duplicate new channel from 2 to 4
-	let chan_5 = create_announced_chan_between_nodes(&nodes, 1, 3);
+	let chan_5 = create_announced_chan_between_nodes(&nodes, 1, 3, LocalFeatures::new(), LocalFeatures::new());
 
 	// Send some payments across both channels
 	let payment_preimage_3 = route_payment(&nodes[0], &vec!(&nodes[1], &nodes[3])[..], 3000000).0;
@@ -1045,8 +1045,8 @@ fn holding_cell_htlc_counting() {
 	// to ensure we don't end up with HTLCs sitting around in our holding cell for several
 	// commitment dance rounds.
 	let mut nodes = create_network(3);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let mut payments = Vec::new();
 	for _ in 0..::ln::channel::OUR_MAX_HTLCS {
@@ -1172,11 +1172,11 @@ fn duplicate_htlc_test() {
 	let mut nodes = create_network(6);
 
 	// Create some initial channels to route via 3 to 4/5 from 0/1/2
-	create_announced_chan_between_nodes(&nodes, 0, 3);
-	create_announced_chan_between_nodes(&nodes, 1, 3);
-	create_announced_chan_between_nodes(&nodes, 2, 3);
-	create_announced_chan_between_nodes(&nodes, 3, 4);
-	create_announced_chan_between_nodes(&nodes, 3, 5);
+	create_announced_chan_between_nodes(&nodes, 0, 3, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 3, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 2, 3, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 3, 4, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 3, 5, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage, payment_hash) = route_payment(&nodes[0], &vec!(&nodes[3], &nodes[4])[..], 1000000);
 
@@ -1197,8 +1197,8 @@ fn do_channel_reserve_test(test_recv: bool) {
 	use ln::msgs::HandleError;
 
 	let mut nodes = create_network(3);
-	let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1900, 1001);
-	let chan_2 = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1900, 1001);
+	let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1900, 1001, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1900, 1001, LocalFeatures::new(), LocalFeatures::new());
 
 	let mut stat01 = get_channel_value_stat!(nodes[0], chan_1.2);
 	let mut stat11 = get_channel_value_stat!(nodes[1], chan_1.2);
@@ -1474,7 +1474,7 @@ fn channel_reserve_in_flight_removes() {
 	//  * Now B happily sends another HTLC, potentially violating its reserve value from A's point
 	//    of view (if A counts the AwaitingRemovedRemoteRevoke HTLC).
 	let mut nodes = create_network(2);
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let b_chan_values = get_channel_value_stat!(nodes[1], chan_1.2);
 	// Route the first two HTLCs.
@@ -1603,10 +1603,10 @@ fn channel_monitor_network_test() {
 	let nodes = create_network(5);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
-	let chan_3 = create_announced_chan_between_nodes(&nodes, 2, 3);
-	let chan_4 = create_announced_chan_between_nodes(&nodes, 3, 4);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
+	let chan_3 = create_announced_chan_between_nodes(&nodes, 2, 3, LocalFeatures::new(), LocalFeatures::new());
+	let chan_4 = create_announced_chan_between_nodes(&nodes, 3, 4, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network a bit by relaying one payment through all the channels...
 	send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2], &nodes[3], &nodes[4])[..], 8000000);
@@ -1729,7 +1729,7 @@ fn test_justice_tx() {
 
 	let nodes = create_network(2);
 	// Create some new channels:
-	let chan_5 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_5 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// A pending HTLC which will be revoked:
 	let payment_preimage_3 = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
@@ -1772,7 +1772,7 @@ fn test_justice_tx() {
 
 	// We test justice_tx build by A on B's revoked HTLC-Success tx
 	// Create some new channels:
-	let chan_6 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_6 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// A pending HTLC which will be revoked:
 	let payment_preimage_4 = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
@@ -1814,7 +1814,7 @@ fn revoked_output_claim() {
 	// Simple test to ensure a node will claim a revoked output when a stale remote commitment
 	// transaction is broadcast by its counterparty
 	let nodes = create_network(2);
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	// node[0] is gonna to revoke an old state thus node[1] should be able to claim the revoked output
 	let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
 	assert_eq!(revoked_local_txn.len(), 1);
@@ -1845,7 +1845,7 @@ fn claim_htlc_outputs_shared_tx() {
 	let nodes = create_network(2);
 
 	// Create some new channel:
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network to generate htlc in the two directions
 	send_payment(&nodes[0], &vec!(&nodes[1])[..], 8000000);
@@ -1919,7 +1919,7 @@ fn claim_htlc_outputs_single_tx() {
 	// Node revoked old state, htlcs have timed out, claim each of them in separated justice tx
 	let nodes = create_network(2);
 
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network to generate htlc in the two directions
 	send_payment(&nodes[0], &vec!(&nodes[1])[..], 8000000);
@@ -2017,8 +2017,8 @@ fn test_htlc_on_chain_success() {
 	let nodes = create_network(3);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network a bit by relaying one payment through all the channels...
 	send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2])[..], 8000000);
@@ -2178,8 +2178,8 @@ fn test_htlc_on_chain_timeout() {
 	let nodes = create_network(3);
 
 	// Create some intial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network a bit by relaying one payment thorugh all the channels...
 	send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2])[..], 8000000);
@@ -2286,8 +2286,8 @@ fn test_simple_commitment_revoked_fail_backward() {
 	let nodes = create_network(3);
 
 	// Create some initial channels
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage, _payment_hash) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 3000000);
 	// Get the will-be-revoked local txn from nodes[2]
@@ -2354,8 +2354,8 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	let mut nodes = create_network(3);
 
 	// Create some initial channels
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage, _payment_hash) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], if no_to_remote { 10_000 } else { 3_000_000 });
 	// Get the will-be-revoked local txn from nodes[2]
@@ -2563,7 +2563,7 @@ fn test_htlc_ignore_latest_remote_commitment() {
 	// Test that HTLC transactions spending the latest remote commitment transaction are simply
 	// ignored if we cannot claim them. This originally tickled an invalid unwrap().
 	let nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	route_payment(&nodes[0], &[&nodes[1]], 10000000);
 	nodes[0].node.force_close_channel(&nodes[0].node.list_channels()[0].channel_id);
@@ -2585,8 +2585,8 @@ fn test_htlc_ignore_latest_remote_commitment() {
 fn test_force_close_fail_back() {
 	// Check which HTLCs are failed-backwards on channel force-closure
 	let mut nodes = create_network(3);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, 42).unwrap();
 
@@ -2659,7 +2659,7 @@ fn test_force_close_fail_back() {
 fn test_unconf_chan() {
 	// After creating a chan between nodes, we disconnect all blocks previously seen to force a channel close on nodes[0] side
 	let nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let channel_state = nodes[0].node.channel_state.lock().unwrap();
 	assert_eq!(channel_state.by_id.len(), 1);
@@ -2688,8 +2688,8 @@ fn test_unconf_chan() {
 fn test_simple_peer_disconnect() {
 	// Test that we can reconnect when there are no lost messages
 	let nodes = create_network(3);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
@@ -2742,10 +2742,10 @@ fn do_test_drop_messages_peer_disconnect(messages_delivered: u8) {
 	// Test that we can reconnect when in-flight HTLC updates get dropped
 	let mut nodes = create_network(2);
 	if messages_delivered == 0 {
-		create_chan_between_nodes_with_value_a(&nodes[0], &nodes[1], 100000, 10001);
+		create_chan_between_nodes_with_value_a(&nodes[0], &nodes[1], 100000, 10001, LocalFeatures::new(), LocalFeatures::new());
 		// nodes[1] doesn't receive the funding_locked message (it'll be re-sent on reconnect)
 	} else {
-		create_announced_chan_between_nodes(&nodes, 0, 1);
+		create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	}
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), Some(&nodes[0].node.list_usable_channels()), &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
@@ -2947,7 +2947,7 @@ fn test_drop_messages_peer_disconnect_b() {
 fn test_funding_peer_disconnect() {
 	// Test that we can lock in our funding tx while disconnected
 	let nodes = create_network(2);
-	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 100000, 10001);
+	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 100000, 10001, LocalFeatures::new(), LocalFeatures::new());
 
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
@@ -2998,7 +2998,7 @@ fn test_drop_messages_peer_disconnect_dual_htlc() {
 	// Test that we can handle reconnecting when both sides of a channel have pending
 	// commitment_updates when we disconnect.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
 
@@ -3138,7 +3138,7 @@ fn test_invalid_channel_announcement() {
 	let secp_ctx = Secp256k1::new();
 	let nodes = create_network(2);
 
-	let chan_announcement = create_chan_between_nodes(&nodes[0], &nodes[1]);
+	let chan_announcement = create_chan_between_nodes(&nodes[0], &nodes[1], LocalFeatures::new(), LocalFeatures::new());
 
 	let a_channel_lock = nodes[0].node.channel_state.lock().unwrap();
 	let b_channel_lock = nodes[1].node.channel_state.lock().unwrap();
@@ -3210,7 +3210,7 @@ fn test_invalid_channel_announcement() {
 fn test_no_txn_manager_serialize_deserialize() {
 	let mut nodes = create_network(2);
 
-	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 100000, 10001);
+	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 100000, 10001, LocalFeatures::new(), LocalFeatures::new());
 
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
@@ -3273,7 +3273,7 @@ fn test_no_txn_manager_serialize_deserialize() {
 #[test]
 fn test_simple_manager_serialize_deserialize() {
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
 	let (_, our_payment_hash) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
@@ -3321,9 +3321,9 @@ fn test_simple_manager_serialize_deserialize() {
 fn test_manager_serialize_deserialize_inconsistent_monitor() {
 	// Test deserializing a ChannelManager with an out-of-date ChannelMonitor
 	let mut nodes = create_network(4);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	create_announced_chan_between_nodes(&nodes, 2, 0);
-	let (_, _, channel_id, funding_tx) = create_announced_chan_between_nodes(&nodes, 0, 3);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 2, 0, LocalFeatures::new(), LocalFeatures::new());
+	let (_, _, channel_id, funding_tx) = create_announced_chan_between_nodes(&nodes, 0, 3, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[2], &[&nodes[0], &nodes[1]], 1000000);
 
@@ -3511,7 +3511,7 @@ fn test_claim_sizeable_push_msat() {
 	// Incidentally test SpendableOutput event generation due to detection of to_local output on commitment tx
 	let nodes = create_network(2);
 
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000, LocalFeatures::new(), LocalFeatures::new());
 	nodes[1].node.force_close_channel(&chan.2);
 	check_closed_broadcast!(nodes[1]);
 	let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
@@ -3533,7 +3533,7 @@ fn test_claim_on_remote_sizeable_push_msat() {
 
 	let nodes = create_network(2);
 
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000, LocalFeatures::new(), LocalFeatures::new());
 	nodes[0].node.force_close_channel(&chan.2);
 	check_closed_broadcast!(nodes[0]);
 
@@ -3558,7 +3558,7 @@ fn test_claim_on_remote_revoked_sizeable_push_msat() {
 
 	let nodes = create_network(2);
 
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 59000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 59000000, LocalFeatures::new(), LocalFeatures::new());
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
 	let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().last_local_commitment_txn.clone();
 	assert_eq!(revoked_local_txn[0].input.len(), 1);
@@ -3583,7 +3583,7 @@ fn test_static_spendable_outputs_preimage_tx() {
 	let nodes = create_network(2);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
 
@@ -3624,7 +3624,7 @@ fn test_static_spendable_outputs_justice_tx_revoked_commitment_tx() {
 	let nodes = create_network(2);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
 	let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.iter().next().unwrap().1.last_local_commitment_txn.clone();
@@ -3654,7 +3654,7 @@ fn test_static_spendable_outputs_justice_tx_revoked_htlc_timeout_tx() {
 	let nodes = create_network(2);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
 	let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
@@ -3698,7 +3698,7 @@ fn test_static_spendable_outputs_justice_tx_revoked_htlc_success_tx() {
 	let nodes = create_network(2);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
 	let revoked_local_txn = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
@@ -3751,8 +3751,8 @@ fn test_onchain_to_onchain_claim() {
 	let nodes = create_network(3);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance the network a bit by relaying one payment through all the channels ...
 	send_payment(&nodes[0], &vec!(&nodes[1], &nodes[2])[..], 8000000);
@@ -3838,8 +3838,8 @@ fn test_duplicate_payment_hash_one_failure_one_success() {
 	// We route 2 payments with same hash between B and C, one will be timeout, the other successfully claim
 	let mut nodes = create_network(3);
 
-	create_announced_chan_between_nodes(&nodes, 0, 1);
-	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
+	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, duplicate_payment_hash) = route_payment(&nodes[0], &vec!(&nodes[1], &nodes[2])[..], 900000);
 	*nodes[0].network_payment_count.borrow_mut() -= 1;
@@ -3953,7 +3953,7 @@ fn test_dynamic_spendable_outputs_local_htlc_success_tx() {
 	let nodes = create_network(2);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 9000000).0;
 	let local_txn = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
@@ -4001,11 +4001,11 @@ fn do_test_fail_backwards_unrevoked_remote_announce(deliver_last_raa: bool, anno
 	// And test where C fails back to A/B when D announces its latest commitment transaction
 	let nodes = create_network(6);
 
-	create_announced_chan_between_nodes(&nodes, 0, 2);
-	create_announced_chan_between_nodes(&nodes, 1, 2);
-	let chan = create_announced_chan_between_nodes(&nodes, 2, 3);
-	create_announced_chan_between_nodes(&nodes, 3, 4);
-	create_announced_chan_between_nodes(&nodes, 3, 5);
+	create_announced_chan_between_nodes(&nodes, 0, 2, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
+	let chan = create_announced_chan_between_nodes(&nodes, 2, 3, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 3, 4, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes(&nodes, 3, 5, LocalFeatures::new(), LocalFeatures::new());
 
 	// Rebalance and check output sanity...
 	send_payment(&nodes[0], &[&nodes[2], &nodes[3], &nodes[4]], 500000);
@@ -4241,7 +4241,7 @@ fn test_dynamic_spendable_outputs_local_htlc_timeout_tx() {
 	let nodes = create_network(2);
 
 	// Create some initial channels
-	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	route_payment(&nodes[0], &vec!(&nodes[1])[..], 9000000).0;
 	let local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
@@ -4275,7 +4275,7 @@ fn test_dynamic_spendable_outputs_local_htlc_timeout_tx() {
 fn test_static_output_closing_tx() {
 	let nodes = create_network(2);
 
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	send_payment(&nodes[0], &vec!(&nodes[1])[..], 8000000);
 	let closing_tx = close_channel(&nodes[0], &nodes[1], &chan.2, chan.3, true).2;
@@ -4294,7 +4294,7 @@ fn test_static_output_closing_tx() {
 
 fn do_htlc_claim_local_commitment_only(use_dust: bool) {
 	let nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[0], &[&nodes[1]], if use_dust { 50000 } else { 3000000 });
 
@@ -4331,7 +4331,7 @@ fn do_htlc_claim_local_commitment_only(use_dust: bool) {
 
 fn do_htlc_claim_current_remote_commitment_only(use_dust: bool) {
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), if use_dust { 50000 } else { 3000000 }, TEST_FINAL_CLTV).unwrap();
 	let (_, payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -4355,7 +4355,7 @@ fn do_htlc_claim_current_remote_commitment_only(use_dust: bool) {
 
 fn do_htlc_claim_previous_remote_commitment_only(use_dust: bool, check_revoke_no_close: bool) {
 	let nodes = create_network(3);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Fail the payment, but don't deliver A's final RAA, resulting in the HTLC only being present
 	// in B's previous (unrevoked) commitment transaction, but none of A's commitment transactions.
@@ -4642,7 +4642,7 @@ fn test_onion_failure() {
 	for node in nodes.iter() {
 		*node.keys_manager.override_session_priv.lock().unwrap() = Some(SecretKey::from_slice(&[3; 32]).unwrap());
 	}
-	let channels = [create_announced_chan_between_nodes(&nodes, 0, 1), create_announced_chan_between_nodes(&nodes, 1, 2)];
+	let channels = [create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new()), create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new())];
 	let (_, payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 40000, TEST_FINAL_CLTV).unwrap();
 	// positve case
@@ -4918,7 +4918,7 @@ fn test_update_add_htlc_bolt2_sender_value_below_minimum_msat() {
 	//BOLT2 Requirement: MUST offer amount_msat greater than 0.
 	//BOLT2 Requirement: MUST NOT offer amount_msat below the receiving node's htlc_minimum_msat (same validation check catches both of these)
 	let mut nodes = create_network(2);
-	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000);
+	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let mut route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 
@@ -4938,7 +4938,7 @@ fn test_update_add_htlc_bolt2_sender_cltv_expiry_too_high() {
 	//BOLT 2 Requirement: MUST set cltv_expiry less than 500000000.
 	//It is enforced when constructing a route.
 	let mut nodes = create_network(2);
-	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 0);
+	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 0, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000000, 500000001).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 
@@ -4957,7 +4957,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_num_and_htlc_id_increment()
 	//BOLT 2 Requirement: for the first HTLC it offers MUST set id to 0.
 	//BOLT 2 Requirement: MUST increase the value of id by 1 for each successive offer.
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 0);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 0, LocalFeatures::new(), LocalFeatures::new());
 	let max_accepted_htlcs = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().their_max_accepted_htlcs as u64;
 
 	for i in 0..max_accepted_htlcs {
@@ -4999,7 +4999,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_value_in_flight() {
 	//BOLT 2 Requirement: if the sum of total offered HTLCs would exceed the remote's max_htlc_value_in_flight_msat: MUST NOT add an HTLC.
 	let mut nodes = create_network(2);
 	let channel_value = 100000;
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 0);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 0, LocalFeatures::new(), LocalFeatures::new());
 	let max_in_flight = get_channel_value_stat!(nodes[0], chan.2).their_max_htlc_value_in_flight_msat;
 
 	send_payment(&nodes[0], &vec!(&nodes[1])[..], max_in_flight);
@@ -5022,7 +5022,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_value_in_flight() {
 fn test_update_add_htlc_bolt2_receiver_check_amount_received_more_than_min() {
 	//BOLT2 Requirement: receiving an amount_msat equal to 0, OR less than its own htlc_minimum_msat -> SHOULD fail the channel.
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let htlc_minimum_msat: u64;
 	{
 		let chan_lock = nodes[0].node.channel_state.lock().unwrap();
@@ -5049,7 +5049,7 @@ fn test_update_add_htlc_bolt2_receiver_check_amount_received_more_than_min() {
 fn test_update_add_htlc_bolt2_receiver_sender_can_afford_amount_sent() {
 	//BOLT2 Requirement: receiving an amount_msat that the sending node cannot afford at the current feerate_per_kw (while maintaining its channel reserve): SHOULD fail the channel
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 
 	let their_channel_reserve = get_channel_value_stat!(nodes[0], chan.2).channel_reserve_msat;
 
@@ -5077,7 +5077,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 	//BOLT 2 Requirement: if a sending node adds more than its max_accepted_htlcs HTLCs to its local commitment transaction: SHOULD fail the channel
 	//BOLT 2 Requirement: MUST allow multiple HTLCs with the same payment_hash.
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 3999999, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 
@@ -5122,7 +5122,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 fn test_update_add_htlc_bolt2_receiver_check_max_in_flight_msat() {
 	//OR adds more than its max_htlc_value_in_flight_msat worth of offered HTLCs to its local commitment transaction: SHOULD fail the channel
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000);
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
@@ -5145,7 +5145,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_in_flight_msat() {
 fn test_update_add_htlc_bolt2_receiver_check_cltv_expiry() {
 	//BOLT2 Requirement: if sending node sets cltv_expiry to greater or equal to 500000000: SHOULD fail the channel.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 3999999, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
@@ -5170,7 +5170,7 @@ fn test_update_add_htlc_bolt2_receiver_check_repeated_id_ignore() {
 	// We test this by first testing that that repeated HTLCs pass commitment signature checks
 	// after disconnect and that non-sequential htlc_ids result in a channel failure.
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
@@ -5215,7 +5215,7 @@ fn test_update_fulfill_htlc_bolt2_update_fulfill_htlc_before_commitment() {
 	//BOLT 2 Requirement: until the corresponding HTLC is irrevocably committed in both sides' commitment transactions:	MUST NOT send an update_fulfill_htlc, update_fail_htlc, or update_fail_malformed_htlc.
 
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (our_payment_preimage, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5247,7 +5247,7 @@ fn test_update_fulfill_htlc_bolt2_update_fail_htlc_before_commitment() {
 	//BOLT 2 Requirement: until the corresponding HTLC is irrevocably committed in both sides' commitment transactions:	MUST NOT send an update_fulfill_htlc, update_fail_htlc, or update_fail_malformed_htlc.
 
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5279,7 +5279,7 @@ fn test_update_fulfill_htlc_bolt2_update_fail_malformed_htlc_before_commitment()
 	//BOLT 2 Requirement: until the corresponding HTLC is irrevocably committed in both sides' commitment transactions:	MUST NOT send an update_fulfill_htlc, update_fail_htlc, or update_fail_malformed_htlc.
 
 	let mut nodes = create_network(2);
-	let chan = create_announced_chan_between_nodes(&nodes, 0, 1);
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5312,7 +5312,7 @@ fn test_update_fulfill_htlc_bolt2_incorrect_htlc_id() {
 	//BOLT 2 Requirement: A receiving node:	if the id does not correspond to an HTLC in its current commitment transaction MUST fail the channel.
 
 	let nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let our_payment_preimage = route_payment(&nodes[0], &[&nodes[1]], 100000).0;
 
@@ -5353,7 +5353,7 @@ fn test_update_fulfill_htlc_bolt2_wrong_preimage() {
 	//BOLT 2 Requirement: A receiving node:	if the payment_preimage value in update_fulfill_htlc doesn't SHA256 hash to the corresponding HTLC payment_hash	MUST fail the channel.
 
 	let nodes = create_network(2);
-	create_announced_chan_between_nodes(&nodes, 0, 1);
+	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let our_payment_preimage = route_payment(&nodes[0], &[&nodes[1]], 100000).0;
 
@@ -5395,7 +5395,7 @@ fn test_update_fulfill_htlc_bolt2_missing_badonion_bit_for_malformed_htlc_messag
 	//BOLT 2 Requirement: A receiving node: if the BADONION bit in failure_code is not set for update_fail_malformed_htlc MUST fail the channel.
 
 	let mut nodes = create_network(2);
-	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
@@ -5441,8 +5441,8 @@ fn test_update_fulfill_htlc_bolt2_after_malformed_htlc_message_must_forward_upda
 	//    * MUST return an error in the update_fail_htlc sent to the link which originally sent the HTLC, using the failure_code given and setting the data to sha256_of_onion.
 
 	let mut nodes = create_network(3);
-	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000);
-	create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1000000, 1000000);
+	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
+	create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 100000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);

--- a/src/ln/functional_tests.rs
+++ b/src/ln/functional_tests.rs
@@ -49,7 +49,7 @@ use ln::functional_test_utils::*;
 
 #[test]
 fn test_async_inbound_update_fee() {
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
@@ -159,7 +159,7 @@ fn test_async_inbound_update_fee() {
 fn test_update_fee_unordered_raa() {
 	// Just the intro to the previous test followed by an out-of-order RAA (which caused a
 	// crash in an earlier version of the update_fee patch)
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
@@ -209,7 +209,7 @@ fn test_update_fee_unordered_raa() {
 
 #[test]
 fn test_multi_flight_update_fee() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
@@ -313,7 +313,7 @@ fn test_multi_flight_update_fee() {
 
 #[test]
 fn test_update_fee_vanilla() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
@@ -351,7 +351,7 @@ fn test_update_fee_vanilla() {
 
 #[test]
 fn test_update_fee_that_funder_cannot_afford() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let channel_value = 1888;
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 700000, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
@@ -404,7 +404,7 @@ fn test_update_fee_that_funder_cannot_afford() {
 
 #[test]
 fn test_update_fee_with_fundee_update_add_htlc() {
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
@@ -498,7 +498,7 @@ fn test_update_fee_with_fundee_update_add_htlc() {
 
 #[test]
 fn test_update_fee() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let channel_id = chan.2;
 
@@ -599,7 +599,7 @@ fn test_update_fee() {
 #[test]
 fn pre_funding_lock_shutdown_test() {
 	// Test sending a shutdown prior to funding_locked after funding generation
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 8000000, 0, LocalFeatures::new(), LocalFeatures::new());
 	let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 	nodes[0].chain_monitor.block_connected_checked(&header, 1, &[&tx; 1], &[1; 1]);
@@ -625,7 +625,7 @@ fn pre_funding_lock_shutdown_test() {
 #[test]
 fn updates_shutdown_wait() {
 	// Test sending a shutdown with outstanding updates pending
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 	let route_1 = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
@@ -697,7 +697,7 @@ fn updates_shutdown_wait() {
 #[test]
 fn htlc_fail_async_shutdown() {
 	// Test HTLCs fail if shutdown starts even if messages are delivered out-of-order
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -778,7 +778,7 @@ fn htlc_fail_async_shutdown() {
 fn do_test_shutdown_rebroadcast(recv_count: u8) {
 	// Test that shutdown/closing_signed is re-sent on reconnect with a variable number of
 	// messages delivered prior to disconnect
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -931,7 +931,7 @@ fn test_shutdown_rebroadcast() {
 fn fake_network_test() {
 	// Simple test which builds a network of ChannelManagers, connects them to each other, and
 	// tests that payments get routed and transactions broadcast in semi-reasonable ways.
-	let nodes = create_network(4);
+	let nodes = create_network(4, &[None, None, None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -1044,7 +1044,7 @@ fn holding_cell_htlc_counting() {
 	// Tests that HTLCs in the holding cell count towards the pending HTLC limits on outbound HTLCs
 	// to ensure we don't end up with HTLCs sitting around in our holding cell for several
 	// commitment dance rounds.
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -1169,7 +1169,7 @@ fn holding_cell_htlc_counting() {
 fn duplicate_htlc_test() {
 	// Test that we accept duplicate payment_hash HTLCs across the network and that
 	// claiming/failing them are all separate and don't affect each other
-	let mut nodes = create_network(6);
+	let mut nodes = create_network(6, &[None, None, None, None, None, None]);
 
 	// Create some initial channels to route via 3 to 4/5 from 0/1/2
 	create_announced_chan_between_nodes(&nodes, 0, 3, LocalFeatures::new(), LocalFeatures::new());
@@ -1196,7 +1196,7 @@ fn do_channel_reserve_test(test_recv: bool) {
 	use std::sync::atomic::Ordering;
 	use ln::msgs::HandleError;
 
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1900, 1001, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1900, 1001, LocalFeatures::new(), LocalFeatures::new());
 
@@ -1473,7 +1473,7 @@ fn channel_reserve_in_flight_removes() {
 	//    removed it fully. B now has the push_msat plus the first two HTLCs in value.
 	//  * Now B happily sends another HTLC, potentially violating its reserve value from A's point
 	//    of view (if A counts the AwaitingRemovedRemoteRevoke HTLC).
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let b_chan_values = get_channel_value_stat!(nodes[1], chan_1.2);
@@ -1600,7 +1600,7 @@ fn channel_reserve_in_flight_removes() {
 fn channel_monitor_network_test() {
 	// Simple test which builds a network of ChannelManagers, connects them to each other, and
 	// tests that ChannelMonitor is able to recover from various states.
-	let nodes = create_network(5);
+	let nodes = create_network(5, &[None, None, None, None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -1727,7 +1727,7 @@ fn channel_monitor_network_test() {
 fn test_justice_tx() {
 	// Test justice txn built on revoked HTLC-Success tx, against both sides
 
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	// Create some new channels:
 	let chan_5 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
@@ -1813,7 +1813,7 @@ fn test_justice_tx() {
 fn revoked_output_claim() {
 	// Simple test to ensure a node will claim a revoked output when a stale remote commitment
 	// transaction is broadcast by its counterparty
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	// node[0] is gonna to revoke an old state thus node[1] should be able to claim the revoked output
 	let revoked_local_txn = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan_1.2).unwrap().last_local_commitment_txn.clone();
@@ -1842,7 +1842,7 @@ fn revoked_output_claim() {
 #[test]
 fn claim_htlc_outputs_shared_tx() {
 	// Node revoked old state, htlcs haven't time out yet, claim them in shared justice tx
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some new channel:
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -1917,7 +1917,7 @@ fn claim_htlc_outputs_shared_tx() {
 #[test]
 fn claim_htlc_outputs_single_tx() {
 	// Node revoked old state, htlcs have timed out, claim each of them in separated justice tx
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
@@ -2014,7 +2014,7 @@ fn test_htlc_on_chain_success() {
 	// the HTLC outputs via the preimage it learned (which, once confirmed should generate a
 	// PaymentSent event).
 
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -2175,7 +2175,7 @@ fn test_htlc_on_chain_timeout() {
 	//    	      \                                  \
 	//    	   B's HTLC timeout tx		     B's timeout tx
 
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 
 	// Create some intial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -2283,7 +2283,7 @@ fn test_simple_commitment_revoked_fail_backward() {
 	// Test that in case of a revoked commitment tx, we detect the resolution of output by justice tx
 	// and fail backward accordingly.
 
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 
 	// Create some initial channels
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -2351,7 +2351,7 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 	// * Once they remove it, we will send a (the first) commitment_signed without the HTLC,
 	//   and once they revoke the previous commitment transaction (allowing us to send a new
 	//   commitment_signed) we will be free to fail/fulfill the HTLC backwards.
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 
 	// Create some initial channels
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -2562,7 +2562,7 @@ fn test_commitment_revoked_fail_backward_exhaustive_b() {
 fn test_htlc_ignore_latest_remote_commitment() {
 	// Test that HTLC transactions spending the latest remote commitment transaction are simply
 	// ignored if we cannot claim them. This originally tickled an invalid unwrap().
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	route_payment(&nodes[0], &[&nodes[1]], 10000000);
@@ -2584,7 +2584,7 @@ fn test_htlc_ignore_latest_remote_commitment() {
 #[test]
 fn test_force_close_fail_back() {
 	// Check which HTLCs are failed-backwards on channel force-closure
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -2658,7 +2658,7 @@ fn test_force_close_fail_back() {
 #[test]
 fn test_unconf_chan() {
 	// After creating a chan between nodes, we disconnect all blocks previously seen to force a channel close on nodes[0] side
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let channel_state = nodes[0].node.channel_state.lock().unwrap();
@@ -2687,7 +2687,7 @@ fn test_unconf_chan() {
 #[test]
 fn test_simple_peer_disconnect() {
 	// Test that we can reconnect when there are no lost messages
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
 
@@ -2740,7 +2740,7 @@ fn test_simple_peer_disconnect() {
 
 fn do_test_drop_messages_peer_disconnect(messages_delivered: u8) {
 	// Test that we can reconnect when in-flight HTLC updates get dropped
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	if messages_delivered == 0 {
 		create_chan_between_nodes_with_value_a(&nodes[0], &nodes[1], 100000, 10001, LocalFeatures::new(), LocalFeatures::new());
 		// nodes[1] doesn't receive the funding_locked message (it'll be re-sent on reconnect)
@@ -2946,7 +2946,7 @@ fn test_drop_messages_peer_disconnect_b() {
 #[test]
 fn test_funding_peer_disconnect() {
 	// Test that we can lock in our funding tx while disconnected
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 100000, 10001, LocalFeatures::new(), LocalFeatures::new());
 
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
@@ -2997,7 +2997,7 @@ fn test_funding_peer_disconnect() {
 fn test_drop_messages_peer_disconnect_dual_htlc() {
 	// Test that we can handle reconnecting when both sides of a channel have pending
 	// commitment_updates when we disconnect.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
@@ -3136,7 +3136,7 @@ fn test_drop_messages_peer_disconnect_dual_htlc() {
 fn test_invalid_channel_announcement() {
 	//Test BOLT 7 channel_announcement msg requirement for final node, gather data to build customed channel_announcement msgs
 	let secp_ctx = Secp256k1::new();
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	let chan_announcement = create_chan_between_nodes(&nodes[0], &nodes[1], LocalFeatures::new(), LocalFeatures::new());
 
@@ -3208,7 +3208,7 @@ fn test_invalid_channel_announcement() {
 
 #[test]
 fn test_no_txn_manager_serialize_deserialize() {
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 
 	let tx = create_chan_between_nodes_with_value_init(&nodes[0], &nodes[1], 100000, 10001, LocalFeatures::new(), LocalFeatures::new());
 
@@ -3272,7 +3272,7 @@ fn test_no_txn_manager_serialize_deserialize() {
 
 #[test]
 fn test_simple_manager_serialize_deserialize() {
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
@@ -3320,7 +3320,7 @@ fn test_simple_manager_serialize_deserialize() {
 #[test]
 fn test_manager_serialize_deserialize_inconsistent_monitor() {
 	// Test deserializing a ChannelManager with an out-of-date ChannelMonitor
-	let mut nodes = create_network(4);
+	let mut nodes = create_network(4, &[None, None, None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 2, 0, LocalFeatures::new(), LocalFeatures::new());
 	let (_, _, channel_id, funding_tx) = create_announced_chan_between_nodes(&nodes, 0, 3, LocalFeatures::new(), LocalFeatures::new());
@@ -3509,7 +3509,7 @@ macro_rules! check_spendable_outputs {
 #[test]
 fn test_claim_sizeable_push_msat() {
 	// Incidentally test SpendableOutput event generation due to detection of to_local output on commitment tx
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000, LocalFeatures::new(), LocalFeatures::new());
 	nodes[1].node.force_close_channel(&chan.2);
@@ -3531,7 +3531,7 @@ fn test_claim_on_remote_sizeable_push_msat() {
 	// Same test as previous, just test on remote commitment tx, as per_commitment_point registration changes following you're funder/fundee and
 	// to_remote output is encumbered by a P2WPKH
 
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 99000000, LocalFeatures::new(), LocalFeatures::new());
 	nodes[0].node.force_close_channel(&chan.2);
@@ -3556,7 +3556,7 @@ fn test_claim_on_remote_revoked_sizeable_push_msat() {
 	// Same test as previous, just test on remote revoked commitment tx, as per_commitment_point registration changes following you're funder/fundee and
 	// to_remote output is encumbered by a P2WPKH
 
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 59000000, LocalFeatures::new(), LocalFeatures::new());
 	let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 3000000).0;
@@ -3580,7 +3580,7 @@ fn test_claim_on_remote_revoked_sizeable_push_msat() {
 
 #[test]
 fn test_static_spendable_outputs_preimage_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -3621,7 +3621,7 @@ fn test_static_spendable_outputs_preimage_tx() {
 
 #[test]
 fn test_static_spendable_outputs_justice_tx_revoked_commitment_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -3651,7 +3651,7 @@ fn test_static_spendable_outputs_justice_tx_revoked_commitment_tx() {
 
 #[test]
 fn test_static_spendable_outputs_justice_tx_revoked_htlc_timeout_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -3695,7 +3695,7 @@ fn test_static_spendable_outputs_justice_tx_revoked_htlc_timeout_tx() {
 
 #[test]
 fn test_static_spendable_outputs_justice_tx_revoked_htlc_success_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -3748,7 +3748,7 @@ fn test_onchain_to_onchain_claim() {
 	// Finally, check that B will claim the HTLC output if A's latest commitment transaction
 	// gets broadcast.
 
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -3836,7 +3836,7 @@ fn test_onchain_to_onchain_claim() {
 fn test_duplicate_payment_hash_one_failure_one_success() {
 	// Topology : A --> B --> C
 	// We route 2 payments with same hash between B and C, one will be timeout, the other successfully claim
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let chan_2 = create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
@@ -3950,7 +3950,7 @@ fn test_duplicate_payment_hash_one_failure_one_success() {
 
 #[test]
 fn test_dynamic_spendable_outputs_local_htlc_success_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -3999,7 +3999,7 @@ fn do_test_fail_backwards_unrevoked_remote_announce(deliver_last_raa: bool, anno
 	//    - C - D -
 	// B /         \ F
 	// And test where C fails back to A/B when D announces its latest commitment transaction
-	let nodes = create_network(6);
+	let nodes = create_network(6, &[None, None, None, None, None, None]);
 
 	create_announced_chan_between_nodes(&nodes, 0, 2, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes(&nodes, 1, 2, LocalFeatures::new(), LocalFeatures::new());
@@ -4238,7 +4238,7 @@ fn test_fail_backwards_previous_remote_announce() {
 
 #[test]
 fn test_dynamic_spendable_outputs_local_htlc_timeout_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// Create some initial channels
 	let chan_1 = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
@@ -4273,7 +4273,7 @@ fn test_dynamic_spendable_outputs_local_htlc_timeout_tx() {
 
 #[test]
 fn test_static_output_closing_tx() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
@@ -4293,7 +4293,7 @@ fn test_static_output_closing_tx() {
 }
 
 fn do_htlc_claim_local_commitment_only(use_dust: bool) {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let (our_payment_preimage, _) = route_payment(&nodes[0], &[&nodes[1]], if use_dust { 50000 } else { 3000000 });
@@ -4330,7 +4330,7 @@ fn do_htlc_claim_local_commitment_only(use_dust: bool) {
 }
 
 fn do_htlc_claim_current_remote_commitment_only(use_dust: bool) {
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), if use_dust { 50000 } else { 3000000 }, TEST_FINAL_CLTV).unwrap();
@@ -4354,7 +4354,7 @@ fn do_htlc_claim_current_remote_commitment_only(use_dust: bool) {
 }
 
 fn do_htlc_claim_previous_remote_commitment_only(use_dust: bool, check_revoke_no_close: bool) {
-	let nodes = create_network(3);
+	let nodes = create_network(3, &[None, None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	// Fail the payment, but don't deliver A's final RAA, resulting in the HTLC only being present
@@ -4638,7 +4638,7 @@ fn test_onion_failure() {
 	const NODE: u16 = 0x2000;
 	const UPDATE: u16 = 0x1000;
 
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	for node in nodes.iter() {
 		*node.keys_manager.override_session_priv.lock().unwrap() = Some(SecretKey::from_slice(&[3; 32]).unwrap());
 	}
@@ -4850,7 +4850,7 @@ fn test_onion_failure() {
 #[test]
 #[should_panic]
 fn bolt2_open_channel_sending_node_checks_part1() { //This test needs to be on its own as we are catching a panic
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	//Force duplicate channel ids
 	for node in nodes.iter() {
 		*node.keys_manager.override_channel_id_priv.lock().unwrap() = Some([0; 32]);
@@ -4869,7 +4869,7 @@ fn bolt2_open_channel_sending_node_checks_part1() { //This test needs to be on i
 
 #[test]
 fn bolt2_open_channel_sending_node_checks_part2() {
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 
 	// BOLT #2 spec: Sending node must set funding_satoshis to less than 2^24 satoshis
 	let channel_value_satoshis=2^24;
@@ -4917,7 +4917,7 @@ fn bolt2_open_channel_sending_node_checks_part2() {
 fn test_update_add_htlc_bolt2_sender_value_below_minimum_msat() {
 	//BOLT2 Requirement: MUST offer amount_msat greater than 0.
 	//BOLT2 Requirement: MUST NOT offer amount_msat below the receiving node's htlc_minimum_msat (same validation check catches both of these)
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let mut route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -4937,7 +4937,7 @@ fn test_update_add_htlc_bolt2_sender_value_below_minimum_msat() {
 fn test_update_add_htlc_bolt2_sender_cltv_expiry_too_high() {
 	//BOLT 2 Requirement: MUST set cltv_expiry less than 500000000.
 	//It is enforced when constructing a route.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let _chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 0, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000000, 500000001).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -4956,7 +4956,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_num_and_htlc_id_increment()
 	//BOLT 2 Requirement: if result would be offering more than the remote's max_accepted_htlcs HTLCs, in the remote commitment transaction: MUST NOT add an HTLC.
 	//BOLT 2 Requirement: for the first HTLC it offers MUST set id to 0.
 	//BOLT 2 Requirement: MUST increase the value of id by 1 for each successive offer.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 0, LocalFeatures::new(), LocalFeatures::new());
 	let max_accepted_htlcs = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().their_max_accepted_htlcs as u64;
 
@@ -4997,7 +4997,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_num_and_htlc_id_increment()
 #[test]
 fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_value_in_flight() {
 	//BOLT 2 Requirement: if the sum of total offered HTLCs would exceed the remote's max_htlc_value_in_flight_msat: MUST NOT add an HTLC.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let channel_value = 100000;
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, channel_value, 0, LocalFeatures::new(), LocalFeatures::new());
 	let max_in_flight = get_channel_value_stat!(nodes[0], chan.2).their_max_htlc_value_in_flight_msat;
@@ -5021,7 +5021,7 @@ fn test_update_add_htlc_bolt2_sender_exceed_max_htlc_value_in_flight() {
 #[test]
 fn test_update_add_htlc_bolt2_receiver_check_amount_received_more_than_min() {
 	//BOLT2 Requirement: receiving an amount_msat equal to 0, OR less than its own htlc_minimum_msat -> SHOULD fail the channel.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let htlc_minimum_msat: u64;
 	{
@@ -5048,7 +5048,7 @@ fn test_update_add_htlc_bolt2_receiver_check_amount_received_more_than_min() {
 #[test]
 fn test_update_add_htlc_bolt2_receiver_sender_can_afford_amount_sent() {
 	//BOLT2 Requirement: receiving an amount_msat that the sending node cannot afford at the current feerate_per_kw (while maintaining its channel reserve): SHOULD fail the channel
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 
 	let their_channel_reserve = get_channel_value_stat!(nodes[0], chan.2).channel_reserve_msat;
@@ -5076,7 +5076,7 @@ fn test_update_add_htlc_bolt2_receiver_sender_can_afford_amount_sent() {
 fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 	//BOLT 2 Requirement: if a sending node adds more than its max_accepted_htlcs HTLCs to its local commitment transaction: SHOULD fail the channel
 	//BOLT 2 Requirement: MUST allow multiple HTLCs with the same payment_hash.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 3999999, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5121,7 +5121,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 #[test]
 fn test_update_add_htlc_bolt2_receiver_check_max_in_flight_msat() {
 	//OR adds more than its max_htlc_value_in_flight_msat worth of offered HTLCs to its local commitment transaction: SHOULD fail the channel
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5144,7 +5144,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_in_flight_msat() {
 #[test]
 fn test_update_add_htlc_bolt2_receiver_check_cltv_expiry() {
 	//BOLT2 Requirement: if sending node sets cltv_expiry to greater or equal to 500000000: SHOULD fail the channel.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 95000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 3999999, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5169,7 +5169,7 @@ fn test_update_add_htlc_bolt2_receiver_check_repeated_id_ignore() {
 	//BOLT 2 requirement: if the sender did not previously acknowledge the commitment of that HTLC: MUST ignore a repeated id value after a reconnection.
 	// We test this by first testing that that repeated HTLCs pass commitment signature checks
 	// after disconnect and that non-sequential htlc_ids result in a channel failure.
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5214,7 +5214,7 @@ fn test_update_add_htlc_bolt2_receiver_check_repeated_id_ignore() {
 fn test_update_fulfill_htlc_bolt2_update_fulfill_htlc_before_commitment() {
 	//BOLT 2 Requirement: until the corresponding HTLC is irrevocably committed in both sides' commitment transactions:	MUST NOT send an update_fulfill_htlc, update_fail_htlc, or update_fail_malformed_htlc.
 
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
@@ -5246,7 +5246,7 @@ fn test_update_fulfill_htlc_bolt2_update_fulfill_htlc_before_commitment() {
 fn test_update_fulfill_htlc_bolt2_update_fail_htlc_before_commitment() {
 	//BOLT 2 Requirement: until the corresponding HTLC is irrevocably committed in both sides' commitment transactions:	MUST NOT send an update_fulfill_htlc, update_fail_htlc, or update_fail_malformed_htlc.
 
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
@@ -5278,7 +5278,7 @@ fn test_update_fulfill_htlc_bolt2_update_fail_htlc_before_commitment() {
 fn test_update_fulfill_htlc_bolt2_update_fail_malformed_htlc_before_commitment() {
 	//BOLT 2 Requirement: until the corresponding HTLC is irrevocably committed in both sides' commitment transactions:	MUST NOT send an update_fulfill_htlc, update_fail_htlc, or update_fail_malformed_htlc.
 
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
@@ -5311,7 +5311,7 @@ fn test_update_fulfill_htlc_bolt2_update_fail_malformed_htlc_before_commitment()
 fn test_update_fulfill_htlc_bolt2_incorrect_htlc_id() {
 	//BOLT 2 Requirement: A receiving node:	if the id does not correspond to an HTLC in its current commitment transaction MUST fail the channel.
 
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let our_payment_preimage = route_payment(&nodes[0], &[&nodes[1]], 100000).0;
@@ -5352,7 +5352,7 @@ fn test_update_fulfill_htlc_bolt2_incorrect_htlc_id() {
 fn test_update_fulfill_htlc_bolt2_wrong_preimage() {
 	//BOLT 2 Requirement: A receiving node:	if the payment_preimage value in update_fulfill_htlc doesn't SHA256 hash to the corresponding HTLC payment_hash	MUST fail the channel.
 
-	let nodes = create_network(2);
+	let nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes(&nodes, 0, 1, LocalFeatures::new(), LocalFeatures::new());
 
 	let our_payment_preimage = route_payment(&nodes[0], &[&nodes[1]], 100000).0;
@@ -5394,7 +5394,7 @@ fn test_update_fulfill_htlc_bolt2_wrong_preimage() {
 fn test_update_fulfill_htlc_bolt2_missing_badonion_bit_for_malformed_htlc_message() {
 	//BOLT 2 Requirement: A receiving node: if the BADONION bit in failure_code is not set for update_fail_malformed_htlc MUST fail the channel.
 
-	let mut nodes = create_network(2);
+	let mut nodes = create_network(2, &[None, None]);
 	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
@@ -5440,7 +5440,7 @@ fn test_update_fulfill_htlc_bolt2_after_malformed_htlc_message_must_forward_upda
 	//BOLT 2 Requirement: a receiving node which has an outgoing HTLC canceled by update_fail_malformed_htlc:
 	//    * MUST return an error in the update_fail_htlc sent to the link which originally sent the HTLC, using the failure_code given and setting the data to sha256_of_onion.
 
-	let mut nodes = create_network(3);
+	let mut nodes = create_network(3, &[None, None, None]);
 	create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 	create_announced_chan_between_nodes_with_value(&nodes, 1, 2, 1000000, 1000000, LocalFeatures::new(), LocalFeatures::new());
 

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -60,9 +60,16 @@ pub struct LocalFeatures {
 
 impl LocalFeatures {
 	/// Create a blank LocalFeatures flags (visibility extended for fuzz tests)
+	#[cfg(not(feature = "fuzztarget"))]
+	pub(crate) fn new() -> LocalFeatures {
+		LocalFeatures {
+			flags: vec![1 << 4],
+		}
+	}
+	#[cfg(feature = "fuzztarget")]
 	pub fn new() -> LocalFeatures {
 		LocalFeatures {
-			flags: Vec::new(),
+			flags: vec![1 << 4],
 		}
 	}
 
@@ -87,8 +94,8 @@ impl LocalFeatures {
 	pub(crate) fn supports_upfront_shutdown_script(&self) -> bool {
 		self.flags.len() > 0 && (self.flags[0] & (3 << 4)) != 0
 	}
-	pub(crate) fn requires_upfront_shutdown_script(&self) -> bool {
-		self.flags.len() > 0 && (self.flags[0] & (1 << 4)) != 0
+	pub(crate) fn unset_upfront_shutdown_script(&mut self) {
+		self.flags[0] ^= 1 << 4;
 	}
 
 	pub(crate) fn requires_unknown_bits(&self) -> bool {
@@ -2011,9 +2018,9 @@ mod tests {
 			target_value.append(&mut hex::decode("0000").unwrap());
 		}
 		if initial_routing_sync {
-			target_value.append(&mut hex::decode("000108").unwrap());
+			target_value.append(&mut hex::decode("000118").unwrap());
 		} else {
-			target_value.append(&mut hex::decode("0000").unwrap());
+			target_value.append(&mut hex::decode("000110").unwrap());
 		}
 		assert_eq!(encoded_value, target_value);
 	}

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -59,7 +59,8 @@ pub struct LocalFeatures {
 }
 
 impl LocalFeatures {
-	pub(crate) fn new() -> LocalFeatures {
+	/// Create a blank LocalFeatures flags (visibility extended for fuzz tests)
+	pub fn new() -> LocalFeatures {
 		LocalFeatures {
 			flags: Vec::new(),
 		}
@@ -611,9 +612,9 @@ pub enum OptionalField<T> {
 pub trait ChannelMessageHandler : events::MessageSendEventsProvider + Send + Sync {
 	//Channel init:
 	/// Handle an incoming open_channel message from the given peer.
-	fn handle_open_channel(&self, their_node_id: &PublicKey, msg: &OpenChannel) -> Result<(), HandleError>;
+	fn handle_open_channel(&self, their_node_id: &PublicKey, their_local_features: LocalFeatures, msg: &OpenChannel) -> Result<(), HandleError>;
 	/// Handle an incoming accept_channel message from the given peer.
-	fn handle_accept_channel(&self, their_node_id: &PublicKey, msg: &AcceptChannel) -> Result<(), HandleError>;
+	fn handle_accept_channel(&self, their_node_id: &PublicKey, their_local_features: LocalFeatures, msg: &AcceptChannel) -> Result<(), HandleError>;
 	/// Handle an incoming funding_created message from the given peer.
 	fn handle_funding_created(&self, their_node_id: &PublicKey, msg: &FundingCreated) -> Result<(), HandleError>;
 	/// Handle an incoming funding_signed message from the given peer.

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -659,11 +659,11 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 											// Channel control:
 											32 => {
 												let msg = try_potential_decodeerror!(msgs::OpenChannel::read(&mut reader));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_open_channel(&peer.their_node_id.unwrap(), &msg));
+												try_potential_handleerror!(self.message_handler.chan_handler.handle_open_channel(&peer.their_node_id.unwrap(), peer.their_local_features.clone().unwrap(), &msg));
 											},
 											33 => {
 												let msg = try_potential_decodeerror!(msgs::AcceptChannel::read(&mut reader));
-												try_potential_handleerror!(self.message_handler.chan_handler.handle_accept_channel(&peer.their_node_id.unwrap(), &msg));
+												try_potential_handleerror!(self.message_handler.chan_handler.handle_accept_channel(&peer.their_node_id.unwrap(), peer.their_local_features.clone().unwrap(), &msg));
 											},
 
 											34 => {

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -587,10 +587,6 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 													log_info!(self, "Peer local features required data_loss_protect");
 													return Err(PeerHandleError{ no_connection_possible: true });
 												}
-												if msg.local_features.requires_upfront_shutdown_script() {
-													log_info!(self, "Peer local features required upfront_shutdown_script");
-													return Err(PeerHandleError{ no_connection_possible: true });
-												}
 												if peer.their_global_features.is_some() {
 													return Err(PeerHandleError{ no_connection_possible: false });
 												}

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -129,6 +129,14 @@ pub struct ChannelConfig {
 	///
 	/// This cannot be changed after the initial channel handshake.
 	pub announced_channel: bool,
+	/// Set to commit to an upfront shutdown_pubkey at channel opening. In case of mutual
+	/// closing, the other peer will check that our closing transction output is encumbered
+	/// by the provided script.
+	///
+	/// We set it by default as this ensure greater security to the user funds.
+	///
+	/// This cannot be changed after channel opening.
+	pub commit_upfront_shutdown_pubkey: bool
 }
 
 impl ChannelConfig {
@@ -137,12 +145,14 @@ impl ChannelConfig {
 		ChannelConfig {
 			fee_proportional_millionths: 0,
 			announced_channel: false,
+			commit_upfront_shutdown_pubkey: true,
 		}
 	}
 }
 
 //Add write and readable traits to channelconfig
-impl_writeable!(ChannelConfig, 8+1, {
+impl_writeable!(ChannelConfig, 8+1+1, {
 	fee_proportional_millionths,
-	announced_channel
+	announced_channel,
+	commit_upfront_shutdown_pubkey
 });

--- a/src/util/test_utils.rs
+++ b/src/util/test_utils.rs
@@ -4,6 +4,7 @@ use chain::transaction::OutPoint;
 use chain::keysinterface;
 use ln::channelmonitor;
 use ln::msgs;
+use ln::msgs::LocalFeatures;
 use ln::msgs::{HandleError};
 use ln::channelmonitor::HTLCUpdate;
 use util::events;
@@ -96,10 +97,10 @@ impl TestChannelMessageHandler {
 }
 
 impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
-	fn handle_open_channel(&self, _their_node_id: &PublicKey, _msg: &msgs::OpenChannel) -> Result<(), HandleError> {
+	fn handle_open_channel(&self, _their_node_id: &PublicKey, _their_local_features: LocalFeatures, _msg: &msgs::OpenChannel) -> Result<(), HandleError> {
 		Err(HandleError { err: "", action: None })
 	}
-	fn handle_accept_channel(&self, _their_node_id: &PublicKey, _msg: &msgs::AcceptChannel) -> Result<(), HandleError> {
+	fn handle_accept_channel(&self, _their_node_id: &PublicKey, _their_local_features: LocalFeatures, _msg: &msgs::AcceptChannel) -> Result<(), HandleError> {
 		Err(HandleError { err: "", action: None })
 	}
 	fn handle_funding_created(&self, _their_node_id: &PublicKey, _msg: &msgs::FundingCreated) -> Result<(), HandleError> {


### PR DESCRIPTION
We take care of not enforcing the option if remote peer send us an open_channel/accept_channel messages including an shutdown_scriptpubkey but without asking for in feature flags.
On the user-side, we rely on the config to decide to commit.

Close #239 