### PR TITLE
 Make SocketDescriptor::send_data take slice instead of vec and offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /target/
+/net-tokio/target/
 **/*.rs.bk
 Cargo.lock
-/target/
-**/*.rs.bk
 .idea
+

--- a/fuzz/fuzz_targets/full_stack_target.rs
+++ b/fuzz/fuzz_targets/full_stack_target.rs
@@ -124,9 +124,8 @@ struct Peer<'a> {
 	peers_connected: &'a RefCell<[bool; 256]>,
 }
 impl<'a> SocketDescriptor for Peer<'a> {
-	fn send_data(&mut self, data: &Vec<u8>, write_offset: usize, _resume_read: bool) -> usize {
-		assert!(write_offset < data.len());
-		data.len() - write_offset
+	fn send_data(&mut self, data: &[u8], _resume_read: bool) -> usize {
+		data.len()
 	}
 	fn disconnect_socket(&mut self) {
 		assert!(self.peers_connected.borrow()[self.id as usize]);

--- a/net-tokio/src/lib.rs
+++ b/net-tokio/src/lib.rs
@@ -128,7 +128,7 @@ impl Connection {
 		let (reader, us) = Self::new(event_notify, stream);
 
 		if let Ok(initial_send) = peer_manager.new_outbound_connection(their_node_id, SocketDescriptor::new(us.clone(), peer_manager.clone())) {
-			if SocketDescriptor::new(us.clone(), peer_manager.clone()).send_data(&initial_send, 0, true) == initial_send.len() {
+			if SocketDescriptor::new(us.clone(), peer_manager.clone()).send_data(&initial_send, true) == initial_send.len() {
 				Self::schedule_read(peer_manager, us, reader);
 			} else {
 				println!("Failed to write first full message to socket!");
@@ -170,7 +170,7 @@ impl SocketDescriptor {
 	}
 }
 impl peer_handler::SocketDescriptor for SocketDescriptor {
-	fn send_data(&mut self, data: &Vec<u8>, write_offset: usize, resume_read: bool) -> usize {
+	fn send_data(&mut self, data: &[u8], resume_read: bool) -> usize {
 		macro_rules! schedule_read {
 			($us_ref: expr) => {
 				tokio::spawn(future::lazy(move || -> Result<(), ()> {
@@ -211,20 +211,20 @@ impl peer_handler::SocketDescriptor for SocketDescriptor {
 			let us_ref = self.clone();
 			schedule_read!(us_ref);
 		}
-		if data.len() == write_offset { return 0; }
+                if data.is_empty() { return 0; }
 		if us.writer.is_none() {
 			us.read_paused = true;
 			return 0;
 		}
 
-		let mut bytes = bytes::BytesMut::with_capacity(data.len() - write_offset);
-		bytes.put(&data[write_offset..]);
+		let mut bytes = bytes::BytesMut::with_capacity(data.len());
+		bytes.put(data);
 		let write_res = us.writer.as_mut().unwrap().start_send(bytes.freeze());
 		match write_res {
 			Ok(res) => {
 				match res {
 					AsyncSink::Ready => {
-						data.len() - write_offset
+						data.len()
 					},
 					AsyncSink::NotReady(_) => {
 						us.read_paused = true;

--- a/src/ln/peer_handler.rs
+++ b/src/ln/peer_handler.rs
@@ -50,7 +50,7 @@ pub trait SocketDescriptor : cmp::Eq + hash::Hash + Clone {
 	/// Note that in the disconnected case, a disconnect_event must still fire and further write
 	/// attempts may occur until that time.
 	///
-	/// If the returned size is smaller than data.len() - write_offset, a write_available event must
+	/// If the returned size is smaller than data.len(), a write_available event must
 	/// trigger the next time more data can be written. Additionally, until the a send_data event
 	/// completes fully, no further read_events should trigger on the same peer!
 	///
@@ -58,7 +58,7 @@ pub trait SocketDescriptor : cmp::Eq + hash::Hash + Clone {
 	/// events should be paused to prevent DoS in the send buffer), resume_read may be set
 	/// indicating that read events on this descriptor should resume. A resume_read of false does
 	/// *not* imply that further read events should be paused.
-	fn send_data(&mut self, data: &Vec<u8>, write_offset: usize, resume_read: bool) -> usize;
+	fn send_data(&mut self, data: &[u8], resume_read: bool) -> usize;
 	/// Disconnect the socket pointed to by this SocketDescriptor. Once this function returns, no
 	/// more calls to write_event, read_event or disconnect_event may be made with this descriptor.
 	/// No disconnect_event should be generated as a result of this call, though obviously races
@@ -387,7 +387,8 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 				};
 
 				let should_be_reading = peer.pending_outbound_buffer.len() < MSG_BUFF_SIZE;
-				let data_sent = descriptor.send_data(next_buff, peer.pending_outbound_buffer_first_msg_offset, should_be_reading);
+        let pending = &next_buff[peer.pending_outbound_buffer_first_msg_offset..];
+				let data_sent = descriptor.send_data(pending, should_be_reading);
 				peer.pending_outbound_buffer_first_msg_offset += data_sent;
 				if peer.pending_outbound_buffer_first_msg_offset == next_buff.len() { true } else { false }
 			} {
@@ -1122,9 +1123,8 @@ mod tests {
 	}
 
 	impl SocketDescriptor for FileDescriptor {
-		fn send_data(&mut self, data: &Vec<u8>, write_offset: usize, _resume_read: bool) -> usize {
-			assert!(write_offset < data.len());
-			data.len() - write_offset
+		fn send_data(&mut self, data: &[u8], _resume_read: bool) -> usize {
+        data.len()
 		}
 
 		fn disconnect_socket(&mut self) {}


### PR DESCRIPTION
By taking in a slice, we can avoid forcing the caller to pass in `write_offset`. 

Another added benefit is that you can pass in slices or anything that can be converted to a slice, including a vec.

Also, added the net-tokio target directory to the .gitignore. Can put this a different PR if preferred. 