### PR TITLE
Enforce MINIMALIF-compliant witnesses

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -54,7 +54,7 @@ pub enum SpendableOutputDescriptor {
 	/// The private key which should be used to sign the transaction is provided, as well as the
 	/// full witness redeemScript which is hashed in the output script_pubkey.
 	/// The witness in the spending input should be:
-	/// <BIP 143 signature generated with the given key> <one zero byte aka OP_0>
+	/// <BIP 143 signature generated with the given key> <empty vector> (MINIMALIF standard rule)
 	/// <witness_script as provided>
 	/// Note that the nSequence field in the input must be set to_self_delay (which corresponds to
 	/// the transaction not being broadcastable until at least to_self_delay blocks after the input

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -4009,7 +4009,7 @@ macro_rules! check_spendable_outputs {
 									let local_delaysig = secp_ctx.sign(&sighash, key);
 									spend_tx.input[0].witness.push(local_delaysig.serialize_der().to_vec());
 									spend_tx.input[0].witness[0].push(SigHashType::All as u8);
-									spend_tx.input[0].witness.push(vec!(0));
+									spend_tx.input[0].witness.push(vec!());
 									spend_tx.input[0].witness.push(witness_script.clone().into_bytes());
 									txn.push(spend_tx);
 								},

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -470,7 +470,7 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 					if let &Some(preimage) = preimage {
 						bumped_tx.input[i].witness.push(preimage.clone().0.to_vec());
 					} else {
-						bumped_tx.input[i].witness.push(vec![0]);
+						bumped_tx.input[i].witness.push(vec![]);
 					}
 					bumped_tx.input[i].witness.push(witness_script.clone().into_bytes());
 					log_trace!(self, "Going to broadcast Claim Transaction {} claiming remote {} htlc output {} from {} with new feerate {}...", bumped_tx.txid(), if preimage.is_some() { "offered" } else { "received" }, outp.vout, outp.txid, new_feerate);


### PR DESCRIPTION
Following genuinely lightning spec lured us to generate non-standard witness for some classes of transaction. That's a serious bug given we may have generate a) timeout tx which don't propagate through the network and offer unlimited claim delay to our counterparty b) bump feerate of timeout tx outside any limit.

rust-bitcoinconsensus/rust-bitcoin should be updated accordingly to test this (pending #420)