### PR TITLE
Don't return a feerate of 0 in full_stack_target fuzz on EOF

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -99,7 +99,7 @@ impl FeeEstimator for FuzzEstimator {
 		//TODO: We should actually be testing at least much more than 64k...
 		match self.input.get_slice(2) {
 			Some(slice) => cmp::max(slice_to_be16(slice) as u64, 253),
-			None => 0
+			None => 253
 		}
 	}
 }


### PR DESCRIPTION
This triggered a (legitimate) panic in OnChainTxHandler that the
feerate in use was non-0, which is required by the feerate API.