### PR TITLE
Add an override optional UserConfig per new outbound channel

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -240,7 +240,7 @@ pub fn do_test(data: &[u8]) {
 	let mut channel_txn = Vec::new();
 	macro_rules! make_channel {
 		($source: expr, $dest: expr, $chan_id: expr) => { {
-			$source.create_channel($dest.get_our_node_id(), 10000000, 42, 0).unwrap();
+			$source.create_channel($dest.get_our_node_id(), 10000000, 42, 0, None).unwrap();
 			let open_channel = {
 				let events = $source.get_and_clear_pending_msg_events();
 				assert_eq!(events.len(), 1);

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -412,7 +412,7 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 				let their_key = get_pubkey!();
 				let chan_value = slice_to_be24(get_slice!(3)) as u64;
 				let push_msat_value = slice_to_be24(get_slice!(3)) as u64;
-				if channelmanager.create_channel(their_key, chan_value, push_msat_value, 0).is_err() { return; }
+				if channelmanager.create_channel(their_key, chan_value, push_msat_value, 0, None).is_err() { return; }
 			},
 			6 => {
 				let mut channels = channelmanager.list_channels();

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -1638,7 +1638,7 @@ fn do_during_funding_monitor_fail(fail_on_generate: bool, restore_between_fails:
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
 	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
-	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 43).unwrap();
+	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 43, None).unwrap();
 	nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), InitFeatures::supported(), &get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id()));
 	nodes[0].node.handle_accept_channel(&nodes[1].node.get_our_node_id(), InitFeatures::supported(), &get_event_msg!(nodes[1], MessageSendEvent::SendAcceptChannel, nodes[0].node.get_our_node_id()));
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -246,7 +246,7 @@ pub fn create_funding_transaction<'a, 'b, 'c>(node: &Node<'a, 'b, 'c>, expected_
 }
 
 pub fn create_chan_between_nodes_with_value_init<'a, 'b, 'c>(node_a: &Node<'a, 'b, 'c>, node_b: &Node<'a, 'b, 'c>, channel_value: u64, push_msat: u64, a_flags: InitFeatures, b_flags: InitFeatures) -> Transaction {
-	node_a.node.create_channel(node_b.node.get_our_node_id(), channel_value, push_msat, 42).unwrap();
+	node_a.node.create_channel(node_b.node.get_our_node_id(), channel_value, push_msat, 42, None).unwrap();
 	node_b.node.handle_open_channel(&node_a.node.get_our_node_id(), a_flags, &get_event_msg!(node_a, MessageSendEvent::SendOpenChannel, node_b.node.get_our_node_id()));
 	node_a.node.handle_accept_channel(&node_b.node.get_our_node_id(), b_flags, &get_event_msg!(node_b, MessageSendEvent::SendAcceptChannel, node_a.node.get_our_node_id()));
 


### PR DESCRIPTION
fixes #485 

This PR adds an optional `UserConfig` parameter when calling `create_channel()` in `ChannelManager`. 

The idea is that if this option is None, `ChannelManager` will revert to the `default_configuration` found in its own fields or the user can provide their own configuration for a particular channel.

Also to add that in the original issue, there was some discussion about implementing a tracked peer-per channel config as in a "whitelist" of pubkeys. It seems like an interesting idea, but I thought that would deserve its own attempt at a PR - since I think we would still need to switch between a `default` and an `override` config per channel.