### PR TITLE
Fix initial outbound sync infinite loop

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -354,7 +354,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref> PeerManager<Descriptor, CM> where 
 					InitSyncTracker::NoSyncRequested => {},
 					InitSyncTracker::ChannelsSyncing(c) if c < 0xffff_ffff_ffff_ffff => {
 						let steps = ((MSG_BUFF_SIZE - peer.pending_outbound_buffer.len() + 2) / 3) as u8;
-						let all_messages = self.message_handler.route_handler.get_next_channel_announcements(0, steps);
+						let all_messages = self.message_handler.route_handler.get_next_channel_announcements(c, steps);
 						for &(ref announce, ref update_a, ref update_b) in all_messages.iter() {
 							encode_and_send_msg!(announce);
 							encode_and_send_msg!(update_a);


### PR DESCRIPTION
Observed in testing as 100% CPU usage just sending the routing table over the wire. This would be a great opportunity to add some much-needed testing for this area of the code, so tagging as such - writing such tests is totally up for grabs, anyone is welcome to do so.