### PR TITLE
Add some helpers for routing debug

### DIFF
--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -427,6 +427,7 @@ impl RoutingMessageHandler for Router {
 					},
 					None => {},
 				}
+				log_trace!(self, "Announced node {}", msg.contents.node_id);
 
 				node.features = msg.contents.features.clone();
 				node.last_update = Some(msg.contents.timestamp);
@@ -555,6 +556,7 @@ impl RoutingMessageHandler for Router {
 				}
 			};
 		}
+		log_trace!(self, "Announced channel {} between {} and {}", msg.contents.short_channel_id, msg.contents.node_id_1, msg.contents.node_id_2);
 
 		add_channel_to_node!(msg.contents.node_id_1);
 		add_channel_to_node!(msg.contents.node_id_2);
@@ -868,6 +870,7 @@ impl Router {
 		if let Some(hops) = first_hops {
 			for chan in hops {
 				let short_channel_id = chan.short_channel_id.expect("first_hops should be filled in with usable channels, not pending ones");
+				log_trace!(self, "First hop link {} to {}", chan.short_channel_id.unwrap(), chan.remote_network_id);
 				if chan.remote_network_id == *target {
 					return Ok(Route {
 						hops: vec![RouteHop {
@@ -955,8 +958,11 @@ impl Router {
 					}
 				}
 
+				log_trace!(self, "Node {} requires {}", $node_id, $node.features.requires_unknown_bits());
 				if !$node.features.requires_unknown_bits() {
+					log_trace!(self, "Node {} with {} links", $node_id, $node.channels.len());
 					for chan_id in $node.channels.iter() {
+						log_trace!(self, "Adding link {}", chan_id);
 						let chan = network.channels.get(chan_id).unwrap();
 						if !chan.features.requires_unknown_bits() {
 							if chan.one_to_two.src_node_id == *$node_id {
@@ -979,6 +985,7 @@ impl Router {
 			};
 		}
 
+		log_trace!(self, "Tracing route to {}...", target);
 		match network.nodes.get(target) {
 			None => {},
 			Some(node) => {
@@ -1006,6 +1013,7 @@ impl Router {
 		}
 
 		while let Some(RouteGraphNode { pubkey, lowest_fee_to_node, .. }) = targets.pop() {
+			log_trace!(self, "Finding link for destination {}", pubkey);
 			if pubkey == network.our_node_id {
 				let mut res = vec!(dist.remove(&network.our_node_id).unwrap().3);
 				loop {

--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -160,9 +160,11 @@ impl_writeable!(ChannelInfo, 0, {
 	announcement_message
 });
 
-#[derive(PartialEq)]
-struct NodeInfo {
-	node_id: PublicKey,
+/// Details of a node, as stored in NetworkMap, and returned by Router::list_vertices
+#[derive(Clone, PartialEq)]
+pub struct NodeInfo {
+	/// The node id
+	pub node_id: PublicKey,
 	#[cfg(feature = "non_bitcoin_chain_hash_routing")]
 	channels: Vec<(u64, Sha256dHash)>,
 	#[cfg(not(feature = "non_bitcoin_chain_hash_routing"))]
@@ -171,14 +173,19 @@ struct NodeInfo {
 	lowest_inbound_channel_fee_base_msat: u32,
 	lowest_inbound_channel_fee_proportional_millionths: u32,
 
-	features: NodeFeatures,
+	/// The node features
+	pub features: NodeFeatures,
 	/// Unlike for channels, we may have a NodeInfo entry before having received a node_update.
 	/// Thus, we have to be able to capture "no update has been received", which we do with an
 	/// Option here.
-	last_update: Option<u32>,
-	rgb: [u8; 3],
-	alias: [u8; 32],
-	addresses: Vec<NetAddress>,
+	/// The last tine a node announcement has been received
+	pub last_update: Option<u32>,
+	/// The custom node color
+	pub rgb: [u8; 3],
+	/// The custom node alias
+	pub alias: [u8; 32],
+	/// The network addresses
+	pub addresses: Vec<NetAddress>,
 	//this is cached here so we can send out it later if required by route_init_sync
 	//keep an eye on this to see if the extra memory is a problem
 	announcement_message: Option<msgs::NodeAnnouncement>,
@@ -1088,6 +1095,17 @@ impl Router {
 			edges.push((*chan).clone());
 		}
 		edges
+	}
+
+	/// Gets the list of announced nodes, in random order. See NodeInfo details field documentation for more information
+	pub fn list_vertices(&self) -> Vec<NodeInfo> {
+		let mut vertices = Vec::new();
+		let network = self.network_map.read().unwrap();
+		vertices.reserve(network.nodes.len());
+		for (_, node) in network.nodes.iter() {
+			vertices.push((*node).clone());
+		}
+		vertices
 	}
 }
 

--- a/lightning/src/ln/router.rs
+++ b/lightning/src/ln/router.rs
@@ -123,6 +123,7 @@ impl_writeable!(DirectionalChannelInfo, 0, {
 
 #[derive(PartialEq)]
 struct ChannelInfo {
+	short_channel_id: u64,
 	features: ChannelFeatures,
 	one_to_two: DirectionalChannelInfo,
 	two_to_one: DirectionalChannelInfo,
@@ -133,12 +134,13 @@ struct ChannelInfo {
 
 impl std::fmt::Display for ChannelInfo {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		write!(f, "features: {}, one_to_two: {}, two_to_one: {}", log_bytes!(self.features.encode()), self.one_to_two, self.two_to_one)?;
+		write!(f, "short_channel_id: {}, features: {}, one_to_two: {}, two_to_one: {}", self.short_channel_id, log_bytes!(self.features.encode()), self.one_to_two, self.two_to_one)?;
 		Ok(())
 	}
 }
 
 impl_writeable!(ChannelInfo, 0, {
+	short_channel_id,
 	features,
 	one_to_two,
 	two_to_one,
@@ -485,6 +487,7 @@ impl RoutingMessageHandler for Router {
 		let should_relay = msg.contents.excess_data.is_empty();
 
 		let chan_info = ChannelInfo {
+				short_channel_id: msg.contents.short_channel_id,
 				features: msg.contents.features.clone(),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: msg.contents.node_id_1.clone(),
@@ -1196,6 +1199,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(1, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(1, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(1)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: our_id.clone(),
@@ -1230,6 +1234,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(2, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(2, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(2)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: our_id.clone(),
@@ -1264,6 +1269,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(12, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(12, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(12)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: our_id.clone(),
@@ -1304,6 +1310,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(3, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(3, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(3)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node1.clone(),
@@ -1327,6 +1334,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(4, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(4, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(4)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node2.clone(),
@@ -1350,6 +1358,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(13, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(13, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(13)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node8.clone(),
@@ -1384,6 +1393,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(5, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(5, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(5)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node3.clone(),
@@ -1418,6 +1428,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(6, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(6, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(6)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node3.clone(),
@@ -1441,6 +1452,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(11, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(11, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(11)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node5.clone(),
@@ -1475,6 +1487,7 @@ mod tests {
 				announcement_message: None,
 			});
 			network.channels.insert(NetworkMap::get_key(7, zero_hash.clone()), ChannelInfo {
+				short_channel_id: NetworkMap::get_key(7, zero_hash.clone()),
 				features: ChannelFeatures::from_le_bytes(id_to_feature_flags!(7)),
 				one_to_two: DirectionalChannelInfo {
 					src_node_id: node3.clone(),


### PR DESCRIPTION
Second commit is used to implement `list_graph` in sample, quite useful to debug path finding. But maybe `EdgeDetails` and `VerticeDetails` expose to much information.