### PR TITLE
Flatten ChannelMonitor substructs that don't add clarity

### DIFF
--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -1098,7 +1098,7 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 
 		let onchain_detection = OnchainDetection {
 			keys: keys.clone(),
-			funding_info: Some(funding_info.clone()),
+			funding_info: Some(funding_info),
 			current_remote_commitment_txid: None,
 			prev_remote_commitment_txid: None,
 		};


### PR DESCRIPTION
The new OnchainDetection struct (which is the remnants of the old
KeyStorage enum, which was removed in 1dbda4f)
doesn't really add any clarity to ChannelMonitor, so best to just
drop it and move its members into ChannelMonitor directly.