### PR TITLE
Update pre-HTLC DataLossProtect to match new spec changes

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3444,10 +3444,10 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 				my_current_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &self.build_local_commitment_secret(self.cur_local_commitment_transaction_number + 1))
 			})
 		} else {
-			log_debug!(self, "We don't seen yet any revoked secret, if this channnel has already been updated it means we are fallen-behind, you should wait for other peer closing");
+			log_info!(self, "Sending a data_loss_protect with no previous remote per_commitment_secret");
 			OptionalField::Present(DataLossProtect {
 				your_last_per_commitment_secret: [0;32],
-				my_current_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &self.build_local_commitment_secret(self.cur_local_commitment_transaction_number))
+				my_current_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &self.build_local_commitment_secret(self.cur_local_commitment_transaction_number + 1))
 			})
 		};
 		msgs::ChannelReestablish {


### PR DESCRIPTION
This was the way DataLossProtect was originally written, however it
didn't match other implementations at the time during testing. It
turns out, other implementations didn't agree with each other
anyway (depending on the exact timeline), so the spec was clarified
somewhat in https://github.com/lightningnetwork/lightning-rfc/pull/550
. This updates us to be in line with the new guidance and appears
to solve out-of-sync issues in testing.

If someone feels super motivated to go write a test for this, they should. I'll circle back around to it sooner or later if not, but it should probably get a test given both the old and new versions happily pass our existing tests.