### PR TITLE
[chaininterface] Add ability for BlockNotifier to unregister listeners

### DIFF
--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -27,7 +27,8 @@ mod onion_utils;
 mod wire;
 
 #[cfg(test)]
-#[macro_use] mod functional_test_utils;
+#[macro_use]
+pub(crate) mod functional_test_utils;
 #[cfg(test)]
 mod functional_tests;
 #[cfg(test)]


### PR DESCRIPTION
This resolves #473.

Note: If a user has registered the _same_ listener multiple times, `unregister_listener` will remove **all** occurrences of that listener.