### PR TITLE
Multi-Path Payments

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -417,7 +417,7 @@ pub fn do_test(data: &[u8]) {
 						fee_msat: 5000000,
 						cltv_expiry_delta: 200,
 					}],
-				}, PaymentHash(payment_hash.into_inner())) {
+				}, PaymentHash(payment_hash.into_inner()), &None) {
 					// Probably ran out of funds
 					test_return!();
 				}
@@ -441,7 +441,7 @@ pub fn do_test(data: &[u8]) {
 						fee_msat: 5000000,
 						cltv_expiry_delta: 200,
 					}],
-				}, PaymentHash(payment_hash.into_inner())) {
+				}, PaymentHash(payment_hash.into_inner()), &None) {
 					// Probably ran out of funds
 					test_return!();
 				}
@@ -602,9 +602,9 @@ pub fn do_test(data: &[u8]) {
 						events::Event::PaymentReceived { payment_hash, .. } => {
 							if claim_set.insert(payment_hash.0) {
 								if $fail {
-									assert!(nodes[$node].fail_htlc_backwards(&payment_hash));
+									assert!(nodes[$node].fail_htlc_backwards(&payment_hash, &None));
 								} else {
-									assert!(nodes[$node].claim_funds(PaymentPreimage(payment_hash.0), 5_000_000));
+									assert!(nodes[$node].claim_funds(PaymentPreimage(payment_hash.0), &None, 5_000_000));
 								}
 							}
 						},

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -408,7 +408,7 @@ pub fn do_test(data: &[u8]) {
 			($source: expr, $dest: expr) => { {
 				let payment_hash = Sha256::hash(&[payment_id; 1]);
 				payment_id = payment_id.wrapping_add(1);
-				if let Err(_) = $source.send_payment(Route {
+				if let Err(_) = $source.send_payment(&Route {
 					paths: vec![vec![RouteHop {
 						pubkey: $dest.0.get_our_node_id(),
 						node_features: NodeFeatures::empty(),
@@ -425,7 +425,7 @@ pub fn do_test(data: &[u8]) {
 			($source: expr, $middle: expr, $dest: expr) => { {
 				let payment_hash = Sha256::hash(&[payment_id; 1]);
 				payment_id = payment_id.wrapping_add(1);
-				if let Err(_) = $source.send_payment(Route {
+				if let Err(_) = $source.send_payment(&Route {
 					paths: vec![vec![RouteHop {
 						pubkey: $middle.0.get_our_node_id(),
 						node_features: NodeFeatures::empty(),
@@ -453,7 +453,7 @@ pub fn do_test(data: &[u8]) {
 				payment_id = payment_id.wrapping_add(1);
 				let payment_secret = Sha256::hash(&[payment_id; 1]);
 				payment_id = payment_id.wrapping_add(1);
-				if let Err(_) = $source.send_payment(Route {
+				if let Err(_) = $source.send_payment(&Route {
 					paths: vec![vec![RouteHop {
 						pubkey: $middle.0.get_our_node_id(),
 						node_features: NodeFeatures::empty(),

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -409,14 +409,14 @@ pub fn do_test(data: &[u8]) {
 				let payment_hash = Sha256::hash(&[payment_id; 1]);
 				payment_id = payment_id.wrapping_add(1);
 				if let Err(_) = $source.send_payment(Route {
-					hops: vec![RouteHop {
+					paths: vec![vec![RouteHop {
 						pubkey: $dest.0.get_our_node_id(),
 						node_features: NodeFeatures::empty(),
 						short_channel_id: $dest.1,
 						channel_features: ChannelFeatures::empty(),
 						fee_msat: 5000000,
 						cltv_expiry_delta: 200,
-					}],
+					}]],
 				}, PaymentHash(payment_hash.into_inner()), &None) {
 					// Probably ran out of funds
 					test_return!();
@@ -426,7 +426,7 @@ pub fn do_test(data: &[u8]) {
 				let payment_hash = Sha256::hash(&[payment_id; 1]);
 				payment_id = payment_id.wrapping_add(1);
 				if let Err(_) = $source.send_payment(Route {
-					hops: vec![RouteHop {
+					paths: vec![vec![RouteHop {
 						pubkey: $middle.0.get_our_node_id(),
 						node_features: NodeFeatures::empty(),
 						short_channel_id: $middle.1,
@@ -440,7 +440,7 @@ pub fn do_test(data: &[u8]) {
 						channel_features: ChannelFeatures::empty(),
 						fee_msat: 5000000,
 						cltv_expiry_delta: 200,
-					}],
+					}]],
 				}, PaymentHash(payment_hash.into_inner()), &None) {
 					// Probably ran out of funds
 					test_return!();

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -27,7 +27,7 @@ use lightning::chain::chaininterface::{BroadcasterInterface,ConfirmationTarget,C
 use lightning::chain::keysinterface::{KeysInterface, InMemoryChannelKeys};
 use lightning::ln::channelmonitor;
 use lightning::ln::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr, HTLCUpdate};
-use lightning::ln::channelmanager::{ChannelManager, PaymentHash, PaymentPreimage, ChannelManagerReadArgs};
+use lightning::ln::channelmanager::{ChannelManager, PaymentHash, PaymentPreimage, PaymentSecret, ChannelManagerReadArgs};
 use lightning::ln::router::{Route, RouteHop};
 use lightning::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, ErrorAction, UpdateAddHTLC, Init};
@@ -447,6 +447,48 @@ pub fn do_test(data: &[u8]) {
 				}
 			} }
 		}
+		macro_rules! send_payment_with_secret {
+			($source: expr, $middle: expr, $dest: expr) => { {
+				let payment_hash = Sha256::hash(&[payment_id; 1]);
+				payment_id = payment_id.wrapping_add(1);
+				let payment_secret = Sha256::hash(&[payment_id; 1]);
+				payment_id = payment_id.wrapping_add(1);
+				if let Err(_) = $source.send_payment(Route {
+					paths: vec![vec![RouteHop {
+						pubkey: $middle.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
+						short_channel_id: $middle.1,
+						channel_features: ChannelFeatures::empty(),
+						fee_msat: 50000,
+						cltv_expiry_delta: 100,
+					},RouteHop {
+						pubkey: $dest.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
+						short_channel_id: $dest.1,
+						channel_features: ChannelFeatures::empty(),
+						fee_msat: 5000000,
+						cltv_expiry_delta: 200,
+					}],vec![RouteHop {
+						pubkey: $middle.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
+						short_channel_id: $middle.1,
+						channel_features: ChannelFeatures::empty(),
+						fee_msat: 50000,
+						cltv_expiry_delta: 100,
+					},RouteHop {
+						pubkey: $dest.0.get_our_node_id(),
+						node_features: NodeFeatures::empty(),
+						short_channel_id: $dest.1,
+						channel_features: ChannelFeatures::empty(),
+						fee_msat: 5000000,
+						cltv_expiry_delta: 200,
+					}]],
+				}, PaymentHash(payment_hash.into_inner()), &Some(PaymentSecret(payment_secret.into_inner()))) {
+					// Probably ran out of funds
+					test_return!();
+				}
+			} }
+		}
 
 		macro_rules! process_msg_events {
 			($node: expr, $corrupt_forward: expr) => { {
@@ -599,12 +641,12 @@ pub fn do_test(data: &[u8]) {
 				});
 				for event in events.drain(..) {
 					match event {
-						events::Event::PaymentReceived { payment_hash, .. } => {
+						events::Event::PaymentReceived { payment_hash, payment_secret, .. } => {
 							if claim_set.insert(payment_hash.0) {
 								if $fail {
-									assert!(nodes[$node].fail_htlc_backwards(&payment_hash, &None));
+									assert!(nodes[$node].fail_htlc_backwards(&payment_hash, &payment_secret));
 								} else {
-									assert!(nodes[$node].claim_funds(PaymentPreimage(payment_hash.0), &None, 5_000_000));
+									assert!(nodes[$node].claim_funds(PaymentPreimage(payment_hash.0), &payment_secret, 5_000_000));
 								}
 							}
 						},
@@ -734,6 +776,8 @@ pub fn do_test(data: &[u8]) {
 				nodes[2] = node_c.clone();
 				monitor_c = new_monitor_c;
 			},
+			0x22 => send_payment_with_secret!(nodes[0], (&nodes[1], chan_a), (&nodes[2], chan_b)),
+			0x23 => send_payment_with_secret!(nodes[2], (&nodes[1], chan_b), (&nodes[0], chan_a)),
 			// 0x24 defined above
 			_ => test_return!(),
 		}

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -401,7 +401,7 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 				sha.input(&payment_hash.0[..]);
 				payment_hash.0 = Sha256::from_engine(sha).into_inner();
 				payments_sent += 1;
-				match channelmanager.send_payment(route, payment_hash, &None) {
+				match channelmanager.send_payment(&route, payment_hash, &None) {
 					Ok(_) => {},
 					Err(_) => return,
 				}

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -30,7 +30,7 @@ fn test_simple_monitor_permanent_update_fail() {
 	let (_, payment_hash_1) = get_payment_preimage_hash!(&nodes[0]);
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::PermanentFailure);
-	unwrap_send_err!(nodes[0].node.send_payment(route, payment_hash_1, &None), true, APIError::ChannelUnavailable {..}, {});
+	unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_1, &None), true, APIError::ChannelUnavailable {..}, {});
 	check_added_monitors!(nodes[0], 2);
 
 	let events_1 = nodes[0].node.get_and_clear_pending_msg_events();
@@ -64,7 +64,7 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
 
-	unwrap_send_err!(nodes[0].node.send_payment(route.clone(), payment_hash_1, &None), false, APIError::MonitorUpdateFailed, {});
+	unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_1, &None), false, APIError::MonitorUpdateFailed, {});
 	check_added_monitors!(nodes[0], 1);
 
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
@@ -107,7 +107,7 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	// Now set it to failed again...
 	let (_, payment_hash_2) = get_payment_preimage_hash!(&nodes[0]);
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	unwrap_send_err!(nodes[0].node.send_payment(route, payment_hash_2, &None), false, APIError::MonitorUpdateFailed, {});
+	unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_2, &None), false, APIError::MonitorUpdateFailed, {});
 	check_added_monitors!(nodes[0], 1);
 
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
@@ -170,7 +170,7 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	unwrap_send_err!(nodes[0].node.send_payment(route.clone(), payment_hash_2, &None), false, APIError::MonitorUpdateFailed, {});
+	unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_2, &None), false, APIError::MonitorUpdateFailed, {});
 	check_added_monitors!(nodes[0], 1);
 
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
@@ -497,7 +497,7 @@ fn test_monitor_update_fail_cs() {
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, our_payment_hash, &None).unwrap();
+	nodes[0].node.send_payment(&route, our_payment_hash, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let send_event = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
@@ -582,7 +582,7 @@ fn test_monitor_update_fail_no_rebroadcast() {
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, our_payment_hash, &None).unwrap();
+	nodes[0].node.send_payment(&route, our_payment_hash, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let send_event = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
@@ -630,13 +630,13 @@ fn test_monitor_update_raa_while_paused() {
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, our_payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, our_payment_hash_1, &None).unwrap();
+	nodes[0].node.send_payment(&route, our_payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let send_event_1 = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
 
 	let route = nodes[1].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, our_payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[1].node.send_payment(route, our_payment_hash_2, &None).unwrap();
+	nodes[1].node.send_payment(&route, our_payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[1], 1);
 	let send_event_2 = SendEvent::from_event(nodes[1].node.get_and_clear_pending_msg_events().remove(0));
 
@@ -724,7 +724,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	// holding cell.
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
-	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let mut send_event = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
@@ -749,7 +749,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 
 	let (_, payment_hash_3) = get_payment_preimage_hash!(nodes[0]);
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
-	nodes[0].node.send_payment(route, payment_hash_3, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_3, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Ok(()); // We succeed in updating the monitor for the first channel
@@ -796,7 +796,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 		// Try to route another payment backwards from 2 to make sure 1 holds off on responding
 		let (payment_preimage_4, payment_hash_4) = get_payment_preimage_hash!(nodes[0]);
 		let route = nodes[2].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
-		nodes[2].node.send_payment(route, payment_hash_4, &None).unwrap();
+		nodes[2].node.send_payment(&route, payment_hash_4, &None).unwrap();
 		check_added_monitors!(nodes[2], 1);
 
 		send_event = SendEvent::from_event(nodes[2].node.get_and_clear_pending_msg_events().remove(0));
@@ -1047,9 +1047,9 @@ fn raa_no_response_awaiting_raa_state() {
 	// immediately after a CS. By setting failing the monitor update failure from the CS (which
 	// requires only an RAA response due to AwaitingRAA) we can deliver the RAA and require the CS
 	// generation during RAA while in monitor-update-failed state.
-	nodes[0].node.send_payment(route.clone(), payment_hash_1, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
-	nodes[0].node.send_payment(route.clone(), payment_hash_2, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 0);
 
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
@@ -1097,7 +1097,7 @@ fn raa_no_response_awaiting_raa_state() {
 	// We send a third payment here, which is somewhat of a redundant test, but the
 	// chanmon_fail_consistency test required it to actually find the bug (by seeing out-of-sync
 	// commitment transaction states) whereas here we can explicitly check for it.
-	nodes[0].node.send_payment(route.clone(), payment_hash_3, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_3, &None).unwrap();
 	check_added_monitors!(nodes[0], 0);
 	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
 
@@ -1186,7 +1186,7 @@ fn claim_while_disconnected_monitor_update_fail() {
 	// the monitor still failed
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let as_updates = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
@@ -1278,7 +1278,7 @@ fn monitor_failed_no_reestablish_response() {
 	// on receipt).
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_1, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
@@ -1348,7 +1348,7 @@ fn first_message_on_recv_ordering() {
 	// can deliver it and fail the monitor update.
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_1, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
@@ -1370,7 +1370,7 @@ fn first_message_on_recv_ordering() {
 	// Route the second payment, generating an update_add_htlc/commitment_signed
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 1);
@@ -1446,7 +1446,7 @@ fn test_monitor_update_fail_claim() {
 
 	let route = nodes[2].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[2].node.send_payment(route, payment_hash_2, &None).unwrap();
+	nodes[2].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[2], 1);
 
 	// Successfully update the monitor on the 1<->2 channel, but the 0<->1 channel should still be
@@ -1527,7 +1527,7 @@ fn test_monitor_update_on_pending_forwards() {
 
 	let route = nodes[2].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[2].node.send_payment(route, payment_hash_2, &None).unwrap();
+	nodes[2].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[2], 1);
 
 	let mut events = nodes[2].node.get_and_clear_pending_msg_events();
@@ -1586,7 +1586,7 @@ fn monitor_update_claim_fail_no_response() {
 	// Now start forwarding a second payment, skipping the last RAA so B is in AwaitingRAA
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
+	nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -30,7 +30,7 @@ fn test_simple_monitor_permanent_update_fail() {
 	let (_, payment_hash_1) = get_payment_preimage_hash!(&nodes[0]);
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::PermanentFailure);
-	if let Err(APIError::ChannelUnavailable {..}) = nodes[0].node.send_payment(route, payment_hash_1) {} else { panic!(); }
+	if let Err(APIError::ChannelUnavailable {..}) = nodes[0].node.send_payment(route, payment_hash_1, &None) {} else { panic!(); }
 	check_added_monitors!(nodes[0], 2);
 
 	let events_1 = nodes[0].node.get_and_clear_pending_msg_events();
@@ -63,7 +63,7 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(&nodes[0]);
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	if let Err(APIError::MonitorUpdateFailed) = nodes[0].node.send_payment(route.clone(), payment_hash_1) {} else { panic!(); }
+	if let Err(APIError::MonitorUpdateFailed) = nodes[0].node.send_payment(route.clone(), payment_hash_1, &None) {} else { panic!(); }
 	check_added_monitors!(nodes[0], 1);
 
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
@@ -93,8 +93,9 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	let events_3 = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events_3.len(), 1);
 	match events_3[0] {
-		Event::PaymentReceived { ref payment_hash, amt } => {
+		Event::PaymentReceived { ref payment_hash, ref payment_secret, amt } => {
 			assert_eq!(payment_hash_1, *payment_hash);
+			assert_eq!(*payment_secret, None);
 			assert_eq!(amt, 1000000);
 		},
 		_ => panic!("Unexpected event"),
@@ -105,7 +106,7 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	// Now set it to failed again...
 	let (_, payment_hash_2) = get_payment_preimage_hash!(&nodes[0]);
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	if let Err(APIError::MonitorUpdateFailed) = nodes[0].node.send_payment(route, payment_hash_2) {} else { panic!(); }
+	if let Err(APIError::MonitorUpdateFailed) = nodes[0].node.send_payment(route, payment_hash_2, &None) {} else { panic!(); }
 	check_added_monitors!(nodes[0], 1);
 
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
@@ -168,7 +169,7 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	if let Err(APIError::MonitorUpdateFailed) = nodes[0].node.send_payment(route.clone(), payment_hash_2) {} else { panic!(); }
+	if let Err(APIError::MonitorUpdateFailed) = nodes[0].node.send_payment(route.clone(), payment_hash_2, &None) {} else { panic!(); }
 	check_added_monitors!(nodes[0], 1);
 
 	assert!(nodes[0].node.get_and_clear_pending_events().is_empty());
@@ -177,7 +178,7 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 
 	// Claim the previous payment, which will result in a update_fulfill_htlc/CS from nodes[1]
 	// but nodes[0] won't respond since it is frozen.
-	assert!(nodes[1].node.claim_funds(payment_preimage_1, 1_000_000));
+	assert!(nodes[1].node.claim_funds(payment_preimage_1, &None, 1_000_000));
 	check_added_monitors!(nodes[1], 1);
 	let events_2 = nodes[1].node.get_and_clear_pending_msg_events();
 	assert_eq!(events_2.len(), 1);
@@ -446,8 +447,9 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	let events_5 = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events_5.len(), 1);
 	match events_5[0] {
-		Event::PaymentReceived { ref payment_hash, amt } => {
+		Event::PaymentReceived { ref payment_hash, ref payment_secret, amt } => {
 			assert_eq!(payment_hash_2, *payment_hash);
+			assert_eq!(*payment_secret, None);
 			assert_eq!(amt, 1000000);
 		},
 		_ => panic!("Unexpected event"),
@@ -494,7 +496,7 @@ fn test_monitor_update_fail_cs() {
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
+	nodes[0].node.send_payment(route, our_payment_hash, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let send_event = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
@@ -555,8 +557,9 @@ fn test_monitor_update_fail_cs() {
 	let events = nodes[1].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 1);
 	match events[0] {
-		Event::PaymentReceived { payment_hash, amt } => {
+		Event::PaymentReceived { payment_hash, payment_secret, amt } => {
 			assert_eq!(payment_hash, our_payment_hash);
+			assert_eq!(payment_secret, None);
 			assert_eq!(amt, 1000000);
 		},
 		_ => panic!("Unexpected event"),
@@ -578,7 +581,7 @@ fn test_monitor_update_fail_no_rebroadcast() {
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
+	nodes[0].node.send_payment(route, our_payment_hash, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let send_event = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
@@ -626,13 +629,13 @@ fn test_monitor_update_raa_while_paused() {
 
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, our_payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, our_payment_hash_1).unwrap();
+	nodes[0].node.send_payment(route, our_payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let send_event_1 = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
 
 	let route = nodes[1].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, our_payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[1].node.send_payment(route, our_payment_hash_2).unwrap();
+	nodes[1].node.send_payment(route, our_payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[1], 1);
 	let send_event_2 = SendEvent::from_event(nodes[1].node.get_and_clear_pending_msg_events().remove(0));
 
@@ -701,7 +704,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	let (_, payment_hash_1) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 1000000);
 
 	// Fail the payment backwards, failing the monitor update on nodes[1]'s receipt of the RAA
-	assert!(nodes[2].node.fail_htlc_backwards(&payment_hash_1));
+	assert!(nodes[2].node.fail_htlc_backwards(&payment_hash_1, &None));
 	expect_pending_htlcs_forwardable!(nodes[2]);
 	check_added_monitors!(nodes[2], 1);
 
@@ -720,7 +723,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	// holding cell.
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
-	nodes[0].node.send_payment(route, payment_hash_2).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let mut send_event = SendEvent::from_event(nodes[0].node.get_and_clear_pending_msg_events().remove(0));
@@ -745,7 +748,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 
 	let (_, payment_hash_3) = get_payment_preimage_hash!(nodes[0]);
 	let route = nodes[0].router.get_route(&nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
-	nodes[0].node.send_payment(route, payment_hash_3).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_3, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Ok(()); // We succeed in updating the monitor for the first channel
@@ -792,7 +795,7 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 		// Try to route another payment backwards from 2 to make sure 1 holds off on responding
 		let (payment_preimage_4, payment_hash_4) = get_payment_preimage_hash!(nodes[0]);
 		let route = nodes[2].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
-		nodes[2].node.send_payment(route, payment_hash_4).unwrap();
+		nodes[2].node.send_payment(route, payment_hash_4, &None).unwrap();
 		check_added_monitors!(nodes[2], 1);
 
 		send_event = SendEvent::from_event(nodes[2].node.get_and_clear_pending_msg_events().remove(0));
@@ -957,7 +960,7 @@ fn test_monitor_update_fail_reestablish() {
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 
-	assert!(nodes[2].node.claim_funds(our_payment_preimage, 1_000_000));
+	assert!(nodes[2].node.claim_funds(our_payment_preimage, &None, 1_000_000));
 	check_added_monitors!(nodes[2], 1);
 	let mut updates = get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
 	assert!(updates.update_add_htlcs.is_empty());
@@ -1043,9 +1046,9 @@ fn raa_no_response_awaiting_raa_state() {
 	// immediately after a CS. By setting failing the monitor update failure from the CS (which
 	// requires only an RAA response due to AwaitingRAA) we can deliver the RAA and require the CS
 	// generation during RAA while in monitor-update-failed state.
-	nodes[0].node.send_payment(route.clone(), payment_hash_1).unwrap();
+	nodes[0].node.send_payment(route.clone(), payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
-	nodes[0].node.send_payment(route.clone(), payment_hash_2).unwrap();
+	nodes[0].node.send_payment(route.clone(), payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 0);
 
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
@@ -1093,7 +1096,7 @@ fn raa_no_response_awaiting_raa_state() {
 	// We send a third payment here, which is somewhat of a redundant test, but the
 	// chanmon_fail_consistency test required it to actually find the bug (by seeing out-of-sync
 	// commitment transaction states) whereas here we can explicitly check for it.
-	nodes[0].node.send_payment(route.clone(), payment_hash_3).unwrap();
+	nodes[0].node.send_payment(route.clone(), payment_hash_3, &None).unwrap();
 	check_added_monitors!(nodes[0], 0);
 	assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
 
@@ -1156,7 +1159,7 @@ fn claim_while_disconnected_monitor_update_fail() {
 	nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
 	nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
 
-	assert!(nodes[1].node.claim_funds(payment_preimage_1, 1_000_000));
+	assert!(nodes[1].node.claim_funds(payment_preimage_1, &None, 1_000_000));
 	check_added_monitors!(nodes[1], 1);
 
 	nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
@@ -1182,7 +1185,7 @@ fn claim_while_disconnected_monitor_update_fail() {
 	// the monitor still failed
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_2).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let as_updates = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
@@ -1274,7 +1277,7 @@ fn monitor_failed_no_reestablish_response() {
 	// on receipt).
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_1).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
@@ -1344,7 +1347,7 @@ fn first_message_on_recv_ordering() {
 	// can deliver it and fail the monitor update.
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_1).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_1, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
@@ -1366,7 +1369,7 @@ fn first_message_on_recv_ordering() {
 	// Route the second payment, generating an update_add_htlc/commitment_signed
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_2).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 1);
@@ -1437,12 +1440,12 @@ fn test_monitor_update_fail_claim() {
 	let (payment_preimage_1, _) = route_payment(&nodes[0], &[&nodes[1]], 1000000);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	assert!(nodes[1].node.claim_funds(payment_preimage_1, 1_000_000));
+	assert!(nodes[1].node.claim_funds(payment_preimage_1, &None, 1_000_000));
 	check_added_monitors!(nodes[1], 1);
 
 	let route = nodes[2].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (_, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[2].node.send_payment(route, payment_hash_2).unwrap();
+	nodes[2].node.send_payment(route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[2], 1);
 
 	// Successfully update the monitor on the 1<->2 channel, but the 0<->1 channel should still be
@@ -1512,7 +1515,7 @@ fn test_monitor_update_on_pending_forwards() {
 	send_payment(&nodes[0], &[&nodes[1], &nodes[2]], 5000000, 5_000_000);
 
 	let (_, payment_hash_1) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 1000000);
-	assert!(nodes[2].node.fail_htlc_backwards(&payment_hash_1));
+	assert!(nodes[2].node.fail_htlc_backwards(&payment_hash_1, &None));
 	expect_pending_htlcs_forwardable!(nodes[2]);
 	check_added_monitors!(nodes[2], 1);
 
@@ -1523,7 +1526,7 @@ fn test_monitor_update_on_pending_forwards() {
 
 	let route = nodes[2].router.get_route(&nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[2].node.send_payment(route, payment_hash_2).unwrap();
+	nodes[2].node.send_payment(route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[2], 1);
 
 	let mut events = nodes[2].node.get_and_clear_pending_msg_events();
@@ -1582,7 +1585,7 @@ fn monitor_update_claim_fail_no_response() {
 	// Now start forwarding a second payment, skipping the last RAA so B is in AwaitingRAA
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV).unwrap();
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
-	nodes[0].node.send_payment(route, payment_hash_2).unwrap();
+	nodes[0].node.send_payment(route, payment_hash_2, &None).unwrap();
 	check_added_monitors!(nodes[0], 1);
 
 	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
@@ -1592,7 +1595,7 @@ fn monitor_update_claim_fail_no_response() {
 	let as_raa = commitment_signed_dance!(nodes[1], nodes[0], payment_event.commitment_msg, false, true, false, true);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
-	assert!(nodes[1].node.claim_funds(payment_preimage_1, 1_000_000));
+	assert!(nodes[1].node.claim_funds(payment_preimage_1, &None, 1_000_000));
 	check_added_monitors!(nodes[1], 1);
 	let events = nodes[1].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 0);

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -1458,7 +1458,7 @@ fn test_monitor_update_fail_claim() {
 	nodes[1].node.handle_update_add_htlc(&nodes[2].node.get_our_node_id(), &payment_event.msgs[0]);
 	let events = nodes[1].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 0);
-	nodes[1].logger.assert_log("lightning::ln::channelmanager".to_string(), "Failed to update ChannelMonitor".to_string(), 1);
+	nodes[1].logger.assert_log("lightning::ln::channelmanager".to_string(), "Temporary failure claiming HTLC, treating as success: Failed to update ChannelMonitor".to_string(), 1);
 	commitment_signed_dance!(nodes[1], nodes[2], payment_event.commitment_msg, false, true);
 
 	let bs_fail_update = get_htlc_update_msgs!(nodes[1], nodes[2].node.get_our_node_id());
@@ -1599,7 +1599,7 @@ fn monitor_update_claim_fail_no_response() {
 	check_added_monitors!(nodes[1], 1);
 	let events = nodes[1].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 0);
-	nodes[1].logger.assert_log("lightning::ln::channelmanager".to_string(), "Failed to update ChannelMonitor".to_string(), 1);
+	nodes[1].logger.assert_log("lightning::ln::channelmanager".to_string(), "Temporary failure claiming HTLC, treating as success: Failed to update ChannelMonitor".to_string(), 1);
 
 	*nodes[1].chan_monitor.update_ret.lock().unwrap() = Ok(());
 	let (outpoint, latest_update) = nodes[1].chan_monitor.latest_monitor_update_id.lock().unwrap().get(&channel_id).unwrap().clone();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1261,7 +1261,7 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> ChannelMan
 	/// If a payment_secret *is* provided, we assume that the invoice had the payment_secret feature
 	/// bit set (either as required or as available). If multiple paths are present in the Route,
 	/// we assume the invoice had the basic_mpp feature set.
-	pub fn send_payment(&self, route: Route, payment_hash: PaymentHash, payment_secret: &Option<PaymentSecret>) -> Result<(), PaymentSendFailure> {
+	pub fn send_payment(&self, route: &Route, payment_hash: PaymentHash, payment_secret: &Option<PaymentSecret>) -> Result<(), PaymentSendFailure> {
 		if route.paths.len() < 1 {
 			return Err(PaymentSendFailure::ParameterError(APIError::RouteError{err: "There must be at least one path to send over"}));
 		}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -897,8 +897,9 @@ pub const TEST_FINAL_CLTV: u32 = 32;
 
 pub fn route_payment<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64) -> (PaymentPreimage, PaymentHash) {
 	let route = origin_node.router.get_route(&expected_route.last().unwrap().node.get_our_node_id(), None, &Vec::new(), recv_value, TEST_FINAL_CLTV).unwrap();
-	assert_eq!(route.hops.len(), expected_route.len());
-	for (node, hop) in expected_route.iter().zip(route.hops.iter()) {
+	assert_eq!(route.paths.len(), 1);
+	assert_eq!(route.paths[0].len(), expected_route.len());
+	for (node, hop) in expected_route.iter().zip(route.paths[0].iter()) {
 		assert_eq!(hop.pubkey, node.node.get_our_node_id());
 	}
 
@@ -907,8 +908,9 @@ pub fn route_payment<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route:
 
 pub fn route_over_limit<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64)  {
 	let route = origin_node.router.get_route(&expected_route.last().unwrap().node.get_our_node_id(), None, &Vec::new(), recv_value, TEST_FINAL_CLTV).unwrap();
-	assert_eq!(route.hops.len(), expected_route.len());
-	for (node, hop) in expected_route.iter().zip(route.hops.iter()) {
+	assert_eq!(route.paths.len(), 1);
+	assert_eq!(route.paths[0].len(), expected_route.len());
+	for (node, hop) in expected_route.iter().zip(route.paths[0].iter()) {
 		assert_eq!(hop.pubkey, node.node.get_our_node_id());
 	}
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -776,51 +776,57 @@ macro_rules! expect_payment_failed {
 	}
 }
 
-pub fn send_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: Option<PaymentSecret>) {
-	let mut payment_event = {
-		origin_node.node.send_payment(route, our_payment_hash, &our_payment_secret).unwrap();
-		check_added_monitors!(origin_node, 1);
+pub fn send_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_paths: &[&[&Node<'a, 'b, 'c>]], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: Option<PaymentSecret>) {
+	origin_node.node.send_payment(route, our_payment_hash, &our_payment_secret).unwrap();
+	check_added_monitors!(origin_node, expected_paths.len());
 
-		let mut events = origin_node.node.get_and_clear_pending_msg_events();
-		assert_eq!(events.len(), 1);
-		SendEvent::from_event(events.remove(0))
-	};
-	let mut prev_node = origin_node;
+	let mut events = origin_node.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), expected_paths.len());
+	for (path_idx, (ev, expected_route)) in events.drain(..).zip(expected_paths.iter()).enumerate() {
+		let mut payment_event = SendEvent::from_event(ev);
+		let mut prev_node = origin_node;
 
-	for (idx, &node) in expected_route.iter().enumerate() {
-		assert_eq!(node.node.get_our_node_id(), payment_event.node_id);
+		for (idx, &node) in expected_route.iter().enumerate() {
+			assert_eq!(node.node.get_our_node_id(), payment_event.node_id);
 
-		node.node.handle_update_add_htlc(&prev_node.node.get_our_node_id(), &payment_event.msgs[0]);
-		check_added_monitors!(node, 0);
-		commitment_signed_dance!(node, prev_node, payment_event.commitment_msg, false);
+			node.node.handle_update_add_htlc(&prev_node.node.get_our_node_id(), &payment_event.msgs[0]);
+			check_added_monitors!(node, 0);
+			commitment_signed_dance!(node, prev_node, payment_event.commitment_msg, false);
 
-		expect_pending_htlcs_forwardable!(node);
+			expect_pending_htlcs_forwardable!(node);
 
-		if idx == expected_route.len() - 1 {
-			let events_2 = node.node.get_and_clear_pending_events();
-			assert_eq!(events_2.len(), 1);
-			match events_2[0] {
-				Event::PaymentReceived { ref payment_hash, ref payment_secret, amt } => {
-					assert_eq!(our_payment_hash, *payment_hash);
-					assert_eq!(our_payment_secret, *payment_secret);
-					assert_eq!(amt, recv_value);
-				},
-				_ => panic!("Unexpected event"),
+			if idx == expected_route.len() - 1 {
+				let events_2 = node.node.get_and_clear_pending_events();
+				// Once we've gotten through all the HTLCs, the last one should result in a
+				// PaymentReceived (but each previous one should not!).
+				if path_idx == expected_paths.len() - 1 {
+					assert_eq!(events_2.len(), 1);
+					match events_2[0] {
+						Event::PaymentReceived { ref payment_hash, ref payment_secret, amt } => {
+							assert_eq!(our_payment_hash, *payment_hash);
+							assert_eq!(our_payment_secret, *payment_secret);
+							assert_eq!(amt, recv_value);
+						},
+						_ => panic!("Unexpected event"),
+					}
+				} else {
+					assert!(events_2.is_empty());
+				}
+			} else {
+				let mut events_2 = node.node.get_and_clear_pending_msg_events();
+				assert_eq!(events_2.len(), 1);
+				check_added_monitors!(node, 1);
+				payment_event = SendEvent::from_event(events_2.remove(0));
+				assert_eq!(payment_event.msgs.len(), 1);
 			}
-		} else {
-			let mut events_2 = node.node.get_and_clear_pending_msg_events();
-			assert_eq!(events_2.len(), 1);
-			check_added_monitors!(node, 1);
-			payment_event = SendEvent::from_event(events_2.remove(0));
-			assert_eq!(payment_event.msgs.len(), 1);
-		}
 
-		prev_node = node;
+			prev_node = node;
+		}
 	}
 }
 
 pub fn send_along_route_with_hash<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64, our_payment_hash: PaymentHash) {
-	send_along_route_with_secret(origin_node, route, expected_route, recv_value, our_payment_hash, None);
+	send_along_route_with_secret(origin_node, route, &[expected_route], recv_value, our_payment_hash, None);
 }
 
 pub fn send_along_route<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64) -> (PaymentPreimage, PaymentHash) {
@@ -829,86 +835,96 @@ pub fn send_along_route<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route
 	(our_payment_preimage, our_payment_hash)
 }
 
-pub fn claim_payment_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], skip_last: bool, our_payment_preimage: PaymentPreimage, our_payment_secret: Option<PaymentSecret>, expected_amount: u64) {
-	assert!(expected_route.last().unwrap().node.claim_funds(our_payment_preimage, &our_payment_secret, expected_amount));
-	check_added_monitors!(expected_route.last().unwrap(), 1);
+pub fn claim_payment_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_paths: &[&[&Node<'a, 'b, 'c>]], skip_last: bool, our_payment_preimage: PaymentPreimage, our_payment_secret: Option<PaymentSecret>, expected_amount: u64) {
+	for path in expected_paths.iter() {
+		assert_eq!(path.last().unwrap().node.get_our_node_id(), expected_paths[0].last().unwrap().node.get_our_node_id());
+	}
+	assert!(expected_paths[0].last().unwrap().node.claim_funds(our_payment_preimage, &our_payment_secret, expected_amount));
+	check_added_monitors!(expected_paths[0].last().unwrap(), expected_paths.len());
 
-	let mut next_msgs: Option<(msgs::UpdateFulfillHTLC, msgs::CommitmentSigned)> = None;
-	let mut expected_next_node = expected_route.last().unwrap().node.get_our_node_id();
-	macro_rules! get_next_msgs {
-		($node: expr) => {
-			{
-				let events = $node.node.get_and_clear_pending_msg_events();
-				assert_eq!(events.len(), 1);
-				match events[0] {
-					MessageSendEvent::UpdateHTLCs { ref node_id, updates: msgs::CommitmentUpdate { ref update_add_htlcs, ref update_fulfill_htlcs, ref update_fail_htlcs, ref update_fail_malformed_htlcs, ref update_fee, ref commitment_signed } } => {
-						assert!(update_add_htlcs.is_empty());
-						assert_eq!(update_fulfill_htlcs.len(), 1);
-						assert!(update_fail_htlcs.is_empty());
-						assert!(update_fail_malformed_htlcs.is_empty());
-						assert!(update_fee.is_none());
-						expected_next_node = node_id.clone();
-						Some((update_fulfill_htlcs[0].clone(), commitment_signed.clone()))
-					},
-					_ => panic!("Unexpected event"),
+	macro_rules! msgs_from_ev {
+		($ev: expr) => {
+			match $ev {
+				&MessageSendEvent::UpdateHTLCs { ref node_id, updates: msgs::CommitmentUpdate { ref update_add_htlcs, ref update_fulfill_htlcs, ref update_fail_htlcs, ref update_fail_malformed_htlcs, ref update_fee, ref commitment_signed } } => {
+					assert!(update_add_htlcs.is_empty());
+					assert_eq!(update_fulfill_htlcs.len(), 1);
+					assert!(update_fail_htlcs.is_empty());
+					assert!(update_fail_malformed_htlcs.is_empty());
+					assert!(update_fee.is_none());
+					((update_fulfill_htlcs[0].clone(), commitment_signed.clone()), node_id.clone())
+				},
+				_ => panic!("Unexpected event"),
+			}
+		}
+	}
+	let mut per_path_msgs: Vec<((msgs::UpdateFulfillHTLC, msgs::CommitmentSigned), PublicKey)> = Vec::with_capacity(expected_paths.len());
+	let events = expected_paths[0].last().unwrap().node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), expected_paths.len());
+	for ev in events.iter() {
+		per_path_msgs.push(msgs_from_ev!(ev));
+	}
+
+	for (expected_route, (path_msgs, next_hop)) in expected_paths.iter().zip(per_path_msgs.drain(..)) {
+		let mut next_msgs = Some(path_msgs);
+		let mut expected_next_node = next_hop;
+
+		macro_rules! last_update_fulfill_dance {
+			($node: expr, $prev_node: expr) => {
+				{
+					$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0);
+					check_added_monitors!($node, 0);
+					assert!($node.node.get_and_clear_pending_msg_events().is_empty());
+					commitment_signed_dance!($node, $prev_node, next_msgs.as_ref().unwrap().1, false);
 				}
 			}
 		}
-	}
-
-	macro_rules! last_update_fulfill_dance {
-		($node: expr, $prev_node: expr) => {
-			{
-				$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0);
-				check_added_monitors!($node, 0);
-				assert!($node.node.get_and_clear_pending_msg_events().is_empty());
-				commitment_signed_dance!($node, $prev_node, next_msgs.as_ref().unwrap().1, false);
+		macro_rules! mid_update_fulfill_dance {
+			($node: expr, $prev_node: expr, $new_msgs: expr) => {
+				{
+					$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0);
+					check_added_monitors!($node, 1);
+					let new_next_msgs = if $new_msgs {
+						let events = $node.node.get_and_clear_pending_msg_events();
+						assert_eq!(events.len(), 1);
+						let (res, nexthop) = msgs_from_ev!(&events[0]);
+						expected_next_node = nexthop;
+						Some(res)
+					} else {
+						assert!($node.node.get_and_clear_pending_msg_events().is_empty());
+						None
+					};
+					commitment_signed_dance!($node, $prev_node, next_msgs.as_ref().unwrap().1, false);
+					next_msgs = new_next_msgs;
+				}
 			}
 		}
-	}
-	macro_rules! mid_update_fulfill_dance {
-		($node: expr, $prev_node: expr, $new_msgs: expr) => {
-			{
-				$node.node.handle_update_fulfill_htlc(&$prev_node.node.get_our_node_id(), &next_msgs.as_ref().unwrap().0);
-				check_added_monitors!($node, 1);
-				let new_next_msgs = if $new_msgs {
-					get_next_msgs!($node)
-				} else {
-					assert!($node.node.get_and_clear_pending_msg_events().is_empty());
-					None
-				};
-				commitment_signed_dance!($node, $prev_node, next_msgs.as_ref().unwrap().1, false);
-				next_msgs = new_next_msgs;
+
+		let mut prev_node = expected_route.last().unwrap();
+		for (idx, node) in expected_route.iter().rev().enumerate().skip(1) {
+			assert_eq!(expected_next_node, node.node.get_our_node_id());
+			let update_next_msgs = !skip_last || idx != expected_route.len() - 1;
+			if next_msgs.is_some() {
+				mid_update_fulfill_dance!(node, prev_node, update_next_msgs);
+			} else {
+				assert!(!update_next_msgs);
+				assert!(node.node.get_and_clear_pending_msg_events().is_empty());
 			}
-		}
-	}
+			if !skip_last && idx == expected_route.len() - 1 {
+				assert_eq!(expected_next_node, origin_node.node.get_our_node_id());
+			}
 
-	let mut prev_node = expected_route.last().unwrap();
-	for (idx, node) in expected_route.iter().rev().enumerate() {
-		assert_eq!(expected_next_node, node.node.get_our_node_id());
-		let update_next_msgs = !skip_last || idx != expected_route.len() - 1;
-		if next_msgs.is_some() {
-			mid_update_fulfill_dance!(node, prev_node, update_next_msgs);
-		} else if update_next_msgs {
-			next_msgs = get_next_msgs!(node);
-		} else {
-			assert!(node.node.get_and_clear_pending_msg_events().is_empty());
-		}
-		if !skip_last && idx == expected_route.len() - 1 {
-			assert_eq!(expected_next_node, origin_node.node.get_our_node_id());
+			prev_node = node;
 		}
 
-		prev_node = node;
-	}
-
-	if !skip_last {
-		last_update_fulfill_dance!(origin_node, expected_route.first().unwrap());
-		expect_payment_sent!(origin_node, our_payment_preimage);
+		if !skip_last {
+			last_update_fulfill_dance!(origin_node, expected_route.first().unwrap());
+			expect_payment_sent!(origin_node, our_payment_preimage);
+		}
 	}
 }
 
 pub fn claim_payment_along_route<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], skip_last: bool, our_payment_preimage: PaymentPreimage, expected_amount: u64) {
-	claim_payment_along_route_with_secret(origin_node, expected_route, skip_last, our_payment_preimage, None, expected_amount);
+	claim_payment_along_route_with_secret(origin_node, &[expected_route], skip_last, our_payment_preimage, None, expected_amount);
 }
 
 pub fn claim_payment<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], our_payment_preimage: PaymentPreimage, expected_amount: u64) {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -777,7 +777,7 @@ macro_rules! expect_payment_failed {
 }
 
 pub fn send_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_paths: &[&[&Node<'a, 'b, 'c>]], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: Option<PaymentSecret>) {
-	origin_node.node.send_payment(route, our_payment_hash, &our_payment_secret).unwrap();
+	origin_node.node.send_payment(&route, our_payment_hash, &our_payment_secret).unwrap();
 	check_added_monitors!(origin_node, expected_paths.len());
 
 	let mut events = origin_node.node.get_and_clear_pending_msg_events();
@@ -953,7 +953,7 @@ pub fn route_over_limit<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_rou
 	}
 
 	let (_, our_payment_hash) = get_payment_preimage_hash!(origin_node);
-	unwrap_send_err!(origin_node.node.send_payment(route, our_payment_hash, &None), true, APIError::ChannelUnavailable { err },
+	unwrap_send_err!(origin_node.node.send_payment(&route, our_payment_hash, &None), true, APIError::ChannelUnavailable { err },
 		assert_eq!(err, "Cannot send value that would put us over the max HTLC value in flight our peer will accept"));
 }
 

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -123,7 +123,9 @@ pub(super) fn build_onion_payloads(route: &Route, starting_htlc_offset: u32) -> 
 		res.insert(0, msgs::OnionHopData {
 			format: if hop.node_features.supports_variable_length_onion() {
 				if idx == 0 {
-					msgs::OnionHopDataFormat::FinalNode
+					msgs::OnionHopDataFormat::FinalNode {
+						payment_data: None,
+					}
 				} else {
 					msgs::OnionHopDataFormat::NonFinalNode {
 						short_channel_id: last_short_channel_id,

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1,6 +1,6 @@
 use ln::channelmanager::{PaymentHash, PaymentSecret, HTLCSource};
 use ln::msgs;
-use ln::router::{Route,RouteHop};
+use ln::router::RouteHop;
 use util::byte_utils;
 use util::chacha20::ChaCha20;
 use util::errors::{self, APIError};
@@ -63,11 +63,11 @@ pub(super) fn gen_ammag_from_shared_secret(shared_secret: &[u8]) -> [u8; 32] {
 
 // can only fail if an intermediary hop has an invalid public key or session_priv is invalid
 #[inline]
-pub(super) fn construct_onion_keys_callback<T: secp256k1::Signing, FType: FnMut(SharedSecret, [u8; 32], PublicKey, &RouteHop)> (secp_ctx: &Secp256k1<T>, route: &Route, session_priv: &SecretKey, mut callback: FType) -> Result<(), secp256k1::Error> {
+pub(super) fn construct_onion_keys_callback<T: secp256k1::Signing, FType: FnMut(SharedSecret, [u8; 32], PublicKey, &RouteHop)> (secp_ctx: &Secp256k1<T>, path: &Vec<RouteHop>, session_priv: &SecretKey, mut callback: FType) -> Result<(), secp256k1::Error> {
 	let mut blinded_priv = session_priv.clone();
 	let mut blinded_pub = PublicKey::from_secret_key(secp_ctx, &blinded_priv);
 
-	for hop in route.hops.iter() {
+	for hop in path.iter() {
 		let shared_secret = SharedSecret::new(&hop.pubkey, &blinded_priv);
 
 		let mut sha = Sha256::engine();
@@ -87,10 +87,10 @@ pub(super) fn construct_onion_keys_callback<T: secp256k1::Signing, FType: FnMut(
 }
 
 // can only fail if an intermediary hop has an invalid public key or session_priv is invalid
-pub(super) fn construct_onion_keys<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T>, route: &Route, session_priv: &SecretKey) -> Result<Vec<OnionKeys>, secp256k1::Error> {
-	let mut res = Vec::with_capacity(route.hops.len());
+pub(super) fn construct_onion_keys<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T>, path: &Vec<RouteHop>, session_priv: &SecretKey) -> Result<Vec<OnionKeys>, secp256k1::Error> {
+	let mut res = Vec::with_capacity(path.len());
 
-	construct_onion_keys_callback(secp_ctx, route, session_priv, |shared_secret, _blinding_factor, ephemeral_pubkey, _| {
+	construct_onion_keys_callback(secp_ctx, path, session_priv, |shared_secret, _blinding_factor, ephemeral_pubkey, _| {
 		let (rho, mu) = gen_rho_mu_from_shared_secret(&shared_secret[..]);
 
 		res.push(OnionKeys {
@@ -108,13 +108,13 @@ pub(super) fn construct_onion_keys<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T
 }
 
 /// returns the hop data, as well as the first-hop value_msat and CLTV value we should send.
-pub(super) fn build_onion_payloads(route: &Route, payment_secret_option: &Option<PaymentSecret>, starting_htlc_offset: u32) -> Result<(Vec<msgs::OnionHopData>, u64, u32), APIError> {
+pub(super) fn build_onion_payloads(path: &Vec<RouteHop>, payment_secret_option: &Option<PaymentSecret>, starting_htlc_offset: u32) -> Result<(Vec<msgs::OnionHopData>, u64, u32), APIError> {
 	let mut cur_value_msat = 0u64;
 	let mut cur_cltv = starting_htlc_offset;
 	let mut last_short_channel_id = 0;
-	let mut res: Vec<msgs::OnionHopData> = Vec::with_capacity(route.hops.len());
+	let mut res: Vec<msgs::OnionHopData> = Vec::with_capacity(path.len());
 
-	for (idx, hop) in route.hops.iter().rev().enumerate() {
+	for (idx, hop) in path.iter().rev().enumerate() {
 		// First hop gets special values so that it can check, on receipt, that everything is
 		// exactly as it should be (and the next hop isn't trying to probe to find out if we're
 		// the intended recipient).
@@ -318,7 +318,7 @@ pub(super) fn build_first_hop_failure_packet(shared_secret: &[u8], failure_type:
 /// OutboundRoute).
 /// Returns update, a boolean indicating that the payment itself failed, and the error code.
 pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T>, logger: &Arc<Logger>, htlc_source: &HTLCSource, mut packet_decrypted: Vec<u8>) -> (Option<msgs::HTLCFailChannelUpdate>, bool, Option<u16>) {
-	if let &HTLCSource::OutboundRoute { ref route, ref session_priv, ref first_hop_htlc_msat } = htlc_source {
+	if let &HTLCSource::OutboundRoute { ref path, ref session_priv, ref first_hop_htlc_msat } = htlc_source {
 		let mut res = None;
 		let mut htlc_msat = *first_hop_htlc_msat;
 		let mut error_code_ret = None;
@@ -326,7 +326,7 @@ pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<
 		let mut is_from_final_node = false;
 
 		// Handle packed channel/node updates for passing back for the route handler
-		construct_onion_keys_callback(secp_ctx, route, session_priv, |shared_secret, _, _, route_hop| {
+		construct_onion_keys_callback(secp_ctx, path, session_priv, |shared_secret, _, _, route_hop| {
 			next_route_hop_ix += 1;
 			if res.is_some() { return; }
 
@@ -341,7 +341,7 @@ pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<
 			chacha.process(&packet_decrypted, &mut decryption_tmp[..]);
 			packet_decrypted = decryption_tmp;
 
-			is_from_final_node = route.hops.last().unwrap().pubkey == route_hop.pubkey;
+			is_from_final_node = path.last().unwrap().pubkey == route_hop.pubkey;
 
 			if let Ok(err_packet) = msgs::DecodedOnionErrorPacket::read(&mut Cursor::new(&packet_decrypted)) {
 				let um = gen_um_from_shared_secret(&shared_secret[..]);
@@ -374,7 +374,7 @@ pub(super) fn process_onion_failure<T: secp256k1::Signing>(secp_ctx: &Secp256k1<
 						}
 						else if error_code & PERM == PERM {
 							fail_channel_update = if payment_failed {None} else {Some(msgs::HTLCFailChannelUpdate::ChannelClosed {
-								short_channel_id: route.hops[next_route_hop_ix - if next_route_hop_ix == route.hops.len() { 1 } else { 0 }].short_channel_id,
+								short_channel_id: path[next_route_hop_ix - if next_route_hop_ix == path.len() { 1 } else { 0 }].short_channel_id,
 								is_permanent: true,
 							})};
 						}
@@ -485,7 +485,7 @@ mod tests {
 		let secp_ctx = Secp256k1::new();
 
 		let route = Route {
-			hops: vec!(
+			paths: vec![vec![
 					RouteHop {
 						pubkey: PublicKey::from_slice(&hex::decode("02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619").unwrap()[..]).unwrap(),
 						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
@@ -511,13 +511,13 @@ mod tests {
 						channel_features: ChannelFeatures::empty(), node_features: NodeFeatures::empty(),
 						short_channel_id: 0, fee_msat: 0, cltv_expiry_delta: 0 // Test vectors are garbage and not generateble from a RouteHop, we fill in payloads manually
 					},
-			),
+			]],
 		};
 
 		let session_priv = SecretKey::from_slice(&hex::decode("4141414141414141414141414141414141414141414141414141414141414141").unwrap()[..]).unwrap();
 
-		let onion_keys = super::construct_onion_keys(&secp_ctx, &route, &session_priv).unwrap();
-		assert_eq!(onion_keys.len(), route.hops.len());
+		let onion_keys = super::construct_onion_keys(&secp_ctx, &route.paths[0], &session_priv).unwrap();
+		assert_eq!(onion_keys.len(), route.paths[0].len());
 		onion_keys
 	}
 

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -108,7 +108,7 @@ pub(super) fn construct_onion_keys<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T
 }
 
 /// returns the hop data, as well as the first-hop value_msat and CLTV value we should send.
-pub(super) fn build_onion_payloads(path: &Vec<RouteHop>, payment_secret_option: &Option<PaymentSecret>, starting_htlc_offset: u32) -> Result<(Vec<msgs::OnionHopData>, u64, u32), APIError> {
+pub(super) fn build_onion_payloads(path: &Vec<RouteHop>, total_msat: u64, payment_secret_option: &Option<PaymentSecret>, starting_htlc_offset: u32) -> Result<(Vec<msgs::OnionHopData>, u64, u32), APIError> {
 	let mut cur_value_msat = 0u64;
 	let mut cur_cltv = starting_htlc_offset;
 	let mut last_short_channel_id = 0;
@@ -127,7 +127,7 @@ pub(super) fn build_onion_payloads(path: &Vec<RouteHop>, payment_secret_option: 
 						payment_data: if let &Some(ref payment_secret) = payment_secret_option {
 							Some(msgs::FinalOnionHopData {
 								payment_secret: payment_secret.clone(),
-								total_msat: hop.fee_msat,
+								total_msat,
 							})
 						} else { None },
 					}

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -1,4 +1,4 @@
-use ln::channelmanager::{PaymentHash, HTLCSource};
+use ln::channelmanager::{PaymentHash, PaymentSecret, HTLCSource};
 use ln::msgs;
 use ln::router::{Route,RouteHop};
 use util::byte_utils;
@@ -108,7 +108,7 @@ pub(super) fn construct_onion_keys<T: secp256k1::Signing>(secp_ctx: &Secp256k1<T
 }
 
 /// returns the hop data, as well as the first-hop value_msat and CLTV value we should send.
-pub(super) fn build_onion_payloads(route: &Route, starting_htlc_offset: u32) -> Result<(Vec<msgs::OnionHopData>, u64, u32), APIError> {
+pub(super) fn build_onion_payloads(route: &Route, payment_secret_option: &Option<PaymentSecret>, starting_htlc_offset: u32) -> Result<(Vec<msgs::OnionHopData>, u64, u32), APIError> {
 	let mut cur_value_msat = 0u64;
 	let mut cur_cltv = starting_htlc_offset;
 	let mut last_short_channel_id = 0;
@@ -124,7 +124,12 @@ pub(super) fn build_onion_payloads(route: &Route, starting_htlc_offset: u32) -> 
 			format: if hop.node_features.supports_variable_length_onion() {
 				if idx == 0 {
 					msgs::OnionHopDataFormat::FinalNode {
-						payment_data: None,
+						payment_data: if let &Some(ref payment_secret) = payment_secret_option {
+							Some(msgs::FinalOnionHopData {
+								payment_secret: payment_secret.clone(),
+								total_msat: hop.fee_msat,
+							})
+						} else { None },
 					}
 				} else {
 					msgs::OnionHopDataFormat::NonFinalNode {

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -39,7 +39,7 @@ fn do_test_onchain_htlc_reorg(local_commitment: bool, claim: bool) {
 	let (our_payment_preimage, our_payment_hash) = route_payment(&nodes[0], &[&nodes[1], &nodes[2]], 1000000);
 
 	// Provide preimage to node 2 by claiming payment
-	nodes[2].node.claim_funds(our_payment_preimage, 1000000);
+	nodes[2].node.claim_funds(our_payment_preimage, &None, 1000000);
 	check_added_monitors!(nodes[2], 1);
 	get_htlc_update_msgs!(nodes[2], nodes[1].node.get_our_node_id());
 

--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -47,19 +47,10 @@ pub struct RouteHop {
 	pub cltv_expiry_delta: u32,
 }
 
-/// A route from us through the network to a destination
-#[derive(Clone, PartialEq)]
-pub struct Route {
-	/// The list of hops, NOT INCLUDING our own, where the last hop is the destination. Thus, this
-	/// must always be at least length one. By protocol rules, this may not currently exceed 20 in
-	/// length.
-	pub hops: Vec<RouteHop>,
-}
-
-impl Writeable for Route {
+impl Writeable for Vec<RouteHop> {
 	fn write<W: ::util::ser::Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
-		(self.hops.len() as u8).write(writer)?;
-		for hop in self.hops.iter() {
+		(self.len() as u8).write(writer)?;
+		for hop in self.iter() {
 			hop.pubkey.write(writer)?;
 			hop.node_features.write(writer)?;
 			hop.short_channel_id.write(writer)?;
@@ -71,8 +62,8 @@ impl Writeable for Route {
 	}
 }
 
-impl Readable for Route {
-	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Route, DecodeError> {
+impl Readable for Vec<RouteHop> {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Vec<RouteHop>, DecodeError> {
 		let hops_count: u8 = Readable::read(reader)?;
 		let mut hops = Vec::with_capacity(hops_count as usize);
 		for _ in 0..hops_count {
@@ -85,9 +76,41 @@ impl Readable for Route {
 				cltv_expiry_delta: Readable::read(reader)?,
 			});
 		}
-		Ok(Route {
-			hops
-		})
+		Ok(hops)
+	}
+}
+
+/// A route directs a payment from the sender (us) to the recipient. If the recipient supports MPP,
+/// it can take multiple paths. Each path is composed of one or more hops through the network.
+#[derive(Clone, PartialEq)]
+pub struct Route {
+	/// The list of routes taken for a single (potentially-)multi-part payment. The pubkey of the
+	/// last RouteHop in each path must be the same.
+	/// Each entry represents a list of hops, NOT INCLUDING our own, where the last hop is the
+	/// destination. Thus, this must always be at least length one. While the maximum length of any
+	/// given path is variable, keeping the length of any path to less than 20 should currently
+	/// ensure it is viable.
+	pub paths: Vec<Vec<RouteHop>>,
+}
+
+impl Writeable for Route {
+	fn write<W: ::util::ser::Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
+		(self.paths.len() as u64).write(writer)?;
+		for hops in self.paths.iter() {
+			hops.write(writer)?;
+		}
+		Ok(())
+	}
+}
+
+impl Readable for Route {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Route, DecodeError> {
+		let path_count: u64 = Readable::read(reader)?;
+		let mut paths = Vec::with_capacity(cmp::min(path_count, 128) as usize);
+		for _ in 0..path_count {
+			paths.push(Readable::read(reader)?);
+		}
+		Ok(Route { paths })
 	}
 }
 
@@ -868,14 +891,14 @@ impl Router {
 				let short_channel_id = chan.short_channel_id.expect("first_hops should be filled in with usable channels, not pending ones");
 				if chan.remote_network_id == *target {
 					return Ok(Route {
-						hops: vec![RouteHop {
+						paths: vec![vec![RouteHop {
 							pubkey: chan.remote_network_id,
 							node_features: NodeFeatures::with_known_relevant_init_flags(&chan.counterparty_features),
 							short_channel_id,
 							channel_features: ChannelFeatures::with_known_relevant_init_flags(&chan.counterparty_features),
 							fee_msat: final_value_msat,
 							cltv_expiry_delta: final_cltv,
-						}],
+						}]],
 					});
 				}
 				first_hop_targets.insert(chan.remote_network_id, (short_channel_id, chan.counterparty_features.clone()));
@@ -1032,7 +1055,7 @@ impl Router {
 				}
 				res.last_mut().unwrap().fee_msat = final_value_msat;
 				res.last_mut().unwrap().cltv_expiry_delta = final_cltv;
-				let route = Route { hops: res };
+				let route = Route { paths: vec![res] };
 				log_trace!(self, "Got route: {}", log_route!(route));
 				return Ok(route);
 			}
@@ -1497,21 +1520,21 @@ mod tests {
 
 		{ // Simple route to 3 via 2
 			let route = router.get_route(&node3, None, &Vec::new(), 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 2);
+			assert_eq!(route.paths[0].len(), 2);
 
-			assert_eq!(route.hops[0].pubkey, node2);
-			assert_eq!(route.hops[0].short_channel_id, 2);
-			assert_eq!(route.hops[0].fee_msat, 100);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (4 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &id_to_feature_flags!(2));
-			assert_eq!(route.hops[0].channel_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].pubkey, node2);
+			assert_eq!(route.paths[0][0].short_channel_id, 2);
+			assert_eq!(route.paths[0][0].fee_msat, 100);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (4 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &id_to_feature_flags!(2));
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 4);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 4);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(4));
 		}
 
 		{ // Disable channels 4 and 12 by requiring unknown feature bits
@@ -1539,21 +1562,21 @@ mod tests {
 				is_live: true,
 			}];
 			let route = router.get_route(&node3, Some(&our_chans), &Vec::new(), 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 2);
+			assert_eq!(route.paths[0].len(), 2);
 
-			assert_eq!(route.hops[0].pubkey, node8);
-			assert_eq!(route.hops[0].short_channel_id, 42);
-			assert_eq!(route.hops[0].fee_msat, 200);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (13 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &vec![0b11]); // it should also override our view of their features
-			assert_eq!(route.hops[0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
+			assert_eq!(route.paths[0][0].pubkey, node8);
+			assert_eq!(route.paths[0][0].short_channel_id, 42);
+			assert_eq!(route.paths[0][0].fee_msat, 200);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (13 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &vec![0b11]); // it should also override our view of their features
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 13);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(13));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 13);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(13));
 		}
 
 		{ // Re-enable channels 4 and 12 by wiping the unknown feature bits
@@ -1588,21 +1611,21 @@ mod tests {
 				is_live: true,
 			}];
 			let route = router.get_route(&node3, Some(&our_chans), &Vec::new(), 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 2);
+			assert_eq!(route.paths[0].len(), 2);
 
-			assert_eq!(route.hops[0].pubkey, node8);
-			assert_eq!(route.hops[0].short_channel_id, 42);
-			assert_eq!(route.hops[0].fee_msat, 200);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (13 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &vec![0b11]); // it should also override our view of their features
-			assert_eq!(route.hops[0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
+			assert_eq!(route.paths[0][0].pubkey, node8);
+			assert_eq!(route.paths[0][0].short_channel_id, 42);
+			assert_eq!(route.paths[0][0].fee_msat, 200);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (13 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &vec![0b11]); // it should also override our view of their features
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 13);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(13));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 13);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(13));
 		}
 
 		{ // Re-enable nodes 1, 2, and 8
@@ -1618,28 +1641,28 @@ mod tests {
 
 		{ // Route to 1 via 2 and 3 because our channel to 1 is disabled
 			let route = router.get_route(&node1, None, &Vec::new(), 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 3);
+			assert_eq!(route.paths[0].len(), 3);
 
-			assert_eq!(route.hops[0].pubkey, node2);
-			assert_eq!(route.hops[0].short_channel_id, 2);
-			assert_eq!(route.hops[0].fee_msat, 200);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (4 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &id_to_feature_flags!(2));
-			assert_eq!(route.hops[0].channel_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].pubkey, node2);
+			assert_eq!(route.paths[0][0].short_channel_id, 2);
+			assert_eq!(route.paths[0][0].fee_msat, 200);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (4 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &id_to_feature_flags!(2));
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 4);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, (3 << 8) | 2);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 4);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, (3 << 8) | 2);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(4));
 
-			assert_eq!(route.hops[2].pubkey, node1);
-			assert_eq!(route.hops[2].short_channel_id, 3);
-			assert_eq!(route.hops[2].fee_msat, 100);
-			assert_eq!(route.hops[2].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[2].node_features.le_flags(), &id_to_feature_flags!(1));
-			assert_eq!(route.hops[2].channel_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][2].pubkey, node1);
+			assert_eq!(route.paths[0][2].short_channel_id, 3);
+			assert_eq!(route.paths[0][2].fee_msat, 100);
+			assert_eq!(route.paths[0][2].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][2].node_features.le_flags(), &id_to_feature_flags!(1));
+			assert_eq!(route.paths[0][2].channel_features.le_flags(), &id_to_feature_flags!(3));
 		}
 
 		{ // If we specify a channel to node8, that overrides our local channel view and that gets used
@@ -1655,21 +1678,21 @@ mod tests {
 				is_live: true,
 			}];
 			let route = router.get_route(&node3, Some(&our_chans), &Vec::new(), 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 2);
+			assert_eq!(route.paths[0].len(), 2);
 
-			assert_eq!(route.hops[0].pubkey, node8);
-			assert_eq!(route.hops[0].short_channel_id, 42);
-			assert_eq!(route.hops[0].fee_msat, 200);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (13 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &vec![0b11]);
-			assert_eq!(route.hops[0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
+			assert_eq!(route.paths[0][0].pubkey, node8);
+			assert_eq!(route.paths[0][0].short_channel_id, 42);
+			assert_eq!(route.paths[0][0].fee_msat, 200);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (13 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &vec![0b11]);
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 13);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(13));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 13);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(13));
 		}
 
 		let mut last_hops = vec!(RouteHint {
@@ -1697,44 +1720,44 @@ mod tests {
 
 		{ // Simple test across 2, 3, 5, and 4 via a last_hop channel
 			let route = router.get_route(&node7, None, &last_hops, 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 5);
+			assert_eq!(route.paths[0].len(), 5);
 
-			assert_eq!(route.hops[0].pubkey, node2);
-			assert_eq!(route.hops[0].short_channel_id, 2);
-			assert_eq!(route.hops[0].fee_msat, 100);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (4 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &id_to_feature_flags!(2));
-			assert_eq!(route.hops[0].channel_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].pubkey, node2);
+			assert_eq!(route.paths[0][0].short_channel_id, 2);
+			assert_eq!(route.paths[0][0].fee_msat, 100);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (4 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &id_to_feature_flags!(2));
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 4);
-			assert_eq!(route.hops[1].fee_msat, 0);
-			assert_eq!(route.hops[1].cltv_expiry_delta, (6 << 8) | 1);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 4);
+			assert_eq!(route.paths[0][1].fee_msat, 0);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, (6 << 8) | 1);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(4));
 
-			assert_eq!(route.hops[2].pubkey, node5);
-			assert_eq!(route.hops[2].short_channel_id, 6);
-			assert_eq!(route.hops[2].fee_msat, 0);
-			assert_eq!(route.hops[2].cltv_expiry_delta, (11 << 8) | 1);
-			assert_eq!(route.hops[2].node_features.le_flags(), &id_to_feature_flags!(5));
-			assert_eq!(route.hops[2].channel_features.le_flags(), &id_to_feature_flags!(6));
+			assert_eq!(route.paths[0][2].pubkey, node5);
+			assert_eq!(route.paths[0][2].short_channel_id, 6);
+			assert_eq!(route.paths[0][2].fee_msat, 0);
+			assert_eq!(route.paths[0][2].cltv_expiry_delta, (11 << 8) | 1);
+			assert_eq!(route.paths[0][2].node_features.le_flags(), &id_to_feature_flags!(5));
+			assert_eq!(route.paths[0][2].channel_features.le_flags(), &id_to_feature_flags!(6));
 
-			assert_eq!(route.hops[3].pubkey, node4);
-			assert_eq!(route.hops[3].short_channel_id, 11);
-			assert_eq!(route.hops[3].fee_msat, 0);
-			assert_eq!(route.hops[3].cltv_expiry_delta, (8 << 8) | 1);
+			assert_eq!(route.paths[0][3].pubkey, node4);
+			assert_eq!(route.paths[0][3].short_channel_id, 11);
+			assert_eq!(route.paths[0][3].fee_msat, 0);
+			assert_eq!(route.paths[0][3].cltv_expiry_delta, (8 << 8) | 1);
 			// If we have a peer in the node map, we'll use their features here since we don't have
 			// a way of figuring out their features from the invoice:
-			assert_eq!(route.hops[3].node_features.le_flags(), &id_to_feature_flags!(4));
-			assert_eq!(route.hops[3].channel_features.le_flags(), &id_to_feature_flags!(11));
+			assert_eq!(route.paths[0][3].node_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][3].channel_features.le_flags(), &id_to_feature_flags!(11));
 
-			assert_eq!(route.hops[4].pubkey, node7);
-			assert_eq!(route.hops[4].short_channel_id, 8);
-			assert_eq!(route.hops[4].fee_msat, 100);
-			assert_eq!(route.hops[4].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[4].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
-			assert_eq!(route.hops[4].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
+			assert_eq!(route.paths[0][4].pubkey, node7);
+			assert_eq!(route.paths[0][4].short_channel_id, 8);
+			assert_eq!(route.paths[0][4].fee_msat, 100);
+			assert_eq!(route.paths[0][4].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][4].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
+			assert_eq!(route.paths[0][4].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
 		}
 
 		{ // Simple test with outbound channel to 4 to test that last_hops and first_hops connect
@@ -1750,100 +1773,100 @@ mod tests {
 				is_live: true,
 			}];
 			let route = router.get_route(&node7, Some(&our_chans), &last_hops, 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 2);
+			assert_eq!(route.paths[0].len(), 2);
 
-			assert_eq!(route.hops[0].pubkey, node4);
-			assert_eq!(route.hops[0].short_channel_id, 42);
-			assert_eq!(route.hops[0].fee_msat, 0);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (8 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &vec![0b11]);
-			assert_eq!(route.hops[0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
+			assert_eq!(route.paths[0][0].pubkey, node4);
+			assert_eq!(route.paths[0][0].short_channel_id, 42);
+			assert_eq!(route.paths[0][0].fee_msat, 0);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (8 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &vec![0b11]);
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &Vec::new()); // No feature flags will meet the relevant-to-channel conversion
 
-			assert_eq!(route.hops[1].pubkey, node7);
-			assert_eq!(route.hops[1].short_channel_id, 8);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[1].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
-			assert_eq!(route.hops[1].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
+			assert_eq!(route.paths[0][1].pubkey, node7);
+			assert_eq!(route.paths[0][1].short_channel_id, 8);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
 		}
 
 		last_hops[0].fee_base_msat = 1000;
 
 		{ // Revert to via 6 as the fee on 8 goes up
 			let route = router.get_route(&node7, None, &last_hops, 100, 42).unwrap();
-			assert_eq!(route.hops.len(), 4);
+			assert_eq!(route.paths[0].len(), 4);
 
-			assert_eq!(route.hops[0].pubkey, node2);
-			assert_eq!(route.hops[0].short_channel_id, 2);
-			assert_eq!(route.hops[0].fee_msat, 200); // fee increased as its % of value transferred across node
-			assert_eq!(route.hops[0].cltv_expiry_delta, (4 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &id_to_feature_flags!(2));
-			assert_eq!(route.hops[0].channel_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].pubkey, node2);
+			assert_eq!(route.paths[0][0].short_channel_id, 2);
+			assert_eq!(route.paths[0][0].fee_msat, 200); // fee increased as its % of value transferred across node
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (4 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &id_to_feature_flags!(2));
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 4);
-			assert_eq!(route.hops[1].fee_msat, 100);
-			assert_eq!(route.hops[1].cltv_expiry_delta, (7 << 8) | 1);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 4);
+			assert_eq!(route.paths[0][1].fee_msat, 100);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, (7 << 8) | 1);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(4));
 
-			assert_eq!(route.hops[2].pubkey, node6);
-			assert_eq!(route.hops[2].short_channel_id, 7);
-			assert_eq!(route.hops[2].fee_msat, 0);
-			assert_eq!(route.hops[2].cltv_expiry_delta, (10 << 8) | 1);
+			assert_eq!(route.paths[0][2].pubkey, node6);
+			assert_eq!(route.paths[0][2].short_channel_id, 7);
+			assert_eq!(route.paths[0][2].fee_msat, 0);
+			assert_eq!(route.paths[0][2].cltv_expiry_delta, (10 << 8) | 1);
 			// If we have a peer in the node map, we'll use their features here since we don't have
 			// a way of figuring out their features from the invoice:
-			assert_eq!(route.hops[2].node_features.le_flags(), &id_to_feature_flags!(6));
-			assert_eq!(route.hops[2].channel_features.le_flags(), &id_to_feature_flags!(7));
+			assert_eq!(route.paths[0][2].node_features.le_flags(), &id_to_feature_flags!(6));
+			assert_eq!(route.paths[0][2].channel_features.le_flags(), &id_to_feature_flags!(7));
 
-			assert_eq!(route.hops[3].pubkey, node7);
-			assert_eq!(route.hops[3].short_channel_id, 10);
-			assert_eq!(route.hops[3].fee_msat, 100);
-			assert_eq!(route.hops[3].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[3].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
-			assert_eq!(route.hops[3].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
+			assert_eq!(route.paths[0][3].pubkey, node7);
+			assert_eq!(route.paths[0][3].short_channel_id, 10);
+			assert_eq!(route.paths[0][3].fee_msat, 100);
+			assert_eq!(route.paths[0][3].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][3].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
+			assert_eq!(route.paths[0][3].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
 		}
 
 		{ // ...but still use 8 for larger payments as 6 has a variable feerate
 			let route = router.get_route(&node7, None, &last_hops, 2000, 42).unwrap();
-			assert_eq!(route.hops.len(), 5);
+			assert_eq!(route.paths[0].len(), 5);
 
-			assert_eq!(route.hops[0].pubkey, node2);
-			assert_eq!(route.hops[0].short_channel_id, 2);
-			assert_eq!(route.hops[0].fee_msat, 3000);
-			assert_eq!(route.hops[0].cltv_expiry_delta, (4 << 8) | 1);
-			assert_eq!(route.hops[0].node_features.le_flags(), &id_to_feature_flags!(2));
-			assert_eq!(route.hops[0].channel_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].pubkey, node2);
+			assert_eq!(route.paths[0][0].short_channel_id, 2);
+			assert_eq!(route.paths[0][0].fee_msat, 3000);
+			assert_eq!(route.paths[0][0].cltv_expiry_delta, (4 << 8) | 1);
+			assert_eq!(route.paths[0][0].node_features.le_flags(), &id_to_feature_flags!(2));
+			assert_eq!(route.paths[0][0].channel_features.le_flags(), &id_to_feature_flags!(2));
 
-			assert_eq!(route.hops[1].pubkey, node3);
-			assert_eq!(route.hops[1].short_channel_id, 4);
-			assert_eq!(route.hops[1].fee_msat, 0);
-			assert_eq!(route.hops[1].cltv_expiry_delta, (6 << 8) | 1);
-			assert_eq!(route.hops[1].node_features.le_flags(), &id_to_feature_flags!(3));
-			assert_eq!(route.hops[1].channel_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][1].pubkey, node3);
+			assert_eq!(route.paths[0][1].short_channel_id, 4);
+			assert_eq!(route.paths[0][1].fee_msat, 0);
+			assert_eq!(route.paths[0][1].cltv_expiry_delta, (6 << 8) | 1);
+			assert_eq!(route.paths[0][1].node_features.le_flags(), &id_to_feature_flags!(3));
+			assert_eq!(route.paths[0][1].channel_features.le_flags(), &id_to_feature_flags!(4));
 
-			assert_eq!(route.hops[2].pubkey, node5);
-			assert_eq!(route.hops[2].short_channel_id, 6);
-			assert_eq!(route.hops[2].fee_msat, 0);
-			assert_eq!(route.hops[2].cltv_expiry_delta, (11 << 8) | 1);
-			assert_eq!(route.hops[2].node_features.le_flags(), &id_to_feature_flags!(5));
-			assert_eq!(route.hops[2].channel_features.le_flags(), &id_to_feature_flags!(6));
+			assert_eq!(route.paths[0][2].pubkey, node5);
+			assert_eq!(route.paths[0][2].short_channel_id, 6);
+			assert_eq!(route.paths[0][2].fee_msat, 0);
+			assert_eq!(route.paths[0][2].cltv_expiry_delta, (11 << 8) | 1);
+			assert_eq!(route.paths[0][2].node_features.le_flags(), &id_to_feature_flags!(5));
+			assert_eq!(route.paths[0][2].channel_features.le_flags(), &id_to_feature_flags!(6));
 
-			assert_eq!(route.hops[3].pubkey, node4);
-			assert_eq!(route.hops[3].short_channel_id, 11);
-			assert_eq!(route.hops[3].fee_msat, 1000);
-			assert_eq!(route.hops[3].cltv_expiry_delta, (8 << 8) | 1);
+			assert_eq!(route.paths[0][3].pubkey, node4);
+			assert_eq!(route.paths[0][3].short_channel_id, 11);
+			assert_eq!(route.paths[0][3].fee_msat, 1000);
+			assert_eq!(route.paths[0][3].cltv_expiry_delta, (8 << 8) | 1);
 			// If we have a peer in the node map, we'll use their features here since we don't have
 			// a way of figuring out their features from the invoice:
-			assert_eq!(route.hops[3].node_features.le_flags(), &id_to_feature_flags!(4));
-			assert_eq!(route.hops[3].channel_features.le_flags(), &id_to_feature_flags!(11));
+			assert_eq!(route.paths[0][3].node_features.le_flags(), &id_to_feature_flags!(4));
+			assert_eq!(route.paths[0][3].channel_features.le_flags(), &id_to_feature_flags!(11));
 
-			assert_eq!(route.hops[4].pubkey, node7);
-			assert_eq!(route.hops[4].short_channel_id, 8);
-			assert_eq!(route.hops[4].fee_msat, 2000);
-			assert_eq!(route.hops[4].cltv_expiry_delta, 42);
-			assert_eq!(route.hops[4].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
-			assert_eq!(route.hops[4].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
+			assert_eq!(route.paths[0][4].pubkey, node7);
+			assert_eq!(route.paths[0][4].short_channel_id, 8);
+			assert_eq!(route.paths[0][4].fee_msat, 2000);
+			assert_eq!(route.paths[0][4].cltv_expiry_delta, 42);
+			assert_eq!(route.paths[0][4].node_features.le_flags(), &Vec::new()); // We dont pass flags in from invoices yet
+			assert_eq!(route.paths[0][4].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
 		}
 
 		{ // Test Router serialization/deserialization

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -73,8 +73,11 @@ macro_rules! log_funding_info {
 pub(crate) struct DebugRoute<'a>(pub &'a Route);
 impl<'a> std::fmt::Display for DebugRoute<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		for h in self.0.hops.iter() {
-			write!(f, "node_id: {}, short_channel_id: {}, fee_msat: {}, cltv_expiry_delta: {}\n", log_pubkey!(h.pubkey), h.short_channel_id, h.fee_msat, h.cltv_expiry_delta)?;
+		for (idx, p) in self.0.paths.iter().enumerate() {
+			write!(f, "path {}:\n", idx)?;
+			for h in p.iter() {
+				write!(f, " node_id: {}, short_channel_id: {}, fee_msat: {}, cltv_expiry_delta: {}\n", log_pubkey!(h.pubkey), h.short_channel_id, h.fee_msat, h.cltv_expiry_delta)?;
+			}
 		}
 		Ok(())
 	}

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -17,7 +17,7 @@ use bitcoin::consensus::Encodable;
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 use std::marker::Sized;
 use ln::msgs::DecodeError;
-use ln::channelmanager::{PaymentPreimage, PaymentHash};
+use ln::channelmanager::{PaymentPreimage, PaymentHash, PaymentSecret};
 use util::byte_utils;
 
 use util::byte_utils::{be64_to_array, be48_to_array, be32_to_array, be16_to_array, slice_to_be16, slice_to_be32, slice_to_be48, slice_to_be64};
@@ -588,6 +588,19 @@ impl Readable for PaymentHash {
 	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		let buf: [u8; 32] = Readable::read(r)?;
 		Ok(PaymentHash(buf))
+	}
+}
+
+impl Writeable for PaymentSecret {
+	fn write<W: Writer>(&self, w: &mut W) -> Result<(), ::std::io::Error> {
+		self.0.write(w)
+	}
+}
+
+impl Readable for PaymentSecret {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		let buf: [u8; 32] = Readable::read(r)?;
+		Ok(PaymentSecret(buf))
 	}
 }
 


### PR DESCRIPTION
This implements Basic AMP from a receive/send side, though not yet from the router end. Only reason its draft is cause we need to support timing out MPP payments that are missing pieces for too long.