### PR TITLE
Dont treat a timer tick as no_connection_possible

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1089,10 +1089,15 @@ impl<Descriptor: SocketDescriptor, CM: Deref> PeerManager<Descriptor, CM> where 
 					descriptors_needing_disconnect.push(descriptor.clone());
 					match peer.their_node_id {
 						Some(node_id) => {
+							log_trace!(self, "Disconnecting peer with id {} due to ping timeout", node_id);
 							node_id_to_descriptor.remove(&node_id);
-							self.message_handler.chan_handler.peer_disconnected(&node_id, true);
+							self.message_handler.chan_handler.peer_disconnected(&node_id, false);
 						}
-						None => {}
+						None => {
+							// This can't actually happen as we should have hit
+							// is_ready_for_encryption() previously on this same peer.
+							unreachable!();
+						},
 					}
 					return false;
 				}

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -755,10 +755,13 @@ impl<Descriptor: SocketDescriptor, CM: Deref> PeerManager<Descriptor, CM> where 
 
 											// Unknown messages:
 											wire::Message::Unknown(msg_type) if msg_type.is_even() => {
+												log_debug!(self, "Received unknown even message of type {}, disconnecting peer!", msg_type);
 												// Fail the channel if message is an even, unknown type as per BOLT #1.
 												return Err(PeerHandleError{ no_connection_possible: true });
 											},
-											wire::Message::Unknown(_) => {},
+											wire::Message::Unknown(msg_type) => {
+												log_trace!(self, "Received unknown odd message of type {}, ignoring", msg_type);
+											},
 										}
 									}
 								}


### PR DESCRIPTION
In testing, due to other patches, I managed to flood the send queue
with messages and cause us not to be able to send pings, thus
getting a peer disconnected for ping timeout. To my surprise, this
also force-closed all of my channels with that peeer.

Obviously a ping timeout does not indicate that no future connection
with said peer will be possible, and we shouldn't be force-closing
channels as a result.

This also logs when a peer is disconnected to ping timeout to make
debug easier.