### PR TITLE
Add missing unwrap() in tests introduced in 4abfd515e554bef90c25dbe

### DIFF
--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5543,7 +5543,7 @@ fn test_update_add_htlc_bolt2_receiver_zero_value_msat() {
 	let route = nodes[0].router.get_route(&nodes[1].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV).unwrap();
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 
-	nodes[0].node.send_payment(route, our_payment_hash);
+	nodes[0].node.send_payment(route, our_payment_hash).unwrap();
 	check_added_monitors!(nodes[0], 1);
 	let mut updates = get_htlc_update_msgs!(nodes[0], nodes[1].node.get_our_node_id());
 	updates.update_add_htlcs[0].amount_msat = 0;


### PR DESCRIPTION
#513 introduced a new compiler warning.