### PR TITLE
Fix ChannelMonitor round-trip introduced by 3d640da5c343111f538f006

### DIFF
--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -1024,7 +1024,7 @@ impl<ChanSigner: ChannelKeys + Writeable> ChannelMonitor<ChanSigner> {
 			for ev in events.iter() {
 				match *ev {
 					OnchainEvent::HTLCUpdate { ref htlc_update } => {
-						writer.write_all(&[1; 1])?;
+						0u8.write(writer)?;
 						htlc_update.0.write(writer)?;
 						htlc_update.1.write(writer)?;
 					},


### PR DESCRIPTION
3d640da5c343111f538f006996c13c9a98e0d9e6 changed the indexes for
some enums in ChannelMonitor deserialization but not serialization.
Thus, the chanmon_deser_target fuzz target failed on travis on at
least one PR.