### PR TITLE
Fix spurious calls of broadcast_by_local_state

### DIFF
--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -2220,7 +2220,8 @@ impl ChannelMonitor {
 				assert!(local_tx.tx.has_local_sig());
 				match self.key_storage {
 					Storage::Local { ref delayed_payment_base_key, .. } => {
-						append_onchain_update!(self.broadcast_by_local_state(local_tx, delayed_payment_base_key, height));
+						let mut res = self.broadcast_by_local_state(local_tx, delayed_payment_base_key, height);
+						append_onchain_update!(res);
 					},
 					Storage::Watchtower { .. } => { }
 				}
@@ -2243,7 +2244,8 @@ impl ChannelMonitor {
 				assert!(local_tx.tx.has_local_sig());
 				match self.key_storage {
 					Storage::Local { ref delayed_payment_base_key, .. } => {
-						append_onchain_update!(self.broadcast_by_local_state(local_tx, delayed_payment_base_key, height));
+						let mut res = self.broadcast_by_local_state(local_tx, delayed_payment_base_key, height);
+						append_onchain_update!(res);
 					},
 					Storage::Watchtower { .. } => { }
 				}


### PR DESCRIPTION
A really dumb bug introduced by myself in 273f2fc while #336, not sure we can't test it in the framework because we where destructuring the result so no supplemental value was returned but w called 4 times broadcast_by_local_state.