### PR TITLE
Renaming PeerChannelEncryptor -> TransportEncryptor

### DIFF
--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -19,9 +19,9 @@ pub mod features;
 pub(crate) mod onchaintx;
 
 #[cfg(feature = "fuzztarget")]
-pub mod peer_channel_encryptor;
+pub mod transport_encryptor;
 #[cfg(not(feature = "fuzztarget"))]
-pub(crate) mod peer_channel_encryptor;
+pub(crate) mod transport_encryptor;
 
 mod channel;
 mod onion_utils;

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -13,7 +13,7 @@ use ln::msgs;
 use ln::msgs::ChannelMessageHandler;
 use ln::channelmanager::{SimpleArcChannelManager, SimpleRefChannelManager};
 use util::ser::VecWriter;
-use ln::peer_channel_encryptor::{PeerChannelEncryptor,NextNoiseStep};
+use ln::transport_encryptor::{TransportEncryptor,NextNoiseStep};
 use ln::wire;
 use ln::wire::Encode;
 use util::byte_utils;
@@ -108,7 +108,7 @@ enum InitSyncTracker{
 }
 
 struct Peer {
-	channel_encryptor: PeerChannelEncryptor,
+	channel_encryptor: TransportEncryptor,
 	outbound: bool,
 	their_node_id: Option<PublicKey>,
 	their_features: Option<InitFeatures>,
@@ -273,7 +273,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref> PeerManager<Descriptor, CM> where 
 	/// Panics if descriptor is duplicative with some other descriptor which has not yet had a
 	/// socket_disconnected().
 	pub fn new_outbound_connection(&self, their_node_id: PublicKey, descriptor: Descriptor) -> Result<Vec<u8>, PeerHandleError> {
-		let mut peer_encryptor = PeerChannelEncryptor::new_outbound(their_node_id.clone(), self.get_ephemeral_key());
+		let mut peer_encryptor = TransportEncryptor::new_outbound(their_node_id.clone(), self.get_ephemeral_key());
 		let res = peer_encryptor.get_act_one().to_vec();
 		let pending_read_buffer = [0; 50].to_vec(); // Noise act two is 50 bytes
 
@@ -311,7 +311,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref> PeerManager<Descriptor, CM> where 
 	/// Panics if descriptor is duplicative with some other descriptor which has not yet had
 	/// socket_disconnected called.
 	pub fn new_inbound_connection(&self, descriptor: Descriptor) -> Result<(), PeerHandleError> {
-		let peer_encryptor = PeerChannelEncryptor::new_inbound(&self.our_node_secret);
+		let peer_encryptor = TransportEncryptor::new_inbound(&self.our_node_secret);
 		let pending_read_buffer = [0; 50].to_vec(); // Noise act one is 50 bytes
 
 		let mut peers = self.peers.lock().unwrap();


### PR DESCRIPTION
This is a small/non-important change, however while reviewing the code I found that `PeerChannelEncryptor` is actually not a channel- or peer-level encryptor, but rather connection-specific transport-level encryptor.

I am working on separation of transport, connection, peer and channel layers in  my code (since I'd like to have multiple connections per peer, multi-peer channels etc) and from this perspective it's quite an important difference.