### PR TITLE
Drop system clock calls for PendingHTLCsForwardable events.

### DIFF
--- a/src/ln/chanmon_update_fail_tests.rs
+++ b/src/ln/chanmon_update_fail_tests.rs
@@ -13,8 +13,6 @@ use util::errors::APIError;
 use bitcoin_hashes::sha256::Hash as Sha256;
 use bitcoin_hashes::Hash;
 
-use std::time::Instant;
-
 use ln::functional_test_utils::*;
 
 #[test]
@@ -1495,7 +1493,6 @@ fn test_monitor_update_on_pending_forwards() {
 		Event::PendingHTLCsForwardable { .. } => { },
 		_ => panic!("Unexpected event"),
 	};
-	nodes[0].node.channel_state.lock().unwrap().next_forward = Instant::now();
 	nodes[0].node.process_pending_htlc_forwards();
 	expect_payment_received!(nodes[0], payment_hash_2, 1000000);
 

--- a/src/ln/functional_test_utils.rs
+++ b/src/ln/functional_test_utils.rs
@@ -32,7 +32,6 @@ use std::collections::HashMap;
 use std::default::Default;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 use std::mem;
 
 pub const CHAN_CONFIRM_DEPTH: u32 = 100;
@@ -536,8 +535,6 @@ macro_rules! expect_pending_htlcs_forwardable {
 			Event::PendingHTLCsForwardable { .. } => { },
 			_ => panic!("Unexpected event"),
 		};
-		let node_ref: &Node = &$node;
-		node_ref.node.channel_state.lock().unwrap().next_forward = Instant::now();
 		$node.node.process_pending_htlc_forwards();
 	}}
 }

--- a/src/ln/functional_tests.rs
+++ b/src/ln/functional_tests.rs
@@ -43,7 +43,6 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::default::Default;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Instant;
 use std::mem;
 
 use ln::functional_test_utils::*;
@@ -2460,7 +2459,6 @@ fn do_test_commitment_revoked_fail_backward_exhaustive(deliver_bs_raa: bool, use
 			_ => panic!("Unexpected event"),
 		};
 	}
-	nodes[1].node.channel_state.lock().unwrap().next_forward = Instant::now();
 	nodes[1].node.process_pending_htlc_forwards();
 	check_added_monitors!(nodes[1], 1);
 
@@ -2813,7 +2811,6 @@ fn do_test_drop_messages_peer_disconnect(messages_delivered: u8) {
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 	reconnect_nodes(&nodes[0], &nodes[1], (false, false), (0, 0), (0, 0), (0, 0), (0, 0), (false, false));
 
-	nodes[1].node.channel_state.lock().unwrap().next_forward = Instant::now();
 	nodes[1].node.process_pending_htlc_forwards();
 
 	let events_2 = nodes[1].node.get_and_clear_pending_events();
@@ -4463,7 +4460,6 @@ fn run_onion_failure_test_with_fail_intercept<F1,F2,F3>(_name: &str, test_case: 
 	macro_rules! expect_htlc_forward {
 		($node: expr) => {{
 			expect_event!($node, Event::PendingHTLCsForwardable);
-			$node.node.channel_state.lock().unwrap().next_forward = Instant::now();
 			$node.node.process_pending_htlc_forwards();
 		}}
 	}

--- a/src/util/events.rs
+++ b/src/util/events.rs
@@ -21,7 +21,7 @@ use bitcoin::blockdata::script::Script;
 
 use secp256k1::key::PublicKey;
 
-use std::time::Instant;
+use std::time::Duration;
 
 /// An Event which you should probably take some action in response to.
 pub enum Event {
@@ -92,8 +92,8 @@ pub enum Event {
 	/// Used to indicate that ChannelManager::process_pending_htlc_forwards should be called at a
 	/// time in the future.
 	PendingHTLCsForwardable {
-		/// The earliest time at which process_pending_htlc_forwards should be called.
-		time_forwardable: Instant,
+		/// The amount of time that should be waited prior to calling process_pending_htlc_forwards
+		time_forwardable: Duration,
 	},
 	/// Used to indicate that an output was generated on-chain which you should know how to spend.
 	/// Such an output will *not* ever be spent by rust-lightning, so you need to store them


### PR DESCRIPTION
Instead, return a Duration and let the user do the work of waiting.
This is one of only a handful of steps to make us
mostly-syscall-free, at least enough to run in WASM according to
elichai.

+ 1 extra commit to remove an entirely-useless field in channel that relied on Instant::now().