### PR TITLE
Add deserialize+load steps to chanmon_fail_consistency (fixes #327)

### DIFF
--- a/src/ln/functional_test_utils.rs
+++ b/src/ln/functional_test_utils.rs
@@ -15,7 +15,7 @@ use util::logger::Logger;
 use util::config::UserConfig;
 
 use bitcoin::util::hash::BitcoinHash;
-use bitcoin::blockdata::block::{BlockHeader, Block};
+use bitcoin::blockdata::block::BlockHeader;
 use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::network::constants::Network;
 
@@ -54,20 +54,6 @@ pub fn connect_blocks(chain: &chaininterface::ChainWatchInterfaceUtil, depth: u3
 		chain.block_connected_checked(&header, height + i, &Vec::new(), &Vec::new());
 	}
 	header.bitcoin_hash()
-}
-
-pub fn disconnect_blocks(chain: &chaininterface::ChainWatchInterfaceUtil, depth: u32, height: u32, parent: bool, prev_blockhash: Sha256d) {
-	let mut header = BlockHeader { version: 0x2000000, prev_blockhash: if parent { prev_blockhash } else { Default::default() }, merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	let mut blocks = Vec::new();
-	for _ in 0..depth {
-		blocks.push(Block { header, txdata: Vec::new() });
-		header = BlockHeader { version: 0x20000000, prev_blockhash: header.bitcoin_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	}
-	let mut height = height;
-	for block in blocks.pop() {
-		chain.block_disconnected(&block.header, height);
-		height -= 1;
-	}
 }
 
 pub struct Node {

--- a/src/ln/functional_tests.rs
+++ b/src/ln/functional_tests.rs
@@ -5664,8 +5664,8 @@ fn do_test_sweep_outbound_htlc_failure_update(revoked: bool, local: bool) {
 
 	let bs_dust_limit = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().our_dust_limit_satoshis;
 
-	let (payment_preimage_1, dust_hash) = route_payment(&nodes[0], &[&nodes[1]], bs_dust_limit*1000);
-	let (payment_preimage_2, non_dust_hash) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
+	let (_payment_preimage_1, dust_hash) = route_payment(&nodes[0], &[&nodes[1]], bs_dust_limit*1000);
+	let (_payment_preimage_2, non_dust_hash) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
 
 	let as_commitment_tx = nodes[0].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().last_local_commitment_txn.clone();
 	let bs_commitment_tx = nodes[1].node.channel_state.lock().unwrap().by_id.get(&chan.2).unwrap().last_local_commitment_txn.clone();

--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -94,6 +94,7 @@ impl LocalFeatures {
 	pub(crate) fn supports_upfront_shutdown_script(&self) -> bool {
 		self.flags.len() > 0 && (self.flags[0] & (3 << 4)) != 0
 	}
+	#[cfg(test)]
 	pub(crate) fn unset_upfront_shutdown_script(&mut self) {
 		self.flags[0] ^= 1 << 4;
 	}


### PR DESCRIPTION
This expands the chanmon_fail_consistency test quite a bit by serializing/loading ChannelManagers/monitors, including potentially stale-but-UpdateTemporaryFailed monitors!