### PR TITLE
Document better BroadcasterInterface implementation requirements wrt to privacy/rebroadcast

### DIFF
--- a/lightning/src/chain/chaininterface.rs
+++ b/lightning/src/chain/chaininterface.rs
@@ -65,6 +65,13 @@ pub trait ChainWatchInterface: Sync + Send {
 }
 
 /// An interface to send a transaction to the Bitcoin network.
+///
+/// We may pass non-final transaction (like local HTLC-timeout tx)
+/// in case of channel force-closure due to an offchain anomaly. To warn
+/// being bounce off of every network mempools, implementation MUST
+/// wait until transaction finalization before p2p announcement. To avoid
+/// unecessary transaction origin privacy leak, rebroadcast is the responsibility
+/// of BroadcasterInterface consumers.
 pub trait BroadcasterInterface: Sync + Send {
 	/// Sends a transaction out to (hopefully) be mined.
 	fn broadcast_transaction(&self, tx: &Transaction);


### PR DESCRIPTION
**Pending on #365 : Rebroadcast logic may be tricky due to privacy leak wrt to time-sensitiviness of LN transactions, waiting on anchor outputs before to implement a broadcasting pool** (see #rust-bitcoin logs 03/19/20)

To avoid a dumb implementation leaking transaction origin badly in
case of rebroadcast, responsibility should be up to BroadcasterInterface
consumers.