### PR TITLE
Clean up documentation around spendable outputs significantly.

### DIFF
--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -99,8 +99,9 @@ pub enum Event {
 		time_forwardable: Duration,
 	},
 	/// Used to indicate that an output was generated on-chain which you should know how to spend.
-	/// Such an output will *not* ever be spent by rust-lightning, so you need to store them
-	/// somewhere and spend them when you create on-chain spends.
+	/// Such an output will *not* ever be spent by rust-lightning, and are not at risk of your
+	/// counterparty spending them due to some kind of timeout. Thus, you need to store them
+	/// somewhere and spend them when you create on-chain transactions.
 	SpendableOutputs {
 		/// The outputs which you should store as spendable by you.
 		outputs: Vec<SpendableOutputDescriptor>,


### PR DESCRIPTION
 * Fixed a number of grammar issues
 * Clarified the docs for users who are intimately farmiliar with
   arbitrary lines of text copied from the BOLTs
 * Added a bit more text so that things are easier to read and less
   disjoint.
 * Clarified exactly how the witness stack should look since I had
   to go dig for it.