### PR TITLE
Increase visibility for external integration tests

### DIFF
--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -67,14 +67,6 @@ pub type ChannelFeatures = Features<sealed::ChannelContext>;
 
 impl InitFeatures {
 	/// Create a Features with the features we support
-	#[cfg(not(feature = "fuzztarget"))]
-	pub(crate) fn supported() -> InitFeatures {
-		InitFeatures {
-			flags: vec![2 | 1 << 5],
-			mark: PhantomData,
-		}
-	}
-	#[cfg(feature = "fuzztarget")]
 	pub fn supported() -> InitFeatures {
 		InitFeatures {
 			flags: vec![2 | 1 << 5],

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -15,16 +15,12 @@ pub mod msgs;
 pub mod router;
 pub mod peer_handler;
 pub mod chan_utils;
+pub mod features;
 
 #[cfg(feature = "fuzztarget")]
 pub mod peer_channel_encryptor;
 #[cfg(not(feature = "fuzztarget"))]
 pub(crate) mod peer_channel_encryptor;
-
-#[cfg(feature = "fuzztarget")]
-pub mod features;
-#[cfg(not(feature = "fuzztarget"))]
-pub(crate) mod features;
 
 mod channel;
 mod onion_utils;

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -139,9 +139,10 @@ pub struct FundingSigned {
 
 /// A funding_locked message to be sent or received from a peer
 #[derive(Clone, PartialEq)]
+#[allow(missing_docs)]
 pub struct FundingLocked {
-	pub(crate) channel_id: [u8; 32],
-	pub(crate) next_per_commitment_point: PublicKey,
+	pub channel_id: [u8; 32],
+	pub next_per_commitment_point: PublicKey,
 }
 
 /// A shutdown message to be sent or received from a peer


### PR DESCRIPTION
I am starting an external integration test suite using rust-lightning.  I found that I needed the following visibility increases in order to be able to compile a functional test.  For example, visibility of `InitFeatures` is needed to orchestrate channel opening via `handle_open_channel`.

Is there an alternative way of achieving this?

The tests are here: https://gitlab.com/lightning-signer/rust-lightning-signer - mostly cribbed from one of the internal rust-lightning functional tests.