### PR TITLE
Refactor logic for setting initial_routing_sync feature bit

### DIFF
--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -604,6 +604,8 @@ pub trait RoutingMessageHandler : Send + Sync {
 	/// starting at the node *after* the provided publickey and including batch_amount entries.
 	/// If None is provided for starting_point, we start at the first node.
 	fn get_next_node_announcements(&self, starting_point: Option<&PublicKey>, batch_amount: u8) -> Vec<NodeAnnouncement>;
+	/// Returns whether a full sync should be requested from a peer.
+	fn should_request_full_sync(&self, node_id: &PublicKey) -> bool;
 }
 
 pub(crate) struct OnionRealm0HopData {

--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -1051,7 +1051,7 @@ mod tests {
 	use ln::channelmanager;
 	use ln::router::{Router,NodeInfo,NetworkMap,ChannelInfo,DirectionalChannelInfo,RouteHint};
 	use ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
-	use ln::msgs::{LightningError, ErrorAction};
+	use ln::msgs::{ErrorAction, LightningError, RoutingMessageHandler};
 	use util::test_utils;
 	use util::test_utils::TestVecWriter;
 	use util::logger::Logger;
@@ -1844,5 +1844,18 @@ mod tests {
 			network.write(&mut w).unwrap();
 			assert!(<NetworkMap>::read(&mut ::std::io::Cursor::new(&w.0)).unwrap() == *network);
 		}
+	}
+
+	#[test]
+	fn request_full_sync_finite_times() {
+		let (secp_ctx, _, router) = create_router();
+		let node_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&hex::decode("0202020202020202020202020202020202020202020202020202020202020202").unwrap()[..]).unwrap());
+
+		assert!(router.should_request_full_sync(&node_id));
+		assert!(router.should_request_full_sync(&node_id));
+		assert!(router.should_request_full_sync(&node_id));
+		assert!(router.should_request_full_sync(&node_id));
+		assert!(router.should_request_full_sync(&node_id));
+		assert!(!router.should_request_full_sync(&node_id));
 	}
 }

--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -1064,17 +1064,23 @@ mod tests {
 	use hex;
 
 	use secp256k1::key::{PublicKey,SecretKey};
+	use secp256k1::All;
 	use secp256k1::Secp256k1;
 
 	use std::sync::Arc;
 
-	#[test]
-	fn route_test() {
+	fn create_router() -> (Secp256k1<All>, PublicKey, Router) {
 		let secp_ctx = Secp256k1::new();
 		let our_id = PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&hex::decode("0101010101010101010101010101010101010101010101010101010101010101").unwrap()[..]).unwrap());
 		let logger: Arc<Logger> = Arc::new(test_utils::TestLogger::new());
 		let chain_monitor = Arc::new(chaininterface::ChainWatchInterfaceUtil::new(Network::Testnet, Arc::clone(&logger)));
 		let router = Router::new(our_id, chain_monitor, Arc::clone(&logger));
+		(secp_ctx, our_id, router)
+	}
+
+	#[test]
+	fn route_test() {
+		let (secp_ctx, our_id, router) = create_router();
 
 		// Build network from our_id to node8:
 		//

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -155,6 +155,9 @@ impl msgs::RoutingMessageHandler for TestRoutingMessageHandler {
 	fn get_next_node_announcements(&self, _starting_point: Option<&PublicKey>, _batch_amount: u8) -> Vec<msgs::NodeAnnouncement> {
 		Vec::new()
 	}
+	fn should_request_full_sync(&self, _node_id: &PublicKey) -> bool {
+		true
+	}
 }
 
 pub struct TestLogger {


### PR DESCRIPTION
Refactor logic for setting `initial_routing_sync` feature bit, moving it from `PeerManager` to `Router`. This eases an upcoming refactoring of peer_handler.rs and moves the logic to a more appropriate place since the router would know best as to whether a full sync is needed.