### PR TITLE
Fix EnforcingChannelKeys panic when our counterparty burns their $.

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -240,7 +240,10 @@ pub(super) struct Channel<ChanSigner: ChannelKeys> {
 	secp_ctx: Secp256k1<secp256k1::All>,
 	channel_value_satoshis: u64,
 
+	#[cfg(not(test))]
 	local_keys: ChanSigner,
+	#[cfg(test)]
+	pub(super) local_keys: ChanSigner,
 	shutdown_pubkey: PublicKey,
 
 	// Our commitment numbers start at 2^48-1 and count down, whereas the ones used in transaction

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1995,6 +1995,17 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 		self.channel_monitor.provide_secret(self.cur_remote_commitment_transaction_number + 1, msg.per_commitment_secret)
 			.map_err(|e| ChannelError::Close(e.0))?;
 
+		if self.channel_state & ChannelState::AwaitingRemoteRevoke as u32 == 0 {
+			// Our counterparty seems to have burned their coins to us (by revoking a state when we
+			// haven't given them a new commitment transaction to broadcast). We should probably
+			// take advantage of this by updating our channel monitor, sending them an error, and
+			// waiting for them to broadcast their latest (now-revoked claim). But, that would be a
+			// lot of work, and there's some chance this is all a misunderstanding anyway.
+			// We have to do *something*, though, since our signer may get mad at us for otherwise
+			// jumping a remote commitment number, so best to just force-close and move on.
+			return Err(ChannelError::Close("Received an unexpected revoke_and_ack"));
+		}
+
 		// Update state now that we've passed all the can-fail calls...
 		// (note that we may still fail to generate the new commitment_signed message, but that's
 		// OK, we step the channel here and *then* if the new generation fails we can fail the


### PR DESCRIPTION
If our counterparty burns their funds by revoking their current
commitment transaction before we've sent them a new one, we'll step
forward the remote commitment number. This would be otherwise fine
(and may even encourage them to broadcast their revoked state(s) on
chain), except that our new EnforcingChannelKeys expects us to not
jump forward in time. Since it isn't too important that we punish
our counterparty in such a corner-case, we opt to just close the
channel in such a case and move on.