### PR TITLE
[travis] Build lightning-net-tokio on Rust 1.39.0+, fuzz on stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ language: rust
 rust:
   - stable
   - beta
+  # 1.22.0 is MSRV for rust-lightning in general:
   - 1.22.0
+  # 1.34.2 is Debian stable
   - 1.34.2
+  # 1.39.0 is MSRV for lightning-net-tokio and generates coverage
+  - 1.39.0
 cache: cargo
 
 before_install:
@@ -11,18 +15,20 @@ before_install:
   - sudo apt-get install -y binutils-dev libunwind8-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc binutils-dev libiberty-dev
 
 script:
-     # Build workspaces with Rust stable, beta, and 1.34.0
-     - if [ "$(rustup show | grep default | grep 1.22.0)" == "" ]; then RUSTFLAGS="-C link-dead-code" cargo build --verbose; fi
-     # Build lightning workspace with Rust 1.22.0
-     - if [ "$(rustup show | grep default | grep 1.22.0)" != "" ]; then RUSTFLAGS="-C link-dead-code" cargo build --verbose -p lightning; fi
+     # Support lightning-net-tokio only on Rust stable, beta, and 1.39.0
+     - if [ "$(rustup show | grep default | grep '1.39.0')" != "" ]; then export BUILD_NET_TOKIO=1; fi
+     - if [ "$(rustup show | grep default | grep '1\.')" == "" ]; then export BUILD_NET_TOKIO=1; fi
+     # Build the appropriate workspace(s)
+     - if [ "$BUILD_NET_TOKIO" == "1" ]; then RUSTFLAGS="-C link-dead-code" cargo build --verbose; fi
+     - if [ "$BUILD_NET_TOKIO" != "1" ]; then RUSTFLAGS="-C link-dead-code" cargo build --verbose -p lightning; fi
      - rm -f target/debug/lightning-* # Make sure we drop old test binaries
-     # Test workspaces for Rust stable, beta, and 1.34.2
-     - if [ "$(rustup show | grep default | grep 1.22.0)" == "" ]; then RUSTFLAGS="-C link-dead-code" cargo test --verbose; fi
-     # Test lightning workspace for 1.22.0
-     - if [ "$(rustup show | grep default | grep 1.22.0)" != "" ]; then RUSTFLAGS="-C link-dead-code" cargo test --verbose -p lightning; fi
-     # Run lightning workspace fuzz tests for Rust 1.34.2
-     - if [ "$(rustup show | grep default | grep 1.34.2)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi
-     - if [ "$(rustup show | grep default | grep stable)" != "" ]; then
+     # Test the appropriate workspace(s)
+     - if [ "$BUILD_NET_TOKIO" == "1" ]; then RUSTFLAGS="-C link-dead-code" cargo test --verbose; fi
+     - if [ "$BUILD_NET_TOKIO" != "1" ]; then RUSTFLAGS="-C link-dead-code" cargo test --verbose -p lightning; fi
+     # Run lightning workspace fuzz tests on Rust stable
+     - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi
+     # Generate code cov information on Rust 1.39.0
+     - if [ "$(rustup show | grep default | grep 1.39.0)" != "" ]; then
            wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz &&
            tar xzf master.tar.gz &&
            cd kcov-master &&


### PR DESCRIPTION
This disables building the lightning-net-tokio crate on 1.34.2 on
Travis in anticiption of relying on async/await for
lightning-net-tokio, with the nice side-effect of reducing the
amount of work done on our slowest Travis job.

This also adds 1.39.0 to Travis as that is the new MSRV for
lightning-net-tokio and uses that for codecov generation.

This also moves fuzzing to Rust stable, as honggfuzz broke its MSRV
and it seems likely it will again in the future.