### PR TITLE
channel: fix not sending FundingLocked when channel minimum depth == 1

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2977,7 +2977,7 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 			self.channel_monitor.last_block_hash = self.last_block_connected;
 			if self.funding_tx_confirmations > 0 {
 				self.funding_tx_confirmations += 1;
-				if self.funding_tx_confirmations == self.minimum_depth as u64 {
+				if self.funding_tx_confirmations == self.minimum_depth as u64 || (self.minimum_depth == 1 && self.funding_tx_confirmations == self.minimum_depth as u64) {
 					let need_commitment_update = if non_shutdown_state == ChannelState::FundingSent as u32 {
 						self.channel_state |= ChannelState::OurFundingLocked as u32;
 						true


### PR DESCRIPTION
If `minimum_depth` is set to 1 we never send `FundingLocked`.

Once we enter `block_connected` after one confirmation the `funding_tx_confirmations` is incremented and we fail the `self.funding_tx_confirmations (2) == self.minimum_depth (1)` test on the next line.

I'm guessing there is a better way to fix this and perhaps a test to add. First time contributor here so please be gentle.