### PR TITLE
Plumb Features through into Routes

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -30,7 +30,7 @@ use lightning::ln::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr, HTL
 use lightning::ln::channelmanager::{ChannelManager, PaymentHash, PaymentPreimage, ChannelManagerReadArgs};
 use lightning::ln::router::{Route, RouteHop};
 use lightning::ln::features::InitFeatures;
-use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, ErrorAction, UpdateAddHTLC};
+use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, ErrorAction, UpdateAddHTLC, Init};
 use lightning::util::enforcing_trait_impls::EnforcingChannelKeys;
 use lightning::util::events;
 use lightning::util::logger::Logger;
@@ -650,15 +650,15 @@ pub fn do_test(data: &[u8]) {
 			},
 			0x11 => {
 				if chan_a_disconnected {
-					nodes[0].peer_connected(&nodes[1].get_our_node_id());
-					nodes[1].peer_connected(&nodes[0].get_our_node_id());
+					nodes[0].peer_connected(&nodes[1].get_our_node_id(), &Init { features: InitFeatures::empty() });
+					nodes[1].peer_connected(&nodes[0].get_our_node_id(), &Init { features: InitFeatures::empty() });
 					chan_a_disconnected = false;
 				}
 			},
 			0x12 => {
 				if chan_b_disconnected {
-					nodes[1].peer_connected(&nodes[2].get_our_node_id());
-					nodes[2].peer_connected(&nodes[1].get_our_node_id());
+					nodes[1].peer_connected(&nodes[2].get_our_node_id(), &Init { features: InitFeatures::empty() });
+					nodes[2].peer_connected(&nodes[1].get_our_node_id(), &Init { features: InitFeatures::empty() });
 					chan_b_disconnected = false;
 				}
 			},

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -29,7 +29,7 @@ use lightning::ln::channelmonitor;
 use lightning::ln::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr, HTLCUpdate};
 use lightning::ln::channelmanager::{ChannelManager, PaymentHash, PaymentPreimage, ChannelManagerReadArgs};
 use lightning::ln::router::{Route, RouteHop};
-use lightning::ln::features::InitFeatures;
+use lightning::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, ErrorAction, UpdateAddHTLC, Init};
 use lightning::util::enforcing_trait_impls::EnforcingChannelKeys;
 use lightning::util::events;
@@ -414,7 +414,9 @@ pub fn do_test(data: &[u8]) {
 				if let Err(_) = $source.send_payment(Route {
 					hops: vec![RouteHop {
 						pubkey: $dest.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
 						short_channel_id: $dest.1,
+						channel_features: ChannelFeatures::empty(),
 						fee_msat: 5000000,
 						cltv_expiry_delta: 200,
 					}],
@@ -429,12 +431,16 @@ pub fn do_test(data: &[u8]) {
 				if let Err(_) = $source.send_payment(Route {
 					hops: vec![RouteHop {
 						pubkey: $middle.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
 						short_channel_id: $middle.1,
+						channel_features: ChannelFeatures::empty(),
 						fee_msat: 50000,
 						cltv_expiry_delta: 100,
 					},RouteHop {
 						pubkey: $dest.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
 						short_channel_id: $dest.1,
+						channel_features: ChannelFeatures::empty(),
 						fee_msat: 5000000,
 						cltv_expiry_delta: 200,
 					}],

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -5,8 +5,9 @@ use bitcoin::blockdata::transaction::Transaction;
 
 use lightning::chain::chaininterface::{ChainError,ChainWatchInterface};
 use lightning::ln::channelmanager::ChannelDetails;
+use lightning::ln::features::InitFeatures;
 use lightning::ln::msgs;
-use lightning::ln::msgs::{RoutingMessageHandler};
+use lightning::ln::msgs::RoutingMessageHandler;
 use lightning::ln::router::{Router, RouteHint};
 use lightning::util::logger::Logger;
 use lightning::util::ser::Readable;
@@ -198,6 +199,7 @@ pub fn do_test(data: &[u8]) {
 								channel_id: [0; 32],
 								short_channel_id: Some(slice_to_be64(get_slice!(8))),
 								remote_network_id: get_pubkey!(),
+								counterparty_features: InitFeatures::empty(),
 								channel_value_satoshis: slice_to_be64(get_slice!(8)),
 								user_id: 0,
 								inbound_capacity_msat: 0,

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -215,10 +215,10 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 		nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 		nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
-		nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+		nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 		let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
 		assert_eq!(reestablish_1.len(), 1);
-		nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+		nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 		let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 		assert_eq!(reestablish_2.len(), 1);
 
@@ -237,10 +237,10 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 		assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
 		assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
 
-		nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+		nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 		let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
 		assert_eq!(reestablish_1.len(), 1);
-		nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+		nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 		let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 		assert_eq!(reestablish_2.len(), 1);
 
@@ -938,8 +938,8 @@ fn test_monitor_update_fail_reestablish() {
 	commitment_signed_dance!(nodes[1], nodes[2], updates.commitment_signed, false);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 
 	let as_reestablish = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReestablish, nodes[1].node.get_our_node_id());
 	let bs_reestablish = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id());
@@ -954,8 +954,8 @@ fn test_monitor_update_fail_reestablish() {
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 
 	assert!(as_reestablish == get_event_msg!(nodes[0], MessageSendEvent::SendChannelReestablish, nodes[1].node.get_our_node_id()));
 	assert!(bs_reestablish == get_event_msg!(nodes[1], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id()));
@@ -1118,8 +1118,8 @@ fn claim_while_disconnected_monitor_update_fail() {
 	assert!(nodes[1].node.claim_funds(payment_preimage_1, 1_000_000));
 	check_added_monitors!(nodes[1], 1);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 
 	let as_reconnect = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReestablish, nodes[1].node.get_our_node_id());
 	let bs_reconnect = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id());
@@ -1246,8 +1246,8 @@ fn monitor_failed_no_reestablish_response() {
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 
 	let as_reconnect = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReestablish, nodes[1].node.get_our_node_id());
 	let bs_reconnect = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id());

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -275,6 +275,12 @@ pub(super) struct ChannelHolder<ChanSigner: ChannelKeys> {
 	pub(super) pending_msg_events: Vec<events::MessageSendEvent>,
 }
 
+/// State we hold per-peer. In the future we should put channels in here, but for now we only hold
+/// the latest Init features we heard from the peer.
+struct PeerState {
+	latest_features: InitFeatures,
+}
+
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 const ERR: () = "You need at least 32 bit pointers (well, usize, but we'll assume they're the same) for ChannelManager::latest_block_height";
 
@@ -327,6 +333,14 @@ pub struct ChannelManager<ChanSigner: ChannelKeys> {
 	#[cfg(not(test))]
 	channel_state: Mutex<ChannelHolder<ChanSigner>>,
 	our_network_key: SecretKey,
+
+	/// The bulk of our storage will eventually be here (channels and message queues and the like).
+	/// If we are connected to a peer we always at least have an entry here, even if no channels
+	/// are currently open with that peer.
+	/// Because adding or removing an entry is rare, we usually take an outer read lock and then
+	/// operate on the inner value freely. Sadly, this prevents parallel operation when opening a
+	/// new channel.
+	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState>>>,
 
 	pending_events: Mutex<Vec<events::Event>>,
 	/// Used when we have to take a BIG lock to make sure everything is self-consistent.
@@ -609,6 +623,8 @@ impl<ChanSigner: ChannelKeys> ChannelManager<ChanSigner> {
 				pending_msg_events: Vec::new(),
 			}),
 			our_network_key: keys_manager.get_node_secret(),
+
+			per_peer_state: RwLock::new(HashMap::new()),
 
 			pending_events: Mutex::new(Vec::new()),
 			total_consistency_lock: RwLock::new(()),
@@ -2780,6 +2796,7 @@ impl<ChanSigner: ChannelKeys> ChannelMessageHandler for ChannelManager<ChanSigne
 		let _ = self.total_consistency_lock.read().unwrap();
 		let mut failed_channels = Vec::new();
 		let mut failed_payments = Vec::new();
+		let mut no_channels_remain = true;
 		{
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
@@ -2818,6 +2835,8 @@ impl<ChanSigner: ChannelKeys> ChannelMessageHandler for ChannelManager<ChanSigne
 								short_to_id.remove(&short_id);
 							}
 							return false;
+						} else {
+							no_channels_remain = false;
 						}
 					}
 					true
@@ -2843,6 +2862,10 @@ impl<ChanSigner: ChannelKeys> ChannelMessageHandler for ChannelManager<ChanSigne
 				}
 			});
 		}
+		if no_channels_remain {
+			self.per_peer_state.write().unwrap().remove(their_node_id);
+		}
+
 		for failure in failed_channels.drain(..) {
 			self.finish_force_close_channel(failure);
 		}
@@ -2853,10 +2876,25 @@ impl<ChanSigner: ChannelKeys> ChannelMessageHandler for ChannelManager<ChanSigne
 		}
 	}
 
-	fn peer_connected(&self, their_node_id: &PublicKey, _init_msg: &msgs::Init) {
+	fn peer_connected(&self, their_node_id: &PublicKey, init_msg: &msgs::Init) {
 		log_debug!(self, "Generating channel_reestablish events for {}", log_pubkey!(their_node_id));
 
 		let _ = self.total_consistency_lock.read().unwrap();
+
+		{
+			let mut peer_state_lock = self.per_peer_state.write().unwrap();
+			match peer_state_lock.entry(their_node_id.clone()) {
+				hash_map::Entry::Vacant(e) => {
+					e.insert(Mutex::new(PeerState {
+						latest_features: init_msg.features.clone(),
+					}));
+				},
+				hash_map::Entry::Occupied(e) => {
+					e.get().lock().unwrap().latest_features = init_msg.features.clone();
+				},
+			}
+		}
+
 		let mut channel_state_lock = self.channel_state.lock().unwrap();
 		let channel_state = &mut *channel_state_lock;
 		let pending_msg_events = &mut channel_state.pending_msg_events;
@@ -3123,6 +3161,14 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for ChannelManager<ChanSigne
 			}
 		}
 
+		let per_peer_state = self.per_peer_state.write().unwrap();
+		(per_peer_state.len() as u64).write(writer)?;
+		for (peer_pubkey, peer_state_mutex) in per_peer_state.iter() {
+			peer_pubkey.write(writer)?;
+			let peer_state = peer_state_mutex.lock().unwrap();
+			peer_state.latest_features.write(writer)?;
+		}
+
 		Ok(())
 	}
 }
@@ -3256,6 +3302,16 @@ impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArg
 			claimable_htlcs.insert(payment_hash, previous_hops);
 		}
 
+		let peer_count: u64 = Readable::read(reader)?;
+		let mut per_peer_state = HashMap::with_capacity(cmp::min(peer_count as usize, 128));
+		for _ in 0..peer_count {
+			let peer_pubkey = Readable::read(reader)?;
+			let peer_state = PeerState {
+				latest_features: Readable::read(reader)?,
+			};
+			per_peer_state.insert(peer_pubkey, Mutex::new(peer_state));
+		}
+
 		let channel_manager = ChannelManager {
 			genesis_hash,
 			fee_estimator: args.fee_estimator,
@@ -3274,6 +3330,8 @@ impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArg
 				pending_msg_events: Vec::new(),
 			}),
 			our_network_key: args.keys_manager.get_node_secret(),
+
+			per_peer_state: RwLock::new(per_peer_state),
 
 			pending_events: Mutex::new(Vec::new()),
 			total_consistency_lock: RwLock::new(()),

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2853,7 +2853,7 @@ impl<ChanSigner: ChannelKeys> ChannelMessageHandler for ChannelManager<ChanSigne
 		}
 	}
 
-	fn peer_connected(&self, their_node_id: &PublicKey) {
+	fn peer_connected(&self, their_node_id: &PublicKey, _init_msg: &msgs::Init) {
 		log_debug!(self, "Generating channel_reestablish events for {}", log_pubkey!(their_node_id));
 
 		let _ = self.total_consistency_lock.read().unwrap();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -404,6 +404,10 @@ pub struct ChannelDetails {
 	pub short_channel_id: Option<u64>,
 	/// The node_id of our counterparty
 	pub remote_network_id: PublicKey,
+	/// The Features the channel counterparty provided upon last connection.
+	/// Useful for routing as it is the most up-to-date copy of the counterparty's features and
+	/// many routing-relevant features are present in the init context.
+	pub counterparty_features: InitFeatures,
 	/// The value, in satoshis, of this channel as appears in the funding output
 	pub channel_value_satoshis: u64,
 	/// The user_id passed in to create_channel, or 0 if the channel was inbound.
@@ -679,20 +683,30 @@ impl<ChanSigner: ChannelKeys> ChannelManager<ChanSigner> {
 	/// Gets the list of open channels, in random order. See ChannelDetail field documentation for
 	/// more information.
 	pub fn list_channels(&self) -> Vec<ChannelDetails> {
-		let channel_state = self.channel_state.lock().unwrap();
-		let mut res = Vec::with_capacity(channel_state.by_id.len());
-		for (channel_id, channel) in channel_state.by_id.iter() {
-			let (inbound_capacity_msat, outbound_capacity_msat) = channel.get_inbound_outbound_available_balance_msat();
-			res.push(ChannelDetails {
-				channel_id: (*channel_id).clone(),
-				short_channel_id: channel.get_short_channel_id(),
-				remote_network_id: channel.get_their_node_id(),
-				channel_value_satoshis: channel.get_value_satoshis(),
-				inbound_capacity_msat,
-				outbound_capacity_msat,
-				user_id: channel.get_user_id(),
-				is_live: channel.is_live(),
-			});
+		let mut res = Vec::new();
+		{
+			let channel_state = self.channel_state.lock().unwrap();
+			res.reserve(channel_state.by_id.len());
+			for (channel_id, channel) in channel_state.by_id.iter() {
+				let (inbound_capacity_msat, outbound_capacity_msat) = channel.get_inbound_outbound_available_balance_msat();
+				res.push(ChannelDetails {
+					channel_id: (*channel_id).clone(),
+					short_channel_id: channel.get_short_channel_id(),
+					remote_network_id: channel.get_their_node_id(),
+					counterparty_features: InitFeatures::empty(),
+					channel_value_satoshis: channel.get_value_satoshis(),
+					inbound_capacity_msat,
+					outbound_capacity_msat,
+					user_id: channel.get_user_id(),
+					is_live: channel.is_live(),
+				});
+			}
+		}
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		for chan in res.iter_mut() {
+			if let Some(peer_state) = per_peer_state.get(&chan.remote_network_id) {
+				chan.counterparty_features = peer_state.lock().unwrap().latest_features.clone();
+			}
 		}
 		res
 	}
@@ -703,24 +717,34 @@ impl<ChanSigner: ChannelKeys> ChannelManager<ChanSigner> {
 	/// These are guaranteed to have their is_live value set to true, see the documentation for
 	/// ChannelDetails::is_live for more info on exactly what the criteria are.
 	pub fn list_usable_channels(&self) -> Vec<ChannelDetails> {
-		let channel_state = self.channel_state.lock().unwrap();
-		let mut res = Vec::with_capacity(channel_state.by_id.len());
-		for (channel_id, channel) in channel_state.by_id.iter() {
-			// Note we use is_live here instead of usable which leads to somewhat confused
-			// internal/external nomenclature, but that's ok cause that's probably what the user
-			// really wanted anyway.
-			if channel.is_live() {
-				let (inbound_capacity_msat, outbound_capacity_msat) = channel.get_inbound_outbound_available_balance_msat();
-				res.push(ChannelDetails {
-					channel_id: (*channel_id).clone(),
-					short_channel_id: channel.get_short_channel_id(),
-					remote_network_id: channel.get_their_node_id(),
-					channel_value_satoshis: channel.get_value_satoshis(),
-					inbound_capacity_msat,
-					outbound_capacity_msat,
-					user_id: channel.get_user_id(),
-					is_live: true,
-				});
+		let mut res = Vec::new();
+		{
+			let channel_state = self.channel_state.lock().unwrap();
+			res.reserve(channel_state.by_id.len());
+			for (channel_id, channel) in channel_state.by_id.iter() {
+				// Note we use is_live here instead of usable which leads to somewhat confused
+				// internal/external nomenclature, but that's ok cause that's probably what the user
+				// really wanted anyway.
+				if channel.is_live() {
+					let (inbound_capacity_msat, outbound_capacity_msat) = channel.get_inbound_outbound_available_balance_msat();
+					res.push(ChannelDetails {
+						channel_id: (*channel_id).clone(),
+						short_channel_id: channel.get_short_channel_id(),
+						remote_network_id: channel.get_their_node_id(),
+						counterparty_features: InitFeatures::empty(),
+						channel_value_satoshis: channel.get_value_satoshis(),
+						inbound_capacity_msat,
+						outbound_capacity_msat,
+						user_id: channel.get_user_id(),
+						is_live: true,
+					});
+				}
+			}
+		}
+		let per_peer_state = self.per_peer_state.read().unwrap();
+		for chan in res.iter_mut() {
+			if let Some(peer_state) = per_peer_state.get(&chan.remote_network_id) {
+				chan.counterparty_features = peer_state.lock().unwrap().latest_features.clone();
 			}
 		}
 		res

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -118,6 +118,13 @@ impl ChannelFeatures {
 			mark: PhantomData,
 		}
 	}
+
+	/// Takes the flags that we know how to interpret in an init-context features that are also
+	/// relevant in a channel-context features and creates a channel-context features from them.
+	pub(crate) fn with_known_relevant_init_flags(_init_ctx: &InitFeatures) -> Self {
+		// There are currently no channel flags defined that we understand.
+		Self { flags: Vec::new(), mark: PhantomData, }
+	}
 }
 
 impl NodeFeatures {
@@ -135,6 +142,17 @@ impl NodeFeatures {
 			flags: vec![2 | 1 << 5],
 			mark: PhantomData,
 		}
+	}
+
+	/// Takes the flags that we know how to interpret in an init-context features that are also
+	/// relevant in a node-context features and creates a node-context features from them.
+	pub(crate) fn with_known_relevant_init_flags(init_ctx: &InitFeatures) -> Self {
+		let mut flags = Vec::new();
+		if init_ctx.flags.len() > 0 {
+			// Pull out data_loss_protect and upfront_shutdown_script (bits 0, 1, 4, and 5)
+			flags.push(init_ctx.flags.last().unwrap() & 0b00110011);
+		}
+		Self { flags, mark: PhantomData, }
 	}
 }
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1087,9 +1087,9 @@ macro_rules! handle_chan_reestablish_msgs {
 /// pending_htlc_adds includes both the holding cell and in-flight update_add_htlcs, whereas
 /// for claims/fails they are separated out.
 pub fn reconnect_nodes(node_a: &Node, node_b: &Node, send_funding_locked: (bool, bool), pending_htlc_adds: (i64, i64), pending_htlc_claims: (usize, usize), pending_cell_htlc_claims: (usize, usize), pending_cell_htlc_fails: (usize, usize), pending_raa: (bool, bool)) {
-	node_a.node.peer_connected(&node_b.node.get_our_node_id());
+	node_a.node.peer_connected(&node_b.node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_1 = get_chan_reestablish_msgs!(node_a, node_b);
-	node_b.node.peer_connected(&node_a.node.get_our_node_id());
+	node_b.node.peer_connected(&node_a.node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_2 = get_chan_reestablish_msgs!(node_b, node_a);
 
 	if send_funding_locked.0 {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -11,7 +11,7 @@ use ln::channelmonitor::{ChannelMonitor, CLTV_CLAIM_BUFFER, LATENCY_GRACE_PERIOD
 use ln::channel::{Channel, ChannelError};
 use ln::onion_utils;
 use ln::router::{Route, RouteHop};
-use ln::features::{ChannelFeatures, InitFeatures};
+use ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use ln::msgs;
 use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler,HTLCFailChannelUpdate, ErrorAction};
 use util::enforcing_trait_impls::EnforcingChannelKeys;
@@ -1029,19 +1029,25 @@ fn fake_network_test() {
 	let mut hops = Vec::with_capacity(3);
 	hops.push(RouteHop {
 		pubkey: nodes[2].node.get_our_node_id(),
+		node_features: NodeFeatures::empty(),
 		short_channel_id: chan_2.0.contents.short_channel_id,
+		channel_features: ChannelFeatures::empty(),
 		fee_msat: 0,
 		cltv_expiry_delta: chan_3.0.contents.cltv_expiry_delta as u32
 	});
 	hops.push(RouteHop {
 		pubkey: nodes[3].node.get_our_node_id(),
+		node_features: NodeFeatures::empty(),
 		short_channel_id: chan_3.0.contents.short_channel_id,
+		channel_features: ChannelFeatures::empty(),
 		fee_msat: 0,
 		cltv_expiry_delta: chan_4.1.contents.cltv_expiry_delta as u32
 	});
 	hops.push(RouteHop {
 		pubkey: nodes[1].node.get_our_node_id(),
+		node_features: NodeFeatures::empty(),
 		short_channel_id: chan_4.0.contents.short_channel_id,
+		channel_features: ChannelFeatures::empty(),
 		fee_msat: 1000000,
 		cltv_expiry_delta: TEST_FINAL_CLTV,
 	});
@@ -1052,19 +1058,25 @@ fn fake_network_test() {
 	let mut hops = Vec::with_capacity(3);
 	hops.push(RouteHop {
 		pubkey: nodes[3].node.get_our_node_id(),
+		node_features: NodeFeatures::empty(),
 		short_channel_id: chan_4.0.contents.short_channel_id,
+		channel_features: ChannelFeatures::empty(),
 		fee_msat: 0,
 		cltv_expiry_delta: chan_3.1.contents.cltv_expiry_delta as u32
 	});
 	hops.push(RouteHop {
 		pubkey: nodes[2].node.get_our_node_id(),
+		node_features: NodeFeatures::empty(),
 		short_channel_id: chan_3.0.contents.short_channel_id,
+		channel_features: ChannelFeatures::empty(),
 		fee_msat: 0,
 		cltv_expiry_delta: chan_2.1.contents.cltv_expiry_delta as u32
 	});
 	hops.push(RouteHop {
 		pubkey: nodes[1].node.get_our_node_id(),
+		node_features: NodeFeatures::empty(),
 		short_channel_id: chan_2.0.contents.short_channel_id,
+		channel_features: ChannelFeatures::empty(),
 		fee_msat: 1000000,
 		cltv_expiry_delta: TEST_FINAL_CLTV,
 	});

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -852,9 +852,9 @@ fn do_test_shutdown_rebroadcast(recv_count: u8) {
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let node_0_reestablish = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReestablish, nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let node_1_reestablish = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id());
 
 	nodes[1].node.handle_channel_reestablish(&nodes[0].node.get_our_node_id(), &node_0_reestablish);
@@ -916,9 +916,9 @@ fn do_test_shutdown_rebroadcast(recv_count: u8) {
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let node_0_2nd_reestablish = get_event_msg!(nodes[0], MessageSendEvent::SendChannelReestablish, nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	if recv_count == 0 {
 		// If all closing_signeds weren't delivered we can just resume where we left off...
 		let node_1_2nd_reestablish = get_event_msg!(nodes[1], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id());
@@ -3254,10 +3254,10 @@ fn test_drop_messages_peer_disconnect_dual_htlc() {
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
 	assert_eq!(reestablish_1.len(), 1);
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 	assert_eq!(reestablish_2.len(), 1);
 
@@ -3451,9 +3451,9 @@ fn test_no_txn_manager_serialize_deserialize() {
 	assert_eq!(nodes[0].node.list_channels().len(), 1);
 	check_added_monitors!(nodes[0], 1);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 
 	nodes[1].node.handle_channel_reestablish(&nodes[0].node.get_our_node_id(), &reestablish_1[0]);
@@ -3586,9 +3586,9 @@ fn test_manager_serialize_deserialize_inconsistent_monitor() {
 	//... and we can even still claim the payment!
 	claim_payment(&nodes[2], &[&nodes[0], &nodes[1]], our_payment_preimage, 1_000_000);
 
-	nodes[3].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[3].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish = get_event_msg!(nodes[3], MessageSendEvent::SendChannelReestablish, nodes[0].node.get_our_node_id());
-	nodes[0].node.peer_connected(&nodes[3].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[3].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	nodes[0].node.handle_channel_reestablish(&nodes[3].node.get_our_node_id(), &reestablish);
 	let msg_events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(msg_events.len(), 1);
@@ -5380,10 +5380,10 @@ fn test_update_add_htlc_bolt2_receiver_check_repeated_id_ignore() {
 	//Disconnect and Reconnect
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
 	assert_eq!(reestablish_1.len(), 1);
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 	assert_eq!(reestablish_2.len(), 1);
 	nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
@@ -6155,8 +6155,8 @@ fn test_data_loss_protect() {
 
 	check_added_monitors!(nodes[0], 1);
 
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 
 	let reestablish_0 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 
@@ -6297,10 +6297,10 @@ fn test_announce_disable_channels() {
 		}
 	}
 	// Reconnect peers
-	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id());
+	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
 	assert_eq!(reestablish_1.len(), 3);
-	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id());
+	nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
 	let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
 	assert_eq!(reestablish_2.len(), 3);
 

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -56,7 +56,10 @@ pub enum DecodeError {
 
 /// An init message to be sent or received from a peer
 pub struct Init {
+	#[cfg(not(feature = "fuzztarget"))]
 	pub(crate) features: InitFeatures,
+	#[cfg(feature = "fuzztarget")]
+	pub features: InitFeatures,
 }
 
 /// An error message to be sent or received from a peer
@@ -571,7 +574,7 @@ pub trait ChannelMessageHandler : events::MessageSendEventsProvider + Send + Syn
 	fn peer_disconnected(&self, their_node_id: &PublicKey, no_connection_possible: bool);
 
 	/// Handle a peer reconnecting, possibly generating channel_reestablish message(s).
-	fn peer_connected(&self, their_node_id: &PublicKey);
+	fn peer_connected(&self, their_node_id: &PublicKey, msg: &Init);
 	/// Handle an incoming channel_reestablish message from the given peer.
 	fn handle_channel_reestablish(&self, their_node_id: &PublicKey, msg: &ChannelReestablish);
 

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -425,6 +425,7 @@ pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<
 #[cfg(test)]
 mod tests {
 	use ln::channelmanager::PaymentHash;
+	use ln::features::{ChannelFeatures, NodeFeatures};
 	use ln::router::{Route, RouteHop};
 	use ln::msgs;
 	use util::ser::Writeable;
@@ -444,22 +445,27 @@ mod tests {
 			hops: vec!(
 					RouteHop {
 						pubkey: PublicKey::from_slice(&hex::decode("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619").unwrap()[..]).unwrap(),
+						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&hex::decode("0324653eac434488002cc06bbfb7f10fe18991e35f9fe4302dbea6d2353dc0ab1c").unwrap()[..]).unwrap(),
+						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&hex::decode("027f31ebc5462c1fdce1b737ecff52d37d75dea43ce11c74d25aa297165faa2007").unwrap()[..]).unwrap(),
+						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&hex::decode("032c0b7cf95324a07d05398b240174dc0c2be444d96b159aa6c7f7b1e668680991").unwrap()[..]).unwrap(),
+						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 					RouteHop {
 						pubkey: PublicKey::from_slice(&hex::decode("02edabbd16b41c8371b92ef2f04c1185b4f03b6dcd52ba9b78d9d7c89c8f221145").unwrap()[..]).unwrap(),
+						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
 			),

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -622,7 +622,6 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 													peer.sync_status = InitSyncTracker::ChannelsSyncing(0);
 													peers.peers_needing_send.insert(peer_descriptor.clone());
 												}
-												peer.their_features = Some(msg.features);
 
 												if !peer.outbound {
 													let mut features = InitFeatures::supported();
@@ -636,7 +635,8 @@ impl<Descriptor: SocketDescriptor> PeerManager<Descriptor> {
 													}, 16);
 												}
 
-												self.message_handler.chan_handler.peer_connected(&peer.their_node_id.unwrap());
+												self.message_handler.chan_handler.peer_connected(&peer.their_node_id.unwrap(), &msg);
+												peer.their_features = Some(msg.features);
 											},
 											17 => {
 												let msg = try_potential_decodeerror!(msgs::ErrorMessage::read(&mut reader));

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -117,7 +117,7 @@ impl msgs::ChannelMessageHandler for TestChannelMessageHandler {
 	fn handle_announcement_signatures(&self, _their_node_id: &PublicKey, _msg: &msgs::AnnouncementSignatures) {}
 	fn handle_channel_reestablish(&self, _their_node_id: &PublicKey, _msg: &msgs::ChannelReestablish) {}
 	fn peer_disconnected(&self, _their_node_id: &PublicKey, _no_connection_possible: bool) {}
-	fn peer_connected(&self, _their_node_id: &PublicKey) {}
+	fn peer_connected(&self, _their_node_id: &PublicKey, _msg: &msgs::Init) {}
 	fn handle_error(&self, _their_node_id: &PublicKey, _msg: &msgs::ErrorMessage) {}
 }
 


### PR DESCRIPTION
<strike>Based on #428, </strike>this plumbs features through into Routes so that we can use that information when we go to construct onions. This is gonna be required for #430.

While we're tracking new info in ChannelManager, we create the map that should eventually hold all channel data and implement #422.