### PR TITLE
Fix crash when a claim tx has some non-witness inputs.

### DIFF
--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -93,15 +93,29 @@ macro_rules! log_route {
 pub(crate) struct DebugTx<'a>(pub &'a Transaction);
 impl<'a> std::fmt::Display for DebugTx<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		if self.0.input.len() == 1 && self.0.input[0].witness.last().unwrap().len() == 71 && (self.0.input[0].sequence >> 8*3) as u8 == 0x80 { write!(f, "commitment tx")?; }
-		else if self.0.input.len() == 1 && self.0.input[0].witness.last().unwrap().len() == 71 { write!(f, "closing tx")?; }
-		else if self.0.input.len() == 1 && self.0.input[0].witness.last().unwrap().len() == 133 && self.0.input[0].witness.len() == 5 { write!(f, "HTLC-timeout tx")?; }
-		else if self.0.input.len() == 1 && (self.0.input[0].witness.last().unwrap().len() == 138 || self.0.input[0].witness.last().unwrap().len() == 139) && self.0.input[0].witness.len() == 5 { write!(f, "HTLC-success tx")?; }
-		else {
-			for inp in &self.0.input {
-				if inp.witness.last().unwrap().len() == 133 { write!(f, "preimage tx")?; break }
-				else if inp.witness.last().unwrap().len() == 138 { write!(f, "timeout tx")?; break }
+		if self.0.input.len() >= 1 && self.0.input.iter().any(|i| !i.witness.is_empty()) {
+			if self.0.input.len() == 1 && self.0.input[0].witness.last().unwrap().len() == 71 &&
+					(self.0.input[0].sequence >> 8*3) as u8 == 0x80 {
+				write!(f, "commitment tx")?;
+			} else if self.0.input.len() == 1 && self.0.input[0].witness.last().unwrap().len() == 71 {
+				write!(f, "closing tx")?;
+			} else if self.0.input.len() == 1 && self.0.input[0].witness.last().unwrap().len() == 133 &&
+					self.0.input[0].witness.len() == 5 {
+				write!(f, "HTLC-timeout tx")?;
+			} else if self.0.input.len() == 1 &&
+					(self.0.input[0].witness.last().unwrap().len() == 138 || self.0.input[0].witness.last().unwrap().len() == 139) &&
+					self.0.input[0].witness.len() == 5 {
+				write!(f, "HTLC-success tx")?;
+			} else {
+				for inp in &self.0.input {
+					if !inp.witness.is_empty() {
+						if inp.witness.last().unwrap().len() == 133 { write!(f, "preimage tx")?; break }
+						else if inp.witness.last().unwrap().len() == 138 { write!(f, "timeout tx")?; break }
+					}
+				}
 			}
+		} else {
+			write!(f, "INVALID TRANSACTION")?;
 		}
 		Ok(())
 	}


### PR DESCRIPTION
The logger which decides what to refer to an on-chain claim tx was
assuming that all inputs would have a witness. While this was fine
for the one-input case, it broke the fuzzer which was connecting a
consensus-invalid transaction. Further, in the case we have multiple
inputs, some may not have a witness, which we shouldn't crash on.

This fixes 9df0250dbbad7449e3ec8f90532ce9197eb31997.