### PR TITLE
Implement option_data_loss_protect on both sides

### DIFF
--- a/src/ln/channel.rs
+++ b/src/ln/channel.rs
@@ -32,7 +32,7 @@ use util::config::{UserConfig,ChannelConfig};
 
 use std;
 use std::default::Default;
-use std::{cmp,mem};
+use std::{cmp,mem,fmt};
 use std::sync::{Arc};
 
 #[cfg(test)]
@@ -366,10 +366,23 @@ pub const OFFERED_HTLC_SCRIPT_WEIGHT: usize = 133;
 /// Used to return a simple Error back to ChannelManager. Will get converted to a
 /// msgs::ErrorAction::SendErrorMessage or msgs::ErrorAction::IgnoreError as appropriate with our
 /// channel_id in ChannelManager.
-#[derive(Debug)]
 pub(super) enum ChannelError {
 	Ignore(&'static str),
 	Close(&'static str),
+	CloseDelayBroadcast {
+		msg: &'static str,
+		update: Option<ChannelMonitor>
+	},
+}
+
+impl fmt::Debug for ChannelError {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match self {
+			&ChannelError::Ignore(e) => write!(f, "Ignore : {}", e),
+			&ChannelError::Close(e) => write!(f, "Close : {}", e),
+			&ChannelError::CloseDelayBroadcast { msg, .. } => write!(f, "CloseDelayBroadcast : {}", msg)
+		}
+	}
 }
 
 macro_rules! secp_check {
@@ -2500,6 +2513,22 @@ impl Channel {
 			return Err(ChannelError::Close("Peer sent a garbage channel_reestablish"));
 		}
 
+		if msg.next_remote_commitment_number > 0 {
+			match msg.data_loss_protect {
+				OptionalField::Present(ref data_loss) => {
+					if chan_utils::build_commitment_secret(self.local_keys.commitment_seed, INITIAL_COMMITMENT_NUMBER - msg.next_remote_commitment_number + 1) != data_loss.your_last_per_commitment_secret {
+						return Err(ChannelError::Close("Peer sent a garbage channel_reestablish with secret key not matching the commitment height provided"));
+					}
+					if msg.next_remote_commitment_number > INITIAL_COMMITMENT_NUMBER - self.cur_local_commitment_transaction_number {
+						self.channel_monitor.provide_rescue_remote_commitment_tx_info(data_loss.my_current_per_commitment_point);
+						return Err(ChannelError::CloseDelayBroadcast { msg: "We have fallen behind - we have received proof that if we broadcast remote is going to claim our funds - we can't do any automated broadcasting", update: Some(self.channel_monitor.clone())
+					});
+					}
+				},
+				OptionalField::Absent => {}
+			}
+		}
+
 		// Go ahead and unmark PeerDisconnected as various calls we may make check for it (and all
 		// remaining cases either succeed or ErrorMessage-fail).
 		self.channel_state &= !(ChannelState::PeerDisconnected as u32);
@@ -2576,7 +2605,7 @@ impl Channel {
 				// now!
 				match self.free_holding_cell_htlcs() {
 					Err(ChannelError::Close(msg)) => return Err(ChannelError::Close(msg)),
-					Err(ChannelError::Ignore(_)) => panic!("Got non-channel-failing result from free_holding_cell_htlcs"),
+					Err(ChannelError::Ignore(_)) | Err(ChannelError::CloseDelayBroadcast { .. }) => panic!("Got non-channel-failing result from free_holding_cell_htlcs"),
 					Ok(Some((commitment_update, channel_monitor))) => return Ok((resend_funding_locked, required_revoke, Some(commitment_update), Some(channel_monitor), self.resend_order.clone(), shutdown_msg)),
 					Ok(None) => return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), shutdown_msg)),
 				}

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -208,6 +208,15 @@ impl MsgHandleErrInternal {
 						},
 					}),
 				},
+				ChannelError::CloseDelayBroadcast { msg, .. } => HandleError {
+					err: msg,
+					action: Some(msgs::ErrorAction::SendErrorMessage {
+						msg: msgs::ErrorMessage {
+							channel_id,
+							data: msg.to_string()
+						},
+					}),
+				},
 			},
 			shutdown_finish: None,
 		}
@@ -447,6 +456,7 @@ macro_rules! break_chan_entry {
 				}
 				break Err(MsgHandleErrInternal::from_finish_shutdown(msg, channel_id, chan.force_shutdown(), $self.get_channel_update(&chan).ok()))
 			},
+			Err(ChannelError::CloseDelayBroadcast { .. }) => { panic!("Wait is only generated on receipt of channel_reestablish, which is handled by try_chan_entry, we don't bother to support it here"); }
 		}
 	}
 }
@@ -466,6 +476,28 @@ macro_rules! try_chan_entry {
 				}
 				return Err(MsgHandleErrInternal::from_finish_shutdown(msg, channel_id, chan.force_shutdown(), $self.get_channel_update(&chan).ok()))
 			},
+			Err(ChannelError::CloseDelayBroadcast { msg, update }) => {
+				log_error!($self, "Channel {} need to be shutdown but closing transactions not broadcast due to {}", log_bytes!($entry.key()[..]), msg);
+				let (channel_id, mut chan) = $entry.remove_entry();
+				if let Some(short_id) = chan.get_short_channel_id() {
+					$channel_state.short_to_id.remove(&short_id);
+				}
+				if let Some(update) = update {
+					if let Err(e) = $self.monitor.add_update_monitor(update.get_funding_txo().unwrap(), update) {
+						match e {
+							// Upstream channel is dead, but we want at least to fail backward HTLCs to save
+							// downstream channels. In case of PermanentFailure, we are not going to be able
+							// to claim back to_remote output on remote commitment transaction. Doesn't
+							// make a difference here, we are concern about HTLCs circuit, not onchain funds.
+							ChannelMonitorUpdateErr::PermanentFailure => {},
+							ChannelMonitorUpdateErr::TemporaryFailure => {},
+						}
+					}
+				}
+				let mut shutdown_res = chan.force_shutdown(); // We drop closing transactions as they are toxic datas and MUST NOT be broadcast
+				shutdown_res.0.clear();
+				return Err(MsgHandleErrInternal::from_finish_shutdown(msg, channel_id, shutdown_res, $self.get_channel_update(&chan).ok()))
+			}
 		}
 	}
 }

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -494,7 +494,10 @@ macro_rules! try_chan_entry {
 						}
 					}
 				}
-				let mut shutdown_res = chan.force_shutdown(); // We drop closing transactions as they are toxic datas and MUST NOT be broadcast
+				let mut shutdown_res = chan.force_shutdown();
+				if shutdown_res.0.len() >= 1 {
+					log_error!($self, "You have a toxic local commitment transaction {} avaible in channel monitor, read comment in ChannelMonitor::get_latest_local_commitment_txn to be informed of manual action to take", shutdown_res.0[0].txid());
+				}
 				shutdown_res.0.clear();
 				return Err(MsgHandleErrInternal::from_finish_shutdown(msg, channel_id, shutdown_res, $self.get_channel_update(&chan).ok()))
 			}

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -763,6 +763,9 @@ impl ChannelMonitor {
 		}
 	}
 
+	pub(super) fn provide_rescue_remote_commitment_tx_info(&mut self, their_revocation_point: PublicKey) {
+	}
+
 	/// Informs this monitor of the latest local (ie broadcastable) commitment transaction. The
 	/// monitor watches for timeouts and may broadcast it if we approach such a timeout. Thus, it
 	/// is important that any clones of this channel monitor (including remote clones) by kept

--- a/src/ln/channelmonitor.rs
+++ b/src/ln/channelmonitor.rs
@@ -2051,9 +2051,16 @@ impl ChannelMonitor {
 		None
 	}
 
-	/// Used by ChannelManager deserialization to broadcast the latest local state if it's copy of
-	/// the Channel was out-of-date.
-	pub(super) fn get_latest_local_commitment_txn(&self) -> Vec<Transaction> {
+	/// Used by ChannelManager deserialization to broadcast the latest local state if its copy of
+	/// the Channel was out-of-date. You may use it to get a broadcastable local toxic tx in case of
+	/// fallen-behind, i.e when receiving a channel_reestablish with a proof that our remote side knows
+	/// a higher revocation secret than the local commitment number we are aware of. Broadcasting these
+	/// transactions are UNSAFE, as they allow remote side to punish you. Nevertheless you may want to
+	/// broadcast them if remote don't close channel with his higher commitment transaction after a
+	/// substantial amount of time (a month or even a year) to get back funds. Best may be to contact
+	/// out-of-band the other node operator to coordinate with him if option is available to you.
+	/// In any-case, choice is up to the user.
+	pub fn get_latest_local_commitment_txn(&self) -> Vec<Transaction> {
 		if let &Some(ref local_tx) = &self.current_local_signed_commitment_tx {
 			let mut res = vec![local_tx.tx.clone()];
 			match self.key_storage {

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -63,23 +63,19 @@ impl LocalFeatures {
 	#[cfg(not(feature = "fuzztarget"))]
 	pub(crate) fn new() -> LocalFeatures {
 		LocalFeatures {
-			flags: vec![1 << 5],
+			flags: vec![2 | 1 << 5],
 		}
 	}
 	#[cfg(feature = "fuzztarget")]
 	pub fn new() -> LocalFeatures {
 		LocalFeatures {
-			flags: vec![1 << 5],
+			flags: vec![2 | 1 << 5],
 		}
 	}
 
 	pub(crate) fn supports_data_loss_protect(&self) -> bool {
 		self.flags.len() > 0 && (self.flags[0] & 3) != 0
 	}
-	pub(crate) fn requires_data_loss_protect(&self) -> bool {
-		self.flags.len() > 0 && (self.flags[0] & 1) != 0
-	}
-
 	pub(crate) fn initial_routing_sync(&self) -> bool {
 		self.flags.len() > 0 && (self.flags[0] & (1 << 3)) != 0
 	}
@@ -2018,9 +2014,9 @@ mod tests {
 			target_value.append(&mut hex::decode("0000").unwrap());
 		}
 		if initial_routing_sync {
-			target_value.append(&mut hex::decode("000128").unwrap());
+			target_value.append(&mut hex::decode("00012a").unwrap());
 		} else {
-			target_value.append(&mut hex::decode("000120").unwrap());
+			target_value.append(&mut hex::decode("000122").unwrap());
 		}
 		assert_eq!(encoded_value, target_value);
 	}

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -621,10 +621,6 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 													log_info!(self, "Peer local features required unknown version bits");
 													return Err(PeerHandleError{ no_connection_possible: true });
 												}
-												if msg.local_features.requires_data_loss_protect() {
-													log_info!(self, "Peer local features required data_loss_protect");
-													return Err(PeerHandleError{ no_connection_possible: true });
-												}
 												if peer.their_global_features.is_some() {
 													return Err(PeerHandleError{ no_connection_possible: false });
 												}


### PR DESCRIPTION
Data Loss Protection could be a bit tricky to get right, as your_last_per_commitment_secret is there to let remote peer prove to you it knows at least a revocation at next_remote_commitment_number - 1 but it can lie by omission.

It's a simpler version than #244 I expect but we may pick tests from there, we want to verify:
* we don't broadcast our Local Commitment Tx in case of fallen behind
* we are able to claim our own outputs thanks to remote my_current_per_commitment_point
* we close channel in case of Bob cheating with erroneous last_per_commitment_secret