### PR TITLE
Track the full list of outpoints a chanmon wants monitoring for

### DIFF
--- a/lightning/src/chain/chaininterface.rs
+++ b/lightning/src/chain/chaininterface.rs
@@ -126,6 +126,7 @@ pub trait FeeEstimator: Sync + Send {
 pub const MIN_RELAY_FEE_SAT_PER_1000_WEIGHT: u64 = 4000;
 
 /// Utility for tracking registered txn/outpoints and checking for matches
+#[cfg_attr(test, derive(PartialEq))]
 pub struct ChainWatchedUtil {
 	watch_all: bool,
 
@@ -303,6 +304,17 @@ pub struct ChainWatchInterfaceUtil {
 	watched: Mutex<ChainWatchedUtil>,
 	reentered: AtomicUsize,
 	logger: Arc<Logger>,
+}
+
+// We only expose PartialEq in test since its somewhat unclear exactly what it should do and we're
+// only comparing a subset of fields (essentially just checking that the set of things we're
+// watching is the same).
+#[cfg(test)]
+impl PartialEq for ChainWatchInterfaceUtil {
+	fn eq(&self, o: &Self) -> bool {
+		self.network == o.network &&
+		*self.watched.lock().unwrap() == *o.watched.lock().unwrap()
+	}
 }
 
 /// Register listener

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -2397,6 +2397,11 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 		}
 	}
 
+	/// Called by SimpleManyChannelMonitor::block_connected, which implements
+	/// ChainListener::block_connected.
+	/// Eventually this should be pub and, roughly, implement ChainListener, however this requires
+	/// &mut self, as well as returns new spendable outputs and outpoints to watch for spending of
+	/// on-chain.
 	fn block_connected(&mut self, txn_matched: &[&Transaction], height: u32, block_hash: &Sha256dHash, broadcaster: &BroadcasterInterface, fee_estimator: &FeeEstimator)-> (Vec<(Sha256dHash, Vec<TxOut>)>, Vec<SpendableOutputDescriptor>, Vec<(HTLCSource, Option<PaymentPreimage>, PaymentHash)>) {
 		for tx in txn_matched {
 			let mut output_val = 0;

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -5,6 +5,7 @@ use chain::chaininterface;
 use chain::transaction::OutPoint;
 use chain::keysinterface::KeysInterface;
 use ln::channelmanager::{ChannelManager,RAACommitmentOrder, PaymentPreimage, PaymentHash};
+use ln::channelmonitor::{ChannelMonitor, ManyChannelMonitor};
 use ln::router::{Route, Router};
 use ln::features::InitFeatures;
 use ln::msgs;
@@ -16,6 +17,7 @@ use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsPro
 use util::errors::APIError;
 use util::logger::Logger;
 use util::config::UserConfig;
+use util::ser::ReadableArgs;
 
 use bitcoin::util::hash::BitcoinHash;
 use bitcoin::blockdata::block::BlockHeader;
@@ -89,6 +91,27 @@ impl<'a, 'b> Drop for Node<'a, 'b> {
 			assert!(self.node.get_and_clear_pending_msg_events().is_empty());
 			assert!(self.node.get_and_clear_pending_events().is_empty());
 			assert!(self.chan_monitor.added_monitors.lock().unwrap().is_empty());
+
+			// Check that if we serialize and then deserialize all our channel monitors we get the
+			// same set of outputs to watch for on chain as we have now. Note that if we write
+			// tests that fully close channels and remove the monitors at some point this may break.
+			let chain_watch = Arc::new(chaininterface::ChainWatchInterfaceUtil::new(Network::Testnet, Arc::clone(&self.logger) as Arc<Logger>));
+			let feeest = Arc::new(test_utils::TestFeeEstimator { sat_per_kw: 253 });
+			let channel_monitor = test_utils::TestChannelMonitor::new(chain_watch.clone(), self.tx_broadcaster.clone(), self.logger.clone(), feeest);
+			let old_monitors = self.chan_monitor.simple_monitor.monitors.lock().unwrap();
+			for (_, old_monitor) in old_monitors.iter() {
+				let mut w = test_utils::TestVecWriter(Vec::new());
+				old_monitor.write_for_disk(&mut w).unwrap();
+				let (_, deserialized_monitor) = <(Sha256d, ChannelMonitor<EnforcingChannelKeys>)>::read(
+					&mut ::std::io::Cursor::new(&w.0), Arc::clone(&self.logger) as Arc<Logger>).unwrap();
+				if let Err(_) = channel_monitor.add_update_monitor(deserialized_monitor.get_funding_txo().unwrap(), deserialized_monitor) {
+					panic!();
+				}
+			}
+
+			if *chain_watch != *self.chain_monitor {
+				panic!();
+			}
 		}
 	}
 }


### PR DESCRIPTION
Upon deserialization/reload we need to be able to register each
outpoint which spends the commitment txo which a channelmonitor
believes to be on chain. While our other internal tracking is
likely sufficient to regenerate these, its much easier to simply
track all outpouts we've ever generated, so we do that here.