### PR TITLE
Fix node `with_relevant_init_flags`

### DIFF
--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -150,6 +150,7 @@ impl NodeFeatures {
 
 	/// Takes the flags that we know how to interpret in an init-context features that are also
 	/// relevant in a node-context features and creates a node-context features from them.
+	/// Be sure to blank out features that are unknown to us.
 	pub(crate) fn with_known_relevant_init_flags(init_ctx: &InitFeatures) -> Self {
 		let mut flags = Vec::new();
 		for (i, feature_byte)in init_ctx.flags.iter().enumerate() {
@@ -347,7 +348,8 @@ mod tests {
 		let res = NodeFeatures::with_known_relevant_init_flags(&init_features);
 
 		{
-			// Check that the flags are as expected.
+			// Check that the flags are as expected: optional_data_loss_protect,
+			// option_upfront_shutdown_script, and var_onion_optin set.
 			assert_eq!(res.flags[0], 0b00100010);
 			assert_eq!(res.flags[1], 0b00000010);
 			assert_eq!(res.flags.len(), 2);

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -401,4 +401,64 @@ mod tests {
 		let message = Message::Unknown(MessageType(43));
 		assert!(!message.type_id().is_even());
 	}
+
+	#[test]
+	fn read_lnd_init_msg() {
+		// Taken from lnd v0.9.0-beta.
+		let buffer = vec![0, 16, 0, 2, 34, 0, 0, 3, 2, 162, 161];
+		check_init_msg(buffer);
+	}
+
+	#[test]
+	fn read_clightning_init_msg() {
+		// Taken from c-lightning v0.8.0.
+		let buffer = vec![0, 16, 0, 2, 34, 0, 0, 3, 2, 170, 162, 1, 32, 6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94, 51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15];
+		check_init_msg(buffer);
+	}
+
+	fn check_init_msg(buffer: Vec<u8>) {
+		let mut reader = ::std::io::Cursor::new(buffer);
+		let decoded_msg = read(&mut reader).unwrap();
+		match decoded_msg {
+			Message::Init(msgs::Init { features }) => {
+				assert!(features.supports_variable_length_onion());
+				assert!(features.supports_upfront_shutdown_script());
+				assert!(features.supports_unknown_bits());
+				assert!(!features.requires_unknown_bits());
+				assert!(!features.initial_routing_sync());
+			},
+			_ => panic!("Expected init message, found message type: {}", decoded_msg.type_id())
+		}
+	}
+
+	#[test]
+	fn read_lnd_node_announcement() {
+		// Taken from lnd v0.9.0-beta.
+		let buffer = vec![1, 1, 91, 164, 146, 213, 213, 165, 21, 227, 102, 33, 105, 179, 214, 21, 221, 175, 228, 93, 57, 177, 191, 127, 107, 229, 31, 50, 21, 81, 179, 71, 39, 18, 35, 2, 89, 224, 110, 123, 66, 39, 148, 246, 177, 85, 12, 19, 70, 226, 173, 132, 156, 26, 122, 146, 71, 213, 247, 48, 93, 190, 185, 177, 12, 172, 0, 3, 2, 162, 161, 94, 103, 195, 37, 2, 37, 242, 97, 140, 2, 111, 69, 85, 39, 118, 30, 221, 99, 254, 120, 49, 103, 22, 170, 227, 111, 172, 164, 160, 49, 68, 138, 116, 16, 22, 206, 107, 51, 153, 255, 97, 108, 105, 99, 101, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 1, 172, 21, 0, 2, 38, 7];
+		let mut reader = ::std::io::Cursor::new(buffer);
+		let decoded_msg = read(&mut reader).unwrap();
+		match decoded_msg {
+			Message::NodeAnnouncement(msgs::NodeAnnouncement { contents: msgs::UnsignedNodeAnnouncement { features, ..}, ..}) => {
+				assert!(features.supports_variable_length_onion());
+				assert!(features.supports_upfront_shutdown_script());
+				assert!(features.supports_unknown_bits());
+				assert!(!features.requires_unknown_bits());
+			},
+			_ => panic!("Expected node announcement, found message type: {}", decoded_msg.type_id())
+		}
+	}
+
+	#[test]
+	fn read_lnd_chan_announcement() {
+		// Taken from lnd v0.9.0-beta.
+		let buffer = vec![1, 0, 82, 238, 153, 33, 128, 87, 215, 2, 28, 241, 140, 250, 98, 255, 56, 5, 79, 240, 214, 231, 172, 35, 240, 171, 44, 9, 78, 91, 8, 193, 102, 5, 17, 178, 142, 106, 180, 183, 46, 38, 217, 212, 25, 236, 69, 47, 92, 217, 181, 221, 161, 205, 121, 201, 99, 38, 158, 216, 186, 193, 230, 86, 222, 6, 206, 67, 22, 255, 137, 212, 141, 161, 62, 134, 76, 48, 241, 54, 50, 167, 187, 247, 73, 27, 74, 1, 129, 185, 197, 153, 38, 90, 255, 138, 39, 161, 102, 172, 213, 74, 107, 88, 150, 90, 0, 49, 104, 7, 182, 184, 194, 219, 181, 172, 8, 245, 65, 226, 19, 228, 101, 145, 25, 159, 52, 31, 58, 93, 53, 59, 218, 91, 37, 84, 103, 17, 74, 133, 33, 35, 2, 203, 101, 73, 19, 94, 175, 122, 46, 224, 47, 168, 128, 128, 25, 26, 25, 214, 52, 247, 43, 241, 117, 52, 206, 94, 135, 156, 52, 164, 143, 234, 58, 185, 50, 185, 140, 198, 174, 71, 65, 18, 105, 70, 131, 172, 137, 0, 164, 51, 215, 143, 117, 119, 217, 241, 197, 177, 227, 227, 170, 199, 114, 7, 218, 12, 107, 30, 191, 236, 203, 21, 61, 242, 48, 192, 90, 233, 200, 199, 111, 162, 68, 234, 54, 219, 1, 233, 66, 5, 82, 74, 84, 211, 95, 199, 245, 202, 89, 223, 102, 124, 62, 166, 253, 253, 90, 180, 118, 21, 61, 110, 37, 5, 96, 167, 0, 0, 6, 34, 110, 70, 17, 26, 11, 89, 202, 175, 18, 96, 67, 235, 91, 191, 40, 195, 79, 58, 94, 51, 42, 31, 199, 178, 183, 60, 241, 136, 145, 15, 0, 2, 65, 0, 0, 1, 0, 0, 2, 37, 242, 97, 140, 2, 111, 69, 85, 39, 118, 30, 221, 99, 254, 120, 49, 103, 22, 170, 227, 111, 172, 164, 160, 49, 68, 138, 116, 16, 22, 206, 107, 3, 54, 61, 144, 88, 171, 247, 136, 208, 99, 9, 135, 37, 201, 178, 253, 136, 0, 185, 235, 68, 160, 106, 110, 12, 46, 21, 125, 204, 18, 75, 234, 16, 3, 42, 171, 28, 52, 224, 11, 30, 30, 253, 156, 148, 175, 203, 121, 250, 111, 122, 195, 84, 122, 77, 183, 56, 135, 101, 88, 41, 60, 191, 99, 232, 85, 2, 36, 17, 156, 11, 8, 12, 189, 177, 68, 88, 28, 15, 207, 21, 179, 151, 56, 226, 158, 148, 3, 120, 113, 177, 243, 184, 17, 173, 37, 46, 222, 16];
+		let mut reader = ::std::io::Cursor::new(buffer);
+		let decoded_msg = read(&mut reader).unwrap();
+		match decoded_msg {
+			Message::ChannelAnnouncement(msgs::ChannelAnnouncement { contents: msgs::UnsignedChannelAnnouncement { features, ..}, ..}) => {
+				assert!(!features.requires_unknown_bits());
+			},
+			_ => panic!("Expected node announcement, found message type: {}", decoded_msg.type_id())
+		}
+	}
 }


### PR DESCRIPTION
As discussed on the ldk slack, currently `NodeFeature`'s `with_known_relevant_init_flags` mistakenly pulls out the last byte of feature flags (which covers feature bits 8-15) rather than the first (which covers feature bits 0-7). 

Additionally, the original code comments indicated that the intention was to blank out the `data_loss_protect` and `upfront_shutdown_script` features, which _are_ supported in a Node context, and therefore shouldn't be blanked out anyway. The only feature that is not valid in a Node context is `initial_routing_sync`, so now that's the only feature we blank out.

Finally, this PR also adds test vectors for feature messages received from other lightning clients.