### PR TITLE
Fix incorrect docs/disconnect handling in peer_handler

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -217,7 +217,7 @@ impl<'a> Drop for MoneyLossDetector<'a> {
 			// Disconnect all peers
 			for (idx, peer) in self.peers.borrow().iter().enumerate() {
 				if *peer {
-					self.handler.disconnect_event(&Peer{id: idx as u8, peers_connected: &self.peers});
+					self.handler.socket_disconnected(&Peer{id: idx as u8, peers_connected: &self.peers});
 				}
 			}
 
@@ -378,7 +378,7 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 			2 => {
 				let peer_id = get_slice!(1)[0];
 				if !peers.borrow()[peer_id as usize] { return; }
-				loss_detector.handler.disconnect_event(&Peer{id: peer_id, peers_connected: &peers});
+				loss_detector.handler.socket_disconnected(&Peer{id: peer_id, peers_connected: &peers});
 				peers.borrow_mut()[peer_id as usize] = false;
 			},
 			3 => {

--- a/lightning-net-tokio/src/lib.rs
+++ b/lightning-net-tokio/src/lib.rs
@@ -59,7 +59,7 @@ impl Connection {
 					return future::Either::A(blocker.then(|_| { Ok(()) }));
 				}
 			}
-			//TODO: There's a race where we don't meet the requirements of disconnect_socket if its
+			//TODO: There's a race where we don't meet the requirements of socket_disconnected if its
 			//called right here, after we release the us_ref lock in the scope above, but before we
 			//call read_event!
 			match peer_manager.read_event(&mut SocketDescriptor::new(us_ref.clone(), peer_manager.clone()), pending_read) {
@@ -84,7 +84,7 @@ impl Connection {
 			future::Either::B(future::result(Ok(())))
 		}).then(move |_| {
 			if us_close_ref.lock().unwrap().need_disconnect {
-				peer_manager_ref.disconnect_event(&SocketDescriptor::new(us_close_ref, peer_manager_ref.clone()));
+				peer_manager_ref.socket_disconnected(&SocketDescriptor::new(us_close_ref, peer_manager_ref.clone()));
 				println!("Peer disconnected!");
 			} else {
 				println!("We disconnected peer!");


### PR DESCRIPTION
The way PeerHandler was written, it was supposed to remove from
self.peers iff the API docs indicate that disconnect_event should
NOT be called (and otherwise rely on disconnect_event to do so).

Sadly, the implementation was way out of whack with reality - in
the implementation, essentially anywhere where PeerHandler
originated the disconnection, the peer was removed and no
disconnect_event was expected. The docs, however, indicated that
disconnect_event should nearly only be called, only not doing so
when the initial handshake message never completed.

We opt to change the docs, mostly, as well as clean up the
ping/pong handling somewhat.

Frankly I'm not sure if lightning-net-tokio complies with this properly, but I'm gonna update #472 with the correct behavior in a sec.