### PR TITLE
Replace randomness source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ max_level_debug = []
 [dependencies]
 bitcoin = "0.18"
 bitcoin_hashes = "0.3"
-rand = "0.4"
+rand = "0.7"
 secp256k1 = "0.12"
 
 [dev-dependencies.bitcoin]

--- a/src/util/rng.rs
+++ b/src/util/rng.rs
@@ -1,15 +1,13 @@
 #[cfg(not(feature = "fuzztarget"))]
 mod real_rng {
-	use rand::{thread_rng,Rng};
+	use rand::{Rng, rngs::OsRng};
 
 	pub fn fill_bytes(data: &mut [u8]) {
-		let mut rng = thread_rng();
-		rng.fill_bytes(data);
+		OsRng.fill(data);
 	}
 
 	pub fn rand_f32() -> f32 {
-		let mut rng = thread_rng();
-		rng.next_f32()
+		OsRng.gen()
 	}
 }
 #[cfg(not(feature = "fuzztarget"))]


### PR DESCRIPTION
Right now we use the JitterRng as a source of randomness(https://docs.rs/rand/0.4.6/rand/jitter/index.html)
This rely on a System clock.
This PR move to use the OS randomness source. and bump the rand version to 0.7.

This enables systems without a clock to use the library after #351 will remove all other clock uses.

`wasm32-unknown-unknown` example that successfully runs `rust-lightning` on the browser: https://github.com/elichai/rust-lightning/tree/wasm/wasm-test

This still requires upgrading rust-secp256k1 here and in rust-bitcoin, and removing the rest of clocks (https://github.com/rust-bitcoin/rust-lightning/compare/master...elichai:wasm)

cc https://github.com/rust-bitcoin/rust-bitcoin/pull/278