### PR TITLE
Do not require upfront_shutdown as the security gain is marginal

### DIFF
--- a/src/ln/msgs.rs
+++ b/src/ln/msgs.rs
@@ -63,13 +63,13 @@ impl LocalFeatures {
 	#[cfg(not(feature = "fuzztarget"))]
 	pub(crate) fn new() -> LocalFeatures {
 		LocalFeatures {
-			flags: vec![1 << 4],
+			flags: vec![1 << 5],
 		}
 	}
 	#[cfg(feature = "fuzztarget")]
 	pub fn new() -> LocalFeatures {
 		LocalFeatures {
-			flags: vec![1 << 4],
+			flags: vec![1 << 5],
 		}
 	}
 
@@ -96,7 +96,7 @@ impl LocalFeatures {
 	}
 	#[cfg(test)]
 	pub(crate) fn unset_upfront_shutdown_script(&mut self) {
-		self.flags[0] ^= 1 << 4;
+		self.flags[0] ^= 1 << 5;
 	}
 
 	pub(crate) fn requires_unknown_bits(&self) -> bool {
@@ -2018,9 +2018,9 @@ mod tests {
 			target_value.append(&mut hex::decode("0000").unwrap());
 		}
 		if initial_routing_sync {
-			target_value.append(&mut hex::decode("000118").unwrap());
+			target_value.append(&mut hex::decode("000128").unwrap());
 		} else {
-			target_value.append(&mut hex::decode("000110").unwrap());
+			target_value.append(&mut hex::decode("000120").unwrap());
 		}
 		assert_eq!(encoded_value, target_value);
 	}

--- a/src/util/config.rs
+++ b/src/util/config.rs
@@ -152,13 +152,15 @@ pub struct ChannelConfig {
 	///
 	/// This cannot be changed after the initial channel handshake.
 	pub announced_channel: bool,
-	/// Set to commit to an upfront shutdown_pubkey at channel opening. In case of mutual
-	/// closing, the other peer will check that our closing transction output is encumbered
-	/// by the provided script.
+	/// When set, we commit to an upfront shutdown_pubkey at channel open. If our counterparty
+	/// supports it, they will then enforce the mutual-close output to us matches what we provided
+	/// at intialization, preventing us from closing to an alternate pubkey.
 	///
-	/// We set it by default as this ensure greater security to the user funds.
+	/// This is set to true by default to provide a slight increase in security, though ultimately
+	/// any attacker who is able to take control of a channel can just as easily send the funds via
+	/// lightning payments, so we never require that our counterparties support this option.
 	///
-	/// This cannot be changed after channel opening.
+	/// This cannot be changed after a channel has been initialized.
 	pub commit_upfront_shutdown_pubkey: bool
 }
 


### PR DESCRIPTION
There is really no reason to want to never open a channel just
because a counterparty doesn't support upfront_shutdown.