### PR TITLE
Remove signing from Channel

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -212,7 +212,7 @@ pub fn do_test(data: &[u8]) {
 				monitor.latest_good_update.lock().unwrap().insert(outpoint, monitor_ser);
 			}
 			let mut monitor_refs = HashMap::new();
-			for (outpoint, monitor) in monitors.iter() {
+			for (outpoint, monitor) in monitors.iter_mut() {
 				monitor_refs.insert(*outpoint, monitor);
 			}
 
@@ -223,7 +223,7 @@ pub fn do_test(data: &[u8]) {
 				tx_broadcaster: broadcast.clone(),
 				logger,
 				default_config: config,
-				channel_monitors: &monitor_refs,
+				channel_monitors: &mut monitor_refs,
 			};
 
 			let res = (<(Sha256d, ChannelManager<EnforcingChannelKeys>)>::read(&mut Cursor::new(&$ser.0), read_args).expect("Failed to read manager").1, monitor);

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -142,7 +142,7 @@ pub trait ChannelKeys : Send {
 	/// TODO: Document the things someone using this interface should enforce before signing.
 	/// TODO: Add more input vars to enable better checking (preferably removing commitment_tx and
 	/// making the callee generate it via some util function we expose)!
-	fn sign_remote_commitment<T: secp256k1::Signing>(&self, channel_value_satoshis: u64, channel_funding_redeemscript: &Script, absolute_fee: u64, commitment_tx: &Transaction, keys: &TxCreationKeys, htlcs: &[&HTLCOutputInCommitment], to_self_delay: u16, secp_ctx: &Secp256k1<T>) -> Result<(Signature, Vec<Signature>), ()>;
+	fn sign_remote_commitment<T: secp256k1::Signing>(&self, channel_value_satoshis: u64, channel_funding_redeemscript: &Script, feerate_per_kw: u64, commitment_tx: &Transaction, keys: &TxCreationKeys, htlcs: &[&HTLCOutputInCommitment], to_self_delay: u16, secp_ctx: &Secp256k1<T>) -> Result<(Signature, Vec<Signature>), ()>;
 
 	/// Create a signature for a (proposed) closing transaction.
 	///

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1791,7 +1791,7 @@ impl<ChanSigner: ChannelKeys> ChannelManager<ChanSigner> {
 			let pending_msg_events = channel_state.pending_msg_events;
 			channel_state.by_id.retain(|_, channel| {
 				if channel.is_awaiting_monitor_update() {
-					let chan_monitor = channel.channel_monitor();
+					let chan_monitor = channel.channel_monitor().clone();
 					if let Err(e) = self.monitor.add_update_monitor(chan_monitor.get_funding_txo().unwrap(), chan_monitor) {
 						match e {
 							ChannelMonitorUpdateErr::PermanentFailure => {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3216,7 +3216,7 @@ pub struct ChannelManagerReadArgs<'a, ChanSigner: ChannelKeys> {
 	///
 	/// In such cases the latest local transactions will be sent to the tx_broadcaster included in
 	/// this struct.
-	pub channel_monitors: &'a HashMap<OutPoint, &'a ChannelMonitor>,
+	pub channel_monitors: &'a mut HashMap<OutPoint, &'a mut ChannelMonitor>,
 }
 
 impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, ChannelManagerReadArgs<'a, ChanSigner>> for (Sha256dHash, ChannelManager<ChanSigner>) {
@@ -3245,7 +3245,7 @@ impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArg
 
 			let funding_txo = channel.channel_monitor().get_funding_txo().ok_or(DecodeError::InvalidValue)?;
 			funding_txo_set.insert(funding_txo.clone());
-			if let Some(monitor) = args.channel_monitors.get(&funding_txo) {
+			if let Some(ref mut monitor) = args.channel_monitors.get_mut(&funding_txo) {
 				if channel.get_cur_local_commitment_transaction_number() != monitor.get_cur_local_commitment_number() ||
 						channel.get_revoked_remote_commitment_transaction_number() != monitor.get_min_seen_secret() ||
 						channel.get_cur_remote_commitment_transaction_number() != monitor.get_cur_remote_commitment_number() {
@@ -3263,7 +3263,7 @@ impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArg
 			}
 		}
 
-		for (ref funding_txo, ref monitor) in args.channel_monitors.iter() {
+		for (ref funding_txo, ref mut monitor) in args.channel_monitors.iter_mut() {
 			if !funding_txo_set.contains(funding_txo) {
 				closed_channels.push((monitor.get_latest_local_commitment_txn(), Vec::new()));
 			}

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -2316,6 +2316,7 @@ impl ChannelMonitor {
 	/// out-of-band the other node operator to coordinate with him if option is available to you.
 	/// In any-case, choice is up to the user.
 	pub fn get_latest_local_commitment_txn(&self) -> Vec<Transaction> {
+		log_trace!(self, "Getting signed latest local commitment transaction!");
 		if let &Some(ref local_tx) = &self.current_local_signed_commitment_tx {
 			let mut res = vec![local_tx.tx.clone()];
 			match self.key_storage {


### PR DESCRIPTION
Based on #419, this takes a few big leaps forward, removing all actual signing from Channel, and dumping it all on ChannelMonitor.