### PR TITLE
Add ChannelKeys to ChannelMonitor

### DIFF
--- a/fuzz/src/chanmon_deser.rs
+++ b/fuzz/src/chanmon_deser.rs
@@ -3,6 +3,7 @@
 
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 
+use lightning::util::enforcing_trait_impls::EnforcingChannelKeys;
 use lightning::ln::channelmonitor;
 use lightning::util::ser::{ReadableArgs, Writer};
 
@@ -25,10 +26,10 @@ impl Writer for VecWriter {
 #[inline]
 pub fn do_test(data: &[u8]) {
 	let logger = Arc::new(test_logger::TestLogger::new("".to_owned()));
-	if let Ok((latest_block_hash, monitor)) = <(Sha256dHash, channelmonitor::ChannelMonitor)>::read(&mut Cursor::new(data), logger.clone()) {
+	if let Ok((latest_block_hash, monitor)) = <(Sha256dHash, channelmonitor::ChannelMonitor<EnforcingChannelKeys>)>::read(&mut Cursor::new(data), logger.clone()) {
 		let mut w = VecWriter(Vec::new());
 		monitor.write_for_disk(&mut w).unwrap();
-		let deserialized_copy = <(Sha256dHash, channelmonitor::ChannelMonitor)>::read(&mut Cursor::new(&w.0), logger.clone()).unwrap();
+		let deserialized_copy = <(Sha256dHash, channelmonitor::ChannelMonitor<EnforcingChannelKeys>)>::read(&mut Cursor::new(&w.0), logger.clone()).unwrap();
 		assert!(latest_block_hash == deserialized_copy.0);
 		assert!(monitor == deserialized_copy.1);
 		w.0.clear();

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -155,7 +155,7 @@ pub struct TxCreationKeys {
 }
 
 /// One counterparty's public keys which do not change over the life of a channel.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct ChannelPublicKeys {
 	/// The public key which is used to sign all commitment transactions, as it appears in the
 	/// on-chain channel lock-in 2-of-2 multisig output.


### PR DESCRIPTION
This is the first step to removing secret key handling from `ChannelMonitor`.

Further steps will include:

- moving left over signing operations into `ChannelKeys`
- eliminating the secret keys

I broke this into steps in order to reduce PR size, even though it does introduce some temporary redundancy.

BTW, I find the generic on `ChanSigner` to be somewhat painful.  It seems that the main reason for this is to have fast inline serialization.  Maybe there's a way to do that while keeping the `ChanSigner` dynamic.
