### PR TITLE
Add ability to broadcast our own node_announcement

### DIFF
--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -124,7 +124,6 @@ pub fn do_test(data: &[u8]) {
 					msgs::DecodeError::UnknownVersion => return,
 					msgs::DecodeError::UnknownRequiredFeature => return,
 					msgs::DecodeError::InvalidValue => return,
-					msgs::DecodeError::ExtraAddressesPerType => return,
 					msgs::DecodeError::BadLengthDescriptor => return,
 					msgs::DecodeError::ShortRead => panic!("We picked the length..."),
 					msgs::DecodeError::Io(e) => panic!(format!("{}", e)),

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -394,10 +394,33 @@ pub fn create_announced_chan_between_nodes<'a, 'b, 'c, 'd>(nodes: &'a Vec<Node<'
 
 pub fn create_announced_chan_between_nodes_with_value<'a, 'b, 'c, 'd>(nodes: &'a Vec<Node<'b, 'c, 'd>>, a: usize, b: usize, channel_value: u64, push_msat: u64, a_flags: InitFeatures, b_flags: InitFeatures) -> (msgs::ChannelUpdate, msgs::ChannelUpdate, [u8; 32], Transaction) {
 	let chan_announcement = create_chan_between_nodes_with_value(&nodes[a], &nodes[b], channel_value, push_msat, a_flags, b_flags);
+
+	nodes[a].node.broadcast_node_announcement([0, 0, 0], [0; 32], Vec::new());
+	let a_events = nodes[a].node.get_and_clear_pending_msg_events();
+	assert_eq!(a_events.len(), 1);
+	let a_node_announcement = match a_events[0] {
+		MessageSendEvent::BroadcastNodeAnnouncement { ref msg } => {
+			(*msg).clone()
+		},
+		_ => panic!("Unexpected event"),
+	};
+
+	nodes[b].node.broadcast_node_announcement([1, 1, 1], [1; 32], Vec::new());
+	let b_events = nodes[b].node.get_and_clear_pending_msg_events();
+	assert_eq!(b_events.len(), 1);
+	let b_node_announcement = match b_events[0] {
+		MessageSendEvent::BroadcastNodeAnnouncement { ref msg } => {
+			(*msg).clone()
+		},
+		_ => panic!("Unexpected event"),
+	};
+
 	for node in nodes {
 		assert!(node.router.handle_channel_announcement(&chan_announcement.0).unwrap());
 		node.router.handle_channel_update(&chan_announcement.1).unwrap();
 		node.router.handle_channel_update(&chan_announcement.2).unwrap();
+		node.router.handle_node_announcement(&a_node_announcement).unwrap();
+		node.router.handle_node_announcement(&b_node_announcement).unwrap();
 	}
 	(chan_announcement.1, chan_announcement.2, chan_announcement.3, chan_announcement.4)
 }

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -600,10 +600,11 @@ pub trait RoutingMessageHandler : Send + Sync {
 	fn handle_htlc_fail_channel_update(&self, update: &HTLCFailChannelUpdate);
 	/// Gets a subset of the channel announcements and updates required to dump our routing table
 	/// to a remote node, starting at the short_channel_id indicated by starting_point and
-	/// including batch_amount entries.
+	/// including the batch_amount entries immediately higher in numerical value than starting_point.
 	fn get_next_channel_announcements(&self, starting_point: u64, batch_amount: u8) -> Vec<(ChannelAnnouncement, ChannelUpdate, ChannelUpdate)>;
 	/// Gets a subset of the node announcements required to dump our routing table to a remote node,
-	/// starting at the node *after* the provided publickey and including batch_amount entries.
+	/// starting at the node *after* the provided publickey and including batch_amount entries
+	/// immediately higher (as defined by <PublicKey as Ord>::cmp) than starting_point.
 	/// If None is provided for starting_point, we start at the first node.
 	fn get_next_node_announcements(&self, starting_point: Option<&PublicKey>, batch_amount: u8) -> Vec<NodeAnnouncement>;
 	/// Returns whether a full sync should be requested from a peer.

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -302,6 +302,9 @@ impl NetAddress {
 			&NetAddress::OnionV3 { .. } => { 37 },
 		}
 	}
+
+	/// The maximum length of any address descriptor, not including the 1-byte type
+	pub(crate) const MAX_LEN: u16 = 37;
 }
 
 impl Writeable for NetAddress {
@@ -1291,7 +1294,7 @@ impl Readable for UnsignedNodeAnnouncement {
 
 impl_writeable_len_match!(NodeAnnouncement, {
 		{ NodeAnnouncement { contents: UnsignedNodeAnnouncement { ref features, ref addresses, ref excess_address_data, ref excess_data, ..}, .. },
-			64 + 76 + features.byte_count() + addresses.len()*38 + excess_address_data.len() + excess_data.len() }
+			64 + 76 + features.byte_count() + addresses.len()*(NetAddress::MAX_LEN as usize + 1) + excess_address_data.len() + excess_data.len() }
 	}, {
 	signature,
 	contents

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -586,10 +586,6 @@ impl<Descriptor: SocketDescriptor, CM: Deref> PeerManager<Descriptor, CM> where 
 														log_debug!(self, "Deserialization failed due to shortness of message");
 														return Err(PeerHandleError { no_connection_possible: false });
 													}
-													msgs::DecodeError::ExtraAddressesPerType => {
-														log_debug!(self, "Error decoding message, ignoring due to lnd spec incompatibility. See https://github.com/lightningnetwork/lnd/issues/1407");
-														continue;
-													}
 													msgs::DecodeError::BadLengthDescriptor => return Err(PeerHandleError { no_connection_possible: false }),
 													msgs::DecodeError::Io(_) => return Err(PeerHandleError { no_connection_possible: false }),
 												}

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -278,11 +278,22 @@ pub enum MessageSendEvent {
 	},
 	/// Used to indicate that a channel_announcement and channel_update should be broadcast to all
 	/// peers (except the peer with node_id either msg.contents.node_id_1 or msg.contents.node_id_2).
+	///
+	/// Note that after doing so, you very likely (unless you did so very recently) want to call
+	/// ChannelManager::broadcast_node_announcement to trigger a BroadcastNodeAnnouncement event.
+	/// This ensures that any nodes which see our channel_announcement also have a relevant
+	/// node_announcement, including relevant feature flags which may be important for routing
+	/// through or to us.
 	BroadcastChannelAnnouncement {
 		/// The channel_announcement which should be sent.
 		msg: msgs::ChannelAnnouncement,
 		/// The followup channel_update which should be sent.
 		update_msg: msgs::ChannelUpdate,
+	},
+	/// Used to indicate that a node_announcement should be broadcast to all peers.
+	BroadcastNodeAnnouncement {
+		/// The node_announcement which should be sent.
+		msg: msgs::NodeAnnouncement,
 	},
 	/// Used to indicate that a channel_update should be broadcast to all peers.
 	BroadcastChannelUpdate {


### PR DESCRIPTION
This is a somewhat-obvious oversight in the capabilities of
rust-lightning, though not a particularly interesting one until we
start relying on node_features (eg for variable-length-onions and
Base AMP).

Sadly its not fully automated as we don't really want to store the
list of available addresses from the user. However, with a simple
call to ChannelManager::broadcast_node_announcement and a sensible
peer_handler, the announcement is made.