### PR TITLE
Fix Router Serialization Roundtrip

### DIFF
--- a/fuzz/src/msg_targets/utils.rs
+++ b/fuzz/src/msg_targets/utils.rs
@@ -28,7 +28,7 @@ macro_rules! test_msg {
 		{
 			use lightning::util::ser::{Writeable, Readable};
 			let mut r = ::std::io::Cursor::new($data);
-			if let Ok(msg) = <$MsgType as Readable<::std::io::Cursor<&[u8]>>>::read(&mut r) {
+			if let Ok(msg) = <$MsgType as Readable>::read(&mut r) {
 				let p = r.position() as usize;
 				let mut w = VecWriter(Vec::new());
 				msg.write(&mut w).unwrap();
@@ -48,11 +48,11 @@ macro_rules! test_msg_simple {
 		{
 			use lightning::util::ser::{Writeable, Readable};
 			let mut r = ::std::io::Cursor::new($data);
-			if let Ok(msg) = <$MsgType as Readable<::std::io::Cursor<&[u8]>>>::read(&mut r) {
+			if let Ok(msg) = <$MsgType as Readable>::read(&mut r) {
 				let mut w = VecWriter(Vec::new());
 				msg.write(&mut w).unwrap();
 
-				let msg = <$MsgType as Readable<::std::io::Cursor<&[u8]>>>::read(&mut ::std::io::Cursor::new(&w.0)).unwrap();
+				let msg = <$MsgType as Readable>::read(&mut ::std::io::Cursor::new(&w.0)).unwrap();
 				let mut w_two = VecWriter(Vec::new());
 				msg.write(&mut w_two).unwrap();
 				assert_eq!(&w.0[..], &w_two.0[..]);
@@ -69,7 +69,7 @@ macro_rules! test_msg_exact {
 		{
 			use lightning::util::ser::{Writeable, Readable};
 			let mut r = ::std::io::Cursor::new($data);
-			if let Ok(msg) = <$MsgType as Readable<::std::io::Cursor<&[u8]>>>::read(&mut r) {
+			if let Ok(msg) = <$MsgType as Readable>::read(&mut r) {
 				let mut w = VecWriter(Vec::new());
 				msg.write(&mut w).unwrap();
 				assert_eq!(&r.into_inner()[..], &w.0[..]);
@@ -86,7 +86,7 @@ macro_rules! test_msg_hole {
 		{
 			use lightning::util::ser::{Writeable, Readable};
 			let mut r = ::std::io::Cursor::new($data);
-			if let Ok(msg) = <$MsgType as Readable<::std::io::Cursor<&[u8]>>>::read(&mut r) {
+			if let Ok(msg) = <$MsgType as Readable>::read(&mut r) {
 				let mut w = VecWriter(Vec::new());
 				msg.write(&mut w).unwrap();
 				let p = w.0.len() as usize;

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -115,8 +115,8 @@ impl Writeable for SpendableOutputDescriptor {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for SpendableOutputDescriptor {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
+impl Readable for SpendableOutputDescriptor {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
 		match Readable::read(reader)? {
 			0u8 => Ok(SpendableOutputDescriptor::StaticOutput {
 				outpoint: Readable::read(reader)?,
@@ -381,8 +381,8 @@ impl Writeable for InMemoryChannelKeys {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for InMemoryChannelKeys {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
+impl Readable for InMemoryChannelKeys {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
 		let funding_key = Readable::read(reader)?;
 		let revocation_base_key = Readable::read(reader)?;
 		let payment_base_key = Readable::read(reader)?;

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -156,8 +156,8 @@ impl Writeable for CounterpartyCommitmentSecrets {
 		Ok(())
 	}
 }
-impl<R: ::std::io::Read> Readable<R> for CounterpartyCommitmentSecrets {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
+impl Readable for CounterpartyCommitmentSecrets {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
 		let mut old_secrets = [([0; 32], 1 << 48); 49];
 		for &mut (ref mut secret, ref mut idx) in old_secrets.iter_mut() {
 			*secret = Readable::read(reader)?;
@@ -607,8 +607,8 @@ impl Writeable for LocalCommitmentTransaction {
 		Ok(())
 	}
 }
-impl<R: ::std::io::Read> Readable<R> for LocalCommitmentTransaction {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
+impl Readable for LocalCommitmentTransaction {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
 		let tx = match Transaction::consensus_decode(reader.by_ref()) {
 			Ok(tx) => tx,
 			Err(e) => match e {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3811,9 +3811,9 @@ impl Writeable for InboundHTLCRemovalReason {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for InboundHTLCRemovalReason {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
-		Ok(match <u8 as Readable<R>>::read(reader)? {
+impl Readable for InboundHTLCRemovalReason {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		Ok(match <u8 as Readable>::read(reader)? {
 			0 => InboundHTLCRemovalReason::FailRelay(Readable::read(reader)?),
 			1 => InboundHTLCRemovalReason::FailMalformed((Readable::read(reader)?, Readable::read(reader)?)),
 			2 => InboundHTLCRemovalReason::Fulfill(Readable::read(reader)?),
@@ -4022,8 +4022,8 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for Channel<ChanSigner> {
 	}
 }
 
-impl<R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, Arc<Logger>> for Channel<ChanSigner> {
-	fn read(reader: &mut R, logger: Arc<Logger>) -> Result<Self, DecodeError> {
+impl<ChanSigner: ChannelKeys + Readable> ReadableArgs<Arc<Logger>> for Channel<ChanSigner> {
+	fn read<R : ::std::io::Read>(reader: &mut R, logger: Arc<Logger>) -> Result<Self, DecodeError> {
 		let _ver: u8 = Readable::read(reader)?;
 		let min_ver: u8 = Readable::read(reader)?;
 		if min_ver > SERIALIZATION_VERSION {
@@ -4056,7 +4056,7 @@ impl<R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R,
 				amount_msat: Readable::read(reader)?,
 				cltv_expiry: Readable::read(reader)?,
 				payment_hash: Readable::read(reader)?,
-				state: match <u8 as Readable<R>>::read(reader)? {
+				state: match <u8 as Readable>::read(reader)? {
 					1 => InboundHTLCState::AwaitingRemoteRevokeToAnnounce(Readable::read(reader)?),
 					2 => InboundHTLCState::AwaitingAnnouncedRemoteRevoke(Readable::read(reader)?),
 					3 => InboundHTLCState::Committed,
@@ -4075,7 +4075,7 @@ impl<R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R,
 				cltv_expiry: Readable::read(reader)?,
 				payment_hash: Readable::read(reader)?,
 				source: Readable::read(reader)?,
-				state: match <u8 as Readable<R>>::read(reader)? {
+				state: match <u8 as Readable>::read(reader)? {
 					0 => OutboundHTLCState::LocalAnnounced(Box::new(Readable::read(reader)?)),
 					1 => OutboundHTLCState::Committed,
 					2 => OutboundHTLCState::RemoteRemoved(Readable::read(reader)?),
@@ -4089,7 +4089,7 @@ impl<R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R,
 		let holding_cell_htlc_update_count: u64 = Readable::read(reader)?;
 		let mut holding_cell_htlc_updates = Vec::with_capacity(cmp::min(holding_cell_htlc_update_count as usize, OUR_MAX_HTLCS as usize*2));
 		for _ in 0..holding_cell_htlc_update_count {
-			holding_cell_htlc_updates.push(match <u8 as Readable<R>>::read(reader)? {
+			holding_cell_htlc_updates.push(match <u8 as Readable>::read(reader)? {
 				0 => HTLCUpdateAwaitingACK::AddHTLC {
 					amount_msat: Readable::read(reader)?,
 					cltv_expiry: Readable::read(reader)?,
@@ -4109,7 +4109,7 @@ impl<R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R,
 			});
 		}
 
-		let resend_order = match <u8 as Readable<R>>::read(reader)? {
+		let resend_order = match <u8 as Readable>::read(reader)? {
 			0 => RAACommitmentOrder::CommitmentFirst,
 			1 => RAACommitmentOrder::RevokeAndACKFirst,
 			_ => return Err(DecodeError::InvalidValue),
@@ -4139,7 +4139,7 @@ impl<R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R,
 		let channel_update_count = Readable::read(reader)?;
 		let feerate_per_kw = Readable::read(reader)?;
 
-		let last_sent_closing_fee = match <u8 as Readable<R>>::read(reader)? {
+		let last_sent_closing_fee = match <u8 as Readable>::read(reader)? {
 			0 => None,
 			1 => Some((Readable::read(reader)?, Readable::read(reader)?, Readable::read(reader)?)),
 			_ => return Err(DecodeError::InvalidValue),

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3883,18 +3883,6 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for Channel<ChanSigner> {
 			}
 		}
 
-		macro_rules! write_option {
-			($thing: expr) => {
-				match &$thing {
-					&None => 0u8.write(writer)?,
-					&Some(ref v) => {
-						1u8.write(writer)?;
-						v.write(writer)?;
-					},
-				}
-			}
-		}
-
 		(self.pending_outbound_htlcs.len() as u64).write(writer)?;
 		for htlc in self.pending_outbound_htlcs.iter() {
 			htlc.htlc_id.write(writer)?;
@@ -3912,15 +3900,15 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for Channel<ChanSigner> {
 				},
 				&OutboundHTLCState::RemoteRemoved(ref fail_reason) => {
 					2u8.write(writer)?;
-					write_option!(*fail_reason);
+					fail_reason.write(writer)?;
 				},
 				&OutboundHTLCState::AwaitingRemoteRevokeToRemove(ref fail_reason) => {
 					3u8.write(writer)?;
-					write_option!(*fail_reason);
+					fail_reason.write(writer)?;
 				},
 				&OutboundHTLCState::AwaitingRemovedRemoteRevoke(ref fail_reason) => {
 					4u8.write(writer)?;
-					write_option!(*fail_reason);
+					fail_reason.write(writer)?;
 				},
 			}
 		}
@@ -3971,8 +3959,8 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for Channel<ChanSigner> {
 			fail_reason.write(writer)?;
 		}
 
-		write_option!(self.pending_update_fee);
-		write_option!(self.holding_cell_update_fee);
+		self.pending_update_fee.write(writer)?;
+		self.holding_cell_update_fee.write(writer)?;
 
 		self.next_local_htlc_id.write(writer)?;
 		(self.next_remote_htlc_id - dropped_inbound_htlcs).write(writer)?;
@@ -3989,9 +3977,9 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for Channel<ChanSigner> {
 			None => 0u8.write(writer)?,
 		}
 
-		write_option!(self.funding_txo);
-		write_option!(self.funding_tx_confirmed_in);
-		write_option!(self.short_channel_id);
+		self.funding_txo.write(writer)?;
+		self.funding_tx_confirmed_in.write(writer)?;
+		self.short_channel_id.write(writer)?;
 
 		self.last_block_connected.write(writer)?;
 		self.funding_tx_confirmations.write(writer)?;
@@ -4007,13 +3995,13 @@ impl<ChanSigner: ChannelKeys + Writeable> Writeable for Channel<ChanSigner> {
 		self.their_max_accepted_htlcs.write(writer)?;
 		self.minimum_depth.write(writer)?;
 
-		write_option!(self.their_pubkeys);
-		write_option!(self.their_cur_commitment_point);
+		self.their_pubkeys.write(writer)?;
+		self.their_cur_commitment_point.write(writer)?;
 
-		write_option!(self.their_prev_commitment_point);
+		self.their_prev_commitment_point.write(writer)?;
 		self.their_node_id.write(writer)?;
 
-		write_option!(self.their_shutdown_scriptpubkey);
+		self.their_shutdown_scriptpubkey.write(writer)?;
 
 		self.commitment_secrets.write(writer)?;
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3062,8 +3062,8 @@ impl Writeable for PendingHTLCInfo {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for PendingHTLCInfo {
-	fn read(reader: &mut R) -> Result<PendingHTLCInfo, DecodeError> {
+impl Readable for PendingHTLCInfo {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<PendingHTLCInfo, DecodeError> {
 		Ok(PendingHTLCInfo {
 			onion_packet: Readable::read(reader)?,
 			incoming_shared_secret: Readable::read(reader)?,
@@ -3091,9 +3091,9 @@ impl Writeable for HTLCFailureMsg {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for HTLCFailureMsg {
-	fn read(reader: &mut R) -> Result<HTLCFailureMsg, DecodeError> {
-		match <u8 as Readable<R>>::read(reader)? {
+impl Readable for HTLCFailureMsg {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<HTLCFailureMsg, DecodeError> {
+		match <u8 as Readable>::read(reader)? {
 			0 => Ok(HTLCFailureMsg::Relay(Readable::read(reader)?)),
 			1 => Ok(HTLCFailureMsg::Malformed(Readable::read(reader)?)),
 			_ => Err(DecodeError::InvalidValue),
@@ -3117,9 +3117,9 @@ impl Writeable for PendingHTLCStatus {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for PendingHTLCStatus {
-	fn read(reader: &mut R) -> Result<PendingHTLCStatus, DecodeError> {
-		match <u8 as Readable<R>>::read(reader)? {
+impl Readable for PendingHTLCStatus {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<PendingHTLCStatus, DecodeError> {
+		match <u8 as Readable>::read(reader)? {
 			0 => Ok(PendingHTLCStatus::Forward(Readable::read(reader)?)),
 			1 => Ok(PendingHTLCStatus::Fail(Readable::read(reader)?)),
 			_ => Err(DecodeError::InvalidValue),
@@ -3151,9 +3151,9 @@ impl Writeable for HTLCSource {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for HTLCSource {
-	fn read(reader: &mut R) -> Result<HTLCSource, DecodeError> {
-		match <u8 as Readable<R>>::read(reader)? {
+impl Readable for HTLCSource {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<HTLCSource, DecodeError> {
+		match <u8 as Readable>::read(reader)? {
 			0 => Ok(HTLCSource::PreviousHopData(Readable::read(reader)?)),
 			1 => Ok(HTLCSource::OutboundRoute {
 				route: Readable::read(reader)?,
@@ -3182,9 +3182,9 @@ impl Writeable for HTLCFailReason {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for HTLCFailReason {
-	fn read(reader: &mut R) -> Result<HTLCFailReason, DecodeError> {
-		match <u8 as Readable<R>>::read(reader)? {
+impl Readable for HTLCFailReason {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<HTLCFailReason, DecodeError> {
+		match <u8 as Readable>::read(reader)? {
 			0 => Ok(HTLCFailReason::LightningError { err: Readable::read(reader)? }),
 			1 => Ok(HTLCFailReason::Reason {
 				failure_code: Readable::read(reader)?,
@@ -3214,9 +3214,9 @@ impl Writeable for HTLCForwardInfo {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for HTLCForwardInfo {
-	fn read(reader: &mut R) -> Result<HTLCForwardInfo, DecodeError> {
-		match <u8 as Readable<R>>::read(reader)? {
+impl Readable for HTLCForwardInfo {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<HTLCForwardInfo, DecodeError> {
+		match <u8 as Readable>::read(reader)? {
 			0 => Ok(HTLCForwardInfo::AddHTLC {
 				prev_short_channel_id: Readable::read(reader)?,
 				prev_htlc_id: Readable::read(reader)?,
@@ -3355,27 +3355,27 @@ pub struct ChannelManagerReadArgs<'a, ChanSigner: 'a + ChannelKeys, M: Deref, T:
 
 // Implement ReadableArgs for an Arc'd ChannelManager to make it a bit easier to work with the
 // SipmleArcChannelManager type:
-impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>, M: Deref, T: Deref, K: Deref, F: Deref>
-	ReadableArgs<R, ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>> for (Sha256dHash, Arc<ChannelManager<ChanSigner, M, T, K, F>>)
+impl<'a, ChanSigner: ChannelKeys + Readable, M: Deref, T: Deref, K: Deref, F: Deref>
+	ReadableArgs<ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>> for (Sha256dHash, Arc<ChannelManager<ChanSigner, M, T, K, F>>)
 	where M::Target: ManyChannelMonitor<ChanSigner>,
         T::Target: BroadcasterInterface,
         K::Target: KeysInterface<ChanKeySigner = ChanSigner>,
         F::Target: FeeEstimator,
 {
-	fn read(reader: &mut R, args: ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>) -> Result<Self, DecodeError> {
+	fn read<R: ::std::io::Read>(reader: &mut R, args: ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>) -> Result<Self, DecodeError> {
 		let (blockhash, chan_manager) = <(Sha256dHash, ChannelManager<ChanSigner, M, T, K, F>)>::read(reader, args)?;
 		Ok((blockhash, Arc::new(chan_manager)))
 	}
 }
 
-impl<'a, R : ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>, M: Deref, T: Deref, K: Deref, F: Deref>
-	ReadableArgs<R, ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>> for (Sha256dHash, ChannelManager<ChanSigner, M, T, K, F>)
+impl<'a, ChanSigner: ChannelKeys + Readable, M: Deref, T: Deref, K: Deref, F: Deref>
+	ReadableArgs<ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>> for (Sha256dHash, ChannelManager<ChanSigner, M, T, K, F>)
 	where M::Target: ManyChannelMonitor<ChanSigner>,
         T::Target: BroadcasterInterface,
         K::Target: KeysInterface<ChanKeySigner = ChanSigner>,
         F::Target: FeeEstimator,
 {
-	fn read(reader: &mut R, args: ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>) -> Result<Self, DecodeError> {
+	fn read<R: ::std::io::Read>(reader: &mut R, args: ChannelManagerReadArgs<'a, ChanSigner, M, T, K, F>) -> Result<Self, DecodeError> {
 		let _ver: u8 = Readable::read(reader)?;
 		let min_ver: u8 = Readable::read(reader)?;
 		if min_ver > SERIALIZATION_VERSION {

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -72,8 +72,8 @@ impl Writeable for ChannelMonitorUpdate {
 		Ok(())
 	}
 }
-impl<R: ::std::io::Read> Readable<R> for ChannelMonitorUpdate {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for ChannelMonitorUpdate {
+	fn read<R: ::std::io::Read>(r: &mut R) -> Result<Self, DecodeError> {
 		let update_id: u64 = Readable::read(r)?;
 		let len: u64 = Readable::read(r)?;
 		let mut updates = Vec::with_capacity(cmp::min(len as usize, MAX_ALLOC_SIZE / ::std::mem::size_of::<ChannelMonitorUpdateStep>()));
@@ -517,14 +517,14 @@ impl Writeable for InputMaterial  {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for InputMaterial {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
-		let input_material = match <u8 as Readable<R>>::read(reader)? {
+impl Readable for InputMaterial {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		let input_material = match <u8 as Readable>::read(reader)? {
 			0 => {
 				let script = Readable::read(reader)?;
 				let pubkey = Readable::read(reader)?;
 				let key = Readable::read(reader)?;
-				let is_htlc = match <u8 as Readable<R>>::read(reader)? {
+				let is_htlc = match <u8 as Readable>::read(reader)? {
 					0 => true,
 					1 => false,
 					_ => return Err(DecodeError::InvalidValue),
@@ -624,8 +624,8 @@ impl Writeable for ClaimTxBumpMaterial  {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for ClaimTxBumpMaterial {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
+impl Readable for ClaimTxBumpMaterial {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
 		let height_timer = Readable::read(reader)?;
 		let feerate_previous = Readable::read(reader)?;
 		let soonest_timelock = Readable::read(reader)?;
@@ -724,8 +724,8 @@ impl Writeable for ChannelMonitorUpdateStep {
 		Ok(())
 	}
 }
-impl<R: ::std::io::Read> Readable<R> for ChannelMonitorUpdateStep {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for ChannelMonitorUpdateStep {
+	fn read<R: ::std::io::Read>(r: &mut R) -> Result<Self, DecodeError> {
 		match Readable::read(r)? {
 			0u8 => {
 				Ok(ChannelMonitorUpdateStep::LatestLocalCommitmentTXInfo {
@@ -751,7 +751,7 @@ impl<R: ::std::io::Read> Readable<R> for ChannelMonitorUpdateStep {
 						let len: u64 = Readable::read(r)?;
 						let mut res = Vec::new();
 						for _ in 0..len {
-							res.push((Readable::read(r)?, <Option<HTLCSource> as Readable<R>>::read(r)?.map(|o| Box::new(o))));
+							res.push((Readable::read(r)?, <Option<HTLCSource> as Readable>::read(r)?.map(|o| Box::new(o))));
 						}
 						res
 					},
@@ -3191,8 +3191,8 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 
 const MAX_ALLOC_SIZE: usize = 64*1024;
 
-impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, Arc<Logger>> for (Sha256dHash, ChannelMonitor<ChanSigner>) {
-	fn read(reader: &mut R, logger: Arc<Logger>) -> Result<Self, DecodeError> {
+impl<ChanSigner: ChannelKeys + Readable> ReadableArgs<Arc<Logger>> for (Sha256dHash, ChannelMonitor<ChanSigner>) {
+	fn read<R: ::std::io::Read>(reader: &mut R, logger: Arc<Logger>) -> Result<Self, DecodeError> {
 		let secp_ctx = Secp256k1::new();
 		macro_rules! unwrap_obj {
 			($key: expr) => {
@@ -3210,9 +3210,9 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 		}
 
 		let latest_update_id: u64 = Readable::read(reader)?;
-		let commitment_transaction_number_obscure_factor = <U48 as Readable<R>>::read(reader)?.0;
+		let commitment_transaction_number_obscure_factor = <U48 as Readable>::read(reader)?.0;
 
-		let key_storage = match <u8 as Readable<R>>::read(reader)? {
+		let key_storage = match <u8 as Readable>::read(reader)? {
 			0 => {
 				let keys = Readable::read(reader)?;
 				let funding_key = Readable::read(reader)?;
@@ -3252,7 +3252,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 		let channel_value_satoshis = Some(Readable::read(reader)?);
 
 		let their_cur_revocation_points = {
-			let first_idx = <U48 as Readable<R>>::read(reader)?.0;
+			let first_idx = <U48 as Readable>::read(reader)?.0;
 			if first_idx == 0 {
 				None
 			} else {
@@ -3294,7 +3294,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 			let htlcs_count: u64 = Readable::read(reader)?;
 			let mut htlcs = Vec::with_capacity(cmp::min(htlcs_count as usize, MAX_ALLOC_SIZE / 32));
 			for _ in 0..htlcs_count {
-				htlcs.push((read_htlc_in_commitment!(), <Option<HTLCSource> as Readable<R>>::read(reader)?.map(|o: HTLCSource| Box::new(o))));
+				htlcs.push((read_htlc_in_commitment!(), <Option<HTLCSource> as Readable>::read(reader)?.map(|o: HTLCSource| Box::new(o))));
 			}
 			if let Some(_) = remote_claimable_outpoints.insert(txid, htlcs) {
 				return Err(DecodeError::InvalidValue);
@@ -3305,8 +3305,8 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 		let mut remote_commitment_txn_on_chain = HashMap::with_capacity(cmp::min(remote_commitment_txn_on_chain_len as usize, MAX_ALLOC_SIZE / 32));
 		for _ in 0..remote_commitment_txn_on_chain_len {
 			let txid: Sha256dHash = Readable::read(reader)?;
-			let commitment_number = <U48 as Readable<R>>::read(reader)?.0;
-			let outputs_count = <u64 as Readable<R>>::read(reader)?;
+			let commitment_number = <U48 as Readable>::read(reader)?.0;
+			let outputs_count = <u64 as Readable>::read(reader)?;
 			let mut outputs = Vec::with_capacity(cmp::min(outputs_count as usize, MAX_ALLOC_SIZE / 8));
 			for _ in 0..outputs_count {
 				outputs.push(Readable::read(reader)?);
@@ -3320,7 +3320,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 		let mut remote_hash_commitment_number = HashMap::with_capacity(cmp::min(remote_hash_commitment_number_len as usize, MAX_ALLOC_SIZE / 32));
 		for _ in 0..remote_hash_commitment_number_len {
 			let payment_hash: PaymentHash = Readable::read(reader)?;
-			let commitment_number = <U48 as Readable<R>>::read(reader)?.0;
+			let commitment_number = <U48 as Readable>::read(reader)?.0;
 			if let Some(_) = remote_hash_commitment_number.insert(payment_hash, commitment_number) {
 				return Err(DecodeError::InvalidValue);
 			}
@@ -3329,7 +3329,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 		macro_rules! read_local_tx {
 			() => {
 				{
-					let tx = <LocalCommitmentTransaction as Readable<R>>::read(reader)?;
+					let tx = <LocalCommitmentTransaction as Readable>::read(reader)?;
 					let revocation_key = Readable::read(reader)?;
 					let a_htlc_key = Readable::read(reader)?;
 					let b_htlc_key = Readable::read(reader)?;
@@ -3341,7 +3341,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 					let mut htlcs = Vec::with_capacity(cmp::min(htlcs_len as usize, MAX_ALLOC_SIZE / 128));
 					for _ in 0..htlcs_len {
 						let htlc = read_htlc_in_commitment!();
-						let sigs = match <u8 as Readable<R>>::read(reader)? {
+						let sigs = match <u8 as Readable>::read(reader)? {
 							0 => None,
 							1 => Some(Readable::read(reader)?),
 							_ => return Err(DecodeError::InvalidValue),
@@ -3358,7 +3358,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 			}
 		}
 
-		let prev_local_signed_commitment_tx = match <u8 as Readable<R>>::read(reader)? {
+		let prev_local_signed_commitment_tx = match <u8 as Readable>::read(reader)? {
 			0 => None,
 			1 => {
 				Some(read_local_tx!())
@@ -3366,7 +3366,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 			_ => return Err(DecodeError::InvalidValue),
 		};
 
-		let current_local_signed_commitment_tx = match <u8 as Readable<R>>::read(reader)? {
+		let current_local_signed_commitment_tx = match <u8 as Readable>::read(reader)? {
 			0 => None,
 			1 => {
 				Some(read_local_tx!())
@@ -3374,7 +3374,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 			_ => return Err(DecodeError::InvalidValue),
 		};
 
-		let current_remote_commitment_number = <U48 as Readable<R>>::read(reader)?.0;
+		let current_remote_commitment_number = <U48 as Readable>::read(reader)?.0;
 
 		let payment_preimages_len: u64 = Readable::read(reader)?;
 		let mut payment_preimages = HashMap::with_capacity(cmp::min(payment_preimages_len as usize, MAX_ALLOC_SIZE / 32));
@@ -3402,7 +3402,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 
 		let last_block_hash: Sha256dHash = Readable::read(reader)?;
 		let destination_script = Readable::read(reader)?;
-		let to_remote_rescue = match <u8 as Readable<R>>::read(reader)? {
+		let to_remote_rescue = match <u8 as Readable>::read(reader)? {
 			0 => None,
 			1 => {
 				let to_remote_script = Readable::read(reader)?;
@@ -3434,7 +3434,7 @@ impl<R: ::std::io::Read, ChanSigner: ChannelKeys + Readable<R>> ReadableArgs<R, 
 			let events_len: u64 = Readable::read(reader)?;
 			let mut events = Vec::with_capacity(cmp::min(events_len as usize, MAX_ALLOC_SIZE / 128));
 			for _ in 0..events_len {
-				let ev = match <u8 as Readable<R>>::read(reader)? {
+				let ev = match <u8 as Readable>::read(reader)? {
 					0 => {
 						let claim_request = Readable::read(reader)?;
 						OnchainEvent::Claim {

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -283,8 +283,8 @@ impl<T: sealed::Context> Writeable for Features<T> {
 	}
 }
 
-impl<R: ::std::io::Read, T: sealed::Context> Readable<R> for Features<T> {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl<T: sealed::Context> Readable for Features<T> {
+	fn read<R: ::std::io::Read>(r: &mut R) -> Result<Self, DecodeError> {
 		let mut flags: Vec<u8> = Readable::read(r)?;
 		flags.reverse(); // Swap to little-endian
 		Ok(Self {

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -336,9 +336,9 @@ impl Writeable for NetAddress {
 	}
 }
 
-impl<R: ::std::io::Read>  Readable<R> for Result<NetAddress, u8> {
-	fn read(reader: &mut R) -> Result<Result<NetAddress, u8>, DecodeError> {
-		let byte = <u8 as Readable<R>>::read(reader)?;
+impl Readable for Result<NetAddress, u8> {
+	fn read<R: Read>(reader: &mut R) -> Result<Result<NetAddress, u8>, DecodeError> {
+		let byte = <u8 as Readable>::read(reader)?;
 		match byte {
 			1 => {
 				Ok(Ok(NetAddress::IPv4 {
@@ -718,9 +718,9 @@ impl Writeable for OptionalField<Script> {
 	}
 }
 
-impl<R: Read> Readable<R> for OptionalField<Script> {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
-		match <u16 as Readable<R>>::read(r) {
+impl Readable for OptionalField<Script> {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
+		match <u16 as Readable>::read(r) {
 			Ok(len) => {
 				let mut buf = vec![0; len as usize];
 				r.read_exact(&mut buf)?;
@@ -777,14 +777,14 @@ impl Writeable for ChannelReestablish {
 	}
 }
 
-impl<R: Read> Readable<R> for ChannelReestablish{
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for ChannelReestablish{
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(Self {
 			channel_id: Readable::read(r)?,
 			next_local_commitment_number: Readable::read(r)?,
 			next_remote_commitment_number: Readable::read(r)?,
 			data_loss_protect: {
-				match <[u8; 32] as Readable<R>>::read(r) {
+				match <[u8; 32] as Readable>::read(r) {
 					Ok(your_last_per_commitment_secret) =>
 						OptionalField::Present(DataLossProtect {
 							your_last_per_commitment_secret,
@@ -846,8 +846,8 @@ impl Writeable for Init {
 	}
 }
 
-impl<R: Read> Readable<R> for Init {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for Init {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		let global_features: InitFeatures = Readable::read(r)?;
 		let features: InitFeatures = Readable::read(r)?;
 		Ok(Init {
@@ -940,8 +940,8 @@ impl Writeable for OnionPacket {
 	}
 }
 
-impl<R: Read> Readable<R> for OnionPacket {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for OnionPacket {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(OnionPacket {
 			version: Readable::read(r)?,
 			public_key: {
@@ -993,8 +993,8 @@ impl Writeable for OnionHopData {
 	}
 }
 
-impl<R: Read> Readable<R> for OnionHopData {
-	fn read(mut r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for OnionHopData {
+	fn read<R: Read>(mut r: &mut R) -> Result<Self, DecodeError> {
 		use bitcoin::consensus::encode::{Decodable, Error, VarInt};
 		let v: VarInt = Decodable::consensus_decode(&mut r)
 			.map_err(|e| match e {
@@ -1049,8 +1049,8 @@ impl Writeable for Ping {
 	}
 }
 
-impl<R: Read> Readable<R> for Ping {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for Ping {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(Ping {
 			ponglen: Readable::read(r)?,
 			byteslen: {
@@ -1070,8 +1070,8 @@ impl Writeable for Pong {
 	}
 }
 
-impl<R: Read> Readable<R> for Pong {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for Pong {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(Pong {
 			byteslen: {
 				let byteslen = Readable::read(r)?;
@@ -1097,8 +1097,8 @@ impl Writeable for UnsignedChannelAnnouncement {
 	}
 }
 
-impl<R: Read> Readable<R> for UnsignedChannelAnnouncement {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for UnsignedChannelAnnouncement {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(Self {
 			features: Readable::read(r)?,
 			chain_hash: Readable::read(r)?,
@@ -1143,8 +1143,8 @@ impl Writeable for UnsignedChannelUpdate {
 	}
 }
 
-impl<R: Read> Readable<R> for UnsignedChannelUpdate {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for UnsignedChannelUpdate {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(Self {
 			chain_hash: Readable::read(r)?,
 			short_channel_id: Readable::read(r)?,
@@ -1181,12 +1181,12 @@ impl Writeable for ErrorMessage {
 	}
 }
 
-impl<R: Read> Readable<R> for ErrorMessage {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for ErrorMessage {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		Ok(Self {
 			channel_id: Readable::read(r)?,
 			data: {
-				let mut sz: usize = <u16 as Readable<R>>::read(r)? as usize;
+				let mut sz: usize = <u16 as Readable>::read(r)? as usize;
 				let mut data = vec![];
 				let data_len = r.read_to_end(&mut data)?;
 				sz = cmp::min(data_len, sz);
@@ -1225,8 +1225,8 @@ impl Writeable for UnsignedNodeAnnouncement {
 	}
 }
 
-impl<R: Read> Readable<R> for UnsignedNodeAnnouncement {
-	fn read(r: &mut R) -> Result<Self, DecodeError> {
+impl Readable for UnsignedNodeAnnouncement {
+	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {
 		let features: NodeFeatures = Readable::read(r)?;
 		let timestamp: u32 = Readable::read(r)?;
 		let node_id: PublicKey = Readable::read(r)?;

--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -71,8 +71,8 @@ impl Writeable for Route {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for Route {
-	fn read(reader: &mut R) -> Result<Route, DecodeError> {
+impl Readable for Route {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Route, DecodeError> {
 		let hops_count: u8 = Readable::read(reader)?;
 		let mut hops = Vec::with_capacity(hops_count as usize);
 		for _ in 0..hops_count {
@@ -195,8 +195,8 @@ impl Writeable for NodeInfo {
 
 const MAX_ALLOC_SIZE: u64 = 64*1024;
 
-impl<R: ::std::io::Read> Readable<R> for NodeInfo {
-	fn read(reader: &mut R) -> Result<NodeInfo, DecodeError> {
+impl Readable for NodeInfo {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<NodeInfo, DecodeError> {
 		let channels_count: u64 = Readable::read(reader)?;
 		let mut channels = Vec::with_capacity(cmp::min(channels_count, MAX_ALLOC_SIZE / 8) as usize);
 		for _ in 0..channels_count {
@@ -261,8 +261,8 @@ impl Writeable for NetworkMap {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for NetworkMap {
-	fn read(reader: &mut R) -> Result<NetworkMap, DecodeError> {
+impl Readable for NetworkMap {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<NetworkMap, DecodeError> {
 		let channels_count: u64 = Readable::read(reader)?;
 		let mut channels = BTreeMap::new();
 		for _ in 0..channels_count {
@@ -381,8 +381,8 @@ pub struct RouterReadArgs {
 	pub logger: Arc<Logger>,
 }
 
-impl<R: ::std::io::Read> ReadableArgs<R, RouterReadArgs> for Router {
-	fn read(reader: &mut R, args: RouterReadArgs) -> Result<Router, DecodeError> {
+impl ReadableArgs<RouterReadArgs> for Router {
+	fn read<R: ::std::io::Read>(reader: &mut R, args: RouterReadArgs) -> Result<Router, DecodeError> {
 		let _ver: u8 = Readable::read(reader)?;
 		let min_ver: u8 = Readable::read(reader)?;
 		if min_ver > SERIALIZATION_VERSION {

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -106,7 +106,7 @@ impl ::std::fmt::Display for MessageType {
 ///
 /// Returns an error if the message payload code not be decoded as the specified type.
 pub fn read<R: ::std::io::Read>(buffer: &mut R) -> Result<Message, msgs::DecodeError> {
-	let message_type = <u16 as Readable<R>>::read(buffer)?;
+	let message_type = <u16 as Readable>::read(buffer)?;
 	match message_type {
 		msgs::Init::TYPE => {
 			Ok(Message::Init(Readable::read(buffer)?))

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -101,8 +101,8 @@ impl Writeable for EnforcingChannelKeys {
 	}
 }
 
-impl<R: ::std::io::Read> Readable<R> for EnforcingChannelKeys {
-	fn read(reader: &mut R) -> Result<Self, DecodeError> {
+impl Readable for EnforcingChannelKeys {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
 		let inner = Readable::read(reader)?;
 		let obscure_and_last = Readable::read(reader)?;
 		Ok(EnforcingChannelKeys {

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -154,8 +154,8 @@ impl Writeable for Event {
 		Ok(())
 	}
 }
-impl<R: ::std::io::Read> MaybeReadable<R> for Event {
-	fn read(reader: &mut R) -> Result<Option<Self>, msgs::DecodeError> {
+impl MaybeReadable for Event {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Option<Self>, msgs::DecodeError> {
 		match Readable::read(reader)? {
 			0u8 => Ok(None),
 			1u8 => Ok(Some(Event::FundingBroadcastSafe {

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -116,8 +116,8 @@ macro_rules! impl_writeable {
 			}
 		}
 
-		impl<R: ::std::io::Read> ::util::ser::Readable<R> for $st {
-			fn read(r: &mut R) -> Result<Self, ::ln::msgs::DecodeError> {
+		impl ::util::ser::Readable for $st {
+			fn read<R: ::std::io::Read>(r: &mut R) -> Result<Self, ::ln::msgs::DecodeError> {
 				Ok(Self {
 					$($field: ::util::ser::Readable::read(r)?),*
 				})
@@ -137,8 +137,8 @@ macro_rules! impl_writeable_len_match {
 			}
 		}
 
-		impl<R: ::std::io::Read> Readable<R> for $st {
-			fn read(r: &mut R) -> Result<Self, DecodeError> {
+		impl ::util::ser::Readable for $st {
+			fn read<R: ::std::io::Read>(r: &mut R) -> Result<Self, DecodeError> {
 				Ok(Self {
 					$($field: Readable::read(r)?),*
 				})
@@ -219,9 +219,9 @@ mod tests {
 			(0xdeadbeef1badbeef, 0x1bad1dea, Some(0x01020304)));
 	}
 
-	impl<R: Read> Readable<R> for (PublicKey, u64, u64) {
+	impl Readable for (PublicKey, u64, u64) {
 		#[inline]
-		fn read(reader: &mut R) -> Result<(PublicKey, u64, u64), DecodeError> {
+		fn read<R: Read>(reader: &mut R) -> Result<(PublicKey, u64, u64), DecodeError> {
 			Ok((Readable::read(reader)?, Readable::read(reader)?, Readable::read(reader)?))
 		}
 	}


### PR DESCRIPTION
In channel/node announcement/updates, we will read_to_end on the input stream to ensure we store any excess bytes at the end. This is great, until we try to go read a Router that contains a bunch of these messages in them, causing us to read data that is unrelated into the messages. To fix, we modify the Option<T> format to write out the length of the object, and then use a LengthLimitingReader to read the T.

This requires we change the Readable trait to have a template in the read function instead of the trait due to lifetime issues, but this change stands on its own as it makes our Readable/Writeable traits symmetric.