### PR TITLE
Fix full_stack_target block disconnection

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -196,10 +196,10 @@ impl<'a> MoneyLossDetector<'a> {
 
 	fn disconnect_block(&mut self) {
 		if self.height > 0 && (self.max_height < 6 || self.height >= self.max_height - 6) {
-			self.height -= 1;
 			let header = BlockHeader { version: 0x20000000, prev_blockhash: self.header_hashes[self.height], merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 			self.manager.block_disconnected(&header, self.height as u32);
 			self.monitor.block_disconnected(&header, self.height as u32);
+			self.height -= 1;
 			let removal_height = self.height;
 			self.txids_confirmed.retain(|_, height| {
 				removal_height != *height

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -2556,6 +2556,7 @@ impl ChannelMonitor {
 	}
 
 	fn block_disconnected(&mut self, height: u32, block_hash: &Sha256dHash, broadcaster: &BroadcasterInterface, fee_estimator: &FeeEstimator) {
+		log_trace!(self, "Block {} at height {} disconnected", block_hash, height);
 		let mut bump_candidates = HashMap::new();
 		if let Some(events) = self.onchain_events_waiting_threshold_conf.remove(&(height + ANTI_REORG_DELAY - 1)) {
 			//We may discard:


### PR DESCRIPTION
Fuzzer found an 'Inconsistencies between pending_claim_requests map and claimable_outpoints map' error but in fact seems to be FST misusing ChainInterface. Pending on further fuzzing