### PR TITLE
Rebroadcast announcement_sigs at peer connection

### DIFF
--- a/fuzz/fuzz_targets/chanmon_fail_consistency.rs
+++ b/fuzz/fuzz_targets/chanmon_fail_consistency.rs
@@ -523,6 +523,9 @@ pub fn do_test(data: &[u8]) {
 							// Can be generated due to a payment forward being rejected due to a
 							// channel having previously failed a monitor update
 						},
+						events::MessageSendEvent::SendAnnouncementSignatures {.. } => {
+							// Can be generated at peer connection
+						}
 						_ => panic!("Unhandled message event"),
 					}
 				}
@@ -539,6 +542,7 @@ pub fn do_test(data: &[u8]) {
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
+							events::MessageSendEvent::SendAnnouncementSignatures { .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
 					}
@@ -551,6 +555,7 @@ pub fn do_test(data: &[u8]) {
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
+							events::MessageSendEvent::SendAnnouncementSignatures { .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
 					}
@@ -572,6 +577,7 @@ pub fn do_test(data: &[u8]) {
 						},
 						events::MessageSendEvent::SendFundingLocked { .. } => false,
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => false,
+						events::MessageSendEvent::SendAnnouncementSignatures { .. } => false,
 						_ => panic!("Unhandled message event"),
 					};
 					if push { msg_sink.push(event); }

--- a/src/ln/channelmanager.rs
+++ b/src/ln/channelmanager.rs
@@ -2835,11 +2835,16 @@ impl ChannelMessageHandler for ChannelManager {
 						node_id: chan.get_their_node_id(),
 						msg: chan.get_channel_reestablish(),
 					});
+					if let Some(announcement_sigs) = self.get_announcement_sigs(chan) {
+						pending_msg_events.push(events::MessageSendEvent::SendAnnouncementSignatures {
+							node_id: *their_node_id,
+							msg: announcement_sigs,
+						});
+					}
 					true
 				}
 			} else { true }
 		});
-		//TODO: Also re-broadcast announcement_signatures
 	}
 
 	fn handle_error(&self, their_node_id: &PublicKey, msg: &msgs::ErrorMessage) {

--- a/src/ln/functional_test_utils.rs
+++ b/src/ln/functional_test_utils.rs
@@ -990,6 +990,8 @@ macro_rules! get_chan_reestablish_msgs {
 				if let MessageSendEvent::SendChannelReestablish { ref node_id, ref msg } = msg {
 					assert_eq!(*node_id, $dst_node.node.get_our_node_id());
 					res.push(msg.clone());
+				} else if let MessageSendEvent::SendAnnouncementSignatures { ref node_id, .. } = msg {
+					assert_eq!(*node_id, $dst_node.node.get_our_node_id());
 				} else {
 					panic!("Unexpected event")
 				}


### PR DESCRIPTION
BOLT 7 : A node upon reconnection if it has NOT received an
announcement_sigs message, SHOULD retransmit the announcement_sigs
message

The requirement "MUST respond to the first announcement_sigs with
its own announcement_sigs message" is covered by this change too.
Instead to wait for other party behaving we send anyway a
announcement_sigs message at connection as there is no order
requirement on announcement_sigs exchange.

Fix tests broken by change.


About SendAnnouncementSignatures in test_restore_channel_monitor, not sure if necessary (I mean don't see requirement in spec)
And isn't a duplicata sending in both funding_locked/block_connected ? (Just go ahead and keep the one in funding_locked without waiting for party first-move)