### PR TITLE
Time out HTLCs before they expire

### DIFF
--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -764,13 +764,19 @@ macro_rules! expect_payment_sent {
 }
 
 macro_rules! expect_payment_failed {
-	($node: expr, $expected_payment_hash: expr, $rejected_by_dest: expr) => {
+	($node: expr, $expected_payment_hash: expr, $rejected_by_dest: expr $(, $expected_error_code: expr, $expected_error_data: expr)*) => {
 		let events = $node.node.get_and_clear_pending_events();
 		assert_eq!(events.len(), 1);
 		match events[0] {
-			Event::PaymentFailed { ref payment_hash, rejected_by_dest, .. } => {
+			Event::PaymentFailed { ref payment_hash, rejected_by_dest, ref error_code, ref error_data } => {
 				assert_eq!(*payment_hash, $expected_payment_hash);
 				assert_eq!(rejected_by_dest, $rejected_by_dest);
+				assert!(error_code.is_some());
+				assert!(error_data.is_some());
+				$(
+					assert_eq!(error_code.unwrap(), $expected_error_code);
+					assert_eq!(&error_data.as_ref().unwrap()[..], $expected_error_data);
+				)*
 			},
 			_ => panic!("Unexpected event"),
 		}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -786,49 +786,57 @@ macro_rules! expect_payment_failed {
 pub fn send_along_route_with_secret<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, route: Route, expected_paths: &[&[&Node<'a, 'b, 'c>]], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: Option<PaymentSecret>) {
 	origin_node.node.send_payment(&route, our_payment_hash, &our_payment_secret).unwrap();
 	check_added_monitors!(origin_node, expected_paths.len());
+	pass_along_route(origin_node, expected_paths, recv_value, our_payment_hash, our_payment_secret);
+}
 
-	let mut events = origin_node.node.get_and_clear_pending_msg_events();
-	assert_eq!(events.len(), expected_paths.len());
-	for (path_idx, (ev, expected_route)) in events.drain(..).zip(expected_paths.iter()).enumerate() {
-		let mut payment_event = SendEvent::from_event(ev);
-		let mut prev_node = origin_node;
+pub fn pass_along_path<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_path: &[&Node<'a, 'b, 'c>], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: Option<PaymentSecret>, ev: MessageSendEvent, payment_received_expected: bool) {
+	let mut payment_event = SendEvent::from_event(ev);
+	let mut prev_node = origin_node;
 
-		for (idx, &node) in expected_route.iter().enumerate() {
-			assert_eq!(node.node.get_our_node_id(), payment_event.node_id);
+	for (idx, &node) in expected_path.iter().enumerate() {
+		assert_eq!(node.node.get_our_node_id(), payment_event.node_id);
 
-			node.node.handle_update_add_htlc(&prev_node.node.get_our_node_id(), &payment_event.msgs[0]);
-			check_added_monitors!(node, 0);
-			commitment_signed_dance!(node, prev_node, payment_event.commitment_msg, false);
+		node.node.handle_update_add_htlc(&prev_node.node.get_our_node_id(), &payment_event.msgs[0]);
+		check_added_monitors!(node, 0);
+		commitment_signed_dance!(node, prev_node, payment_event.commitment_msg, false);
 
-			expect_pending_htlcs_forwardable!(node);
+		expect_pending_htlcs_forwardable!(node);
 
-			if idx == expected_route.len() - 1 {
-				let events_2 = node.node.get_and_clear_pending_events();
-				// Once we've gotten through all the HTLCs, the last one should result in a
-				// PaymentReceived (but each previous one should not!).
-				if path_idx == expected_paths.len() - 1 {
-					assert_eq!(events_2.len(), 1);
-					match events_2[0] {
-						Event::PaymentReceived { ref payment_hash, ref payment_secret, amt } => {
-							assert_eq!(our_payment_hash, *payment_hash);
-							assert_eq!(our_payment_secret, *payment_secret);
-							assert_eq!(amt, recv_value);
-						},
-						_ => panic!("Unexpected event"),
-					}
-				} else {
-					assert!(events_2.is_empty());
+		if idx == expected_path.len() - 1 {
+			let events_2 = node.node.get_and_clear_pending_events();
+			if payment_received_expected {
+				assert_eq!(events_2.len(), 1);
+				match events_2[0] {
+					Event::PaymentReceived { ref payment_hash, ref payment_secret, amt } => {
+						assert_eq!(our_payment_hash, *payment_hash);
+						assert_eq!(our_payment_secret, *payment_secret);
+						assert_eq!(amt, recv_value);
+					},
+					_ => panic!("Unexpected event"),
 				}
 			} else {
-				let mut events_2 = node.node.get_and_clear_pending_msg_events();
-				assert_eq!(events_2.len(), 1);
-				check_added_monitors!(node, 1);
-				payment_event = SendEvent::from_event(events_2.remove(0));
-				assert_eq!(payment_event.msgs.len(), 1);
+				assert!(events_2.is_empty());
 			}
-
-			prev_node = node;
+		} else {
+			let mut events_2 = node.node.get_and_clear_pending_msg_events();
+			assert_eq!(events_2.len(), 1);
+			check_added_monitors!(node, 1);
+			payment_event = SendEvent::from_event(events_2.remove(0));
+			assert_eq!(payment_event.msgs.len(), 1);
 		}
+
+		prev_node = node;
+	}
+}
+
+pub fn pass_along_route<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&[&Node<'a, 'b, 'c>]], recv_value: u64, our_payment_hash: PaymentHash, our_payment_secret: Option<PaymentSecret>) {
+	let mut events = origin_node.node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), expected_route.len());
+	for (path_idx, (ev, expected_path)) in events.drain(..).zip(expected_route.iter()).enumerate() {
+		// Once we've gotten through all the HTLCs, the last one should result in a
+		// PaymentReceived (but each previous one should not!), .
+		let expect_payment = path_idx == expected_route.len() - 1;
+		pass_along_path(origin_node, expected_path, recv_value, our_payment_hash.clone(), our_payment_secret, ev, expect_payment);
 	}
 }
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -717,7 +717,7 @@ macro_rules! get_payment_preimage_hash {
 	}
 }
 
-macro_rules! expect_pending_htlcs_forwardable {
+macro_rules! expect_pending_htlcs_forwardable_ignore {
 	($node: expr) => {{
 		let events = $node.node.get_and_clear_pending_events();
 		assert_eq!(events.len(), 1);
@@ -725,6 +725,12 @@ macro_rules! expect_pending_htlcs_forwardable {
 			Event::PendingHTLCsForwardable { .. } => { },
 			_ => panic!("Unexpected event"),
 		};
+	}}
+}
+
+macro_rules! expect_pending_htlcs_forwardable {
+	($node: expr) => {{
+		expect_pending_htlcs_forwardable_ignore!($node);
 		$node.node.process_pending_htlc_forwards();
 	}}
 }

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -2320,6 +2320,8 @@ fn claim_htlc_outputs_single_tx() {
 		check_added_monitors!(nodes[0], 1);
 		nodes[1].block_notifier.block_connected(&Block { header, txdata: vec![revoked_local_txn[0].clone()] }, 200);
 		check_added_monitors!(nodes[1], 1);
+		expect_pending_htlcs_forwardable_ignore!(nodes[0]);
+
 		connect_blocks(&nodes[1].block_notifier, ANTI_REORG_DELAY - 1, 200, true, header.bitcoin_hash());
 
 		let events = nodes[1].node.get_and_clear_pending_events();
@@ -3651,6 +3653,60 @@ fn test_drop_messages_peer_disconnect_dual_htlc() {
 	check_added_monitors!(nodes[0], 1);
 
 	claim_payment(&nodes[0], &[&nodes[1]], payment_preimage_2, 1_000_000);
+}
+
+#[test]
+fn test_htlc_timeout() {
+	// If the user fails to claim/fail an HTLC within the HTLC CLTV timeout we fail it for them
+	// to avoid our counterparty failing the channel.
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::supported(), InitFeatures::supported());
+	let (_, our_payment_hash) = route_payment(&nodes[0], &[&nodes[1]], 100000);
+
+	let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	nodes[0].block_notifier.block_connected_checked(&header, 101, &[], &[]);
+	nodes[1].block_notifier.block_connected_checked(&header, 101, &[], &[]);
+	for i in 102..TEST_FINAL_CLTV + 100 + 1 - CLTV_CLAIM_BUFFER - LATENCY_GRACE_PERIOD_BLOCKS {
+		header.prev_blockhash = header.bitcoin_hash();
+		nodes[0].block_notifier.block_connected_checked(&header, i, &[], &[]);
+		nodes[1].block_notifier.block_connected_checked(&header, i, &[], &[]);
+	}
+
+	expect_pending_htlcs_forwardable!(nodes[1]);
+
+	check_added_monitors!(nodes[1], 1);
+	let htlc_timeout_updates = get_htlc_update_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+	assert!(htlc_timeout_updates.update_add_htlcs.is_empty());
+	assert_eq!(htlc_timeout_updates.update_fail_htlcs.len(), 1);
+	assert!(htlc_timeout_updates.update_fail_malformed_htlcs.is_empty());
+	assert!(htlc_timeout_updates.update_fee.is_none());
+
+	nodes[0].node.handle_update_fail_htlc(&nodes[1].node.get_our_node_id(), &htlc_timeout_updates.update_fail_htlcs[0]);
+	commitment_signed_dance!(nodes[0], nodes[1], htlc_timeout_updates.commitment_signed, false);
+	let events = nodes[0].node.get_and_clear_pending_events();
+	match &events[0] {
+		&Event::PaymentFailed { payment_hash, rejected_by_dest, error_code, ref error_data } => {
+			assert_eq!(payment_hash, our_payment_hash);
+			assert!(rejected_by_dest);
+			assert_eq!(error_code.unwrap(), 0x4000 | 15);
+			// 100_000 msat as u64, followed by a height of 123 as u32
+			assert_eq!(&error_data.as_ref().unwrap()[..], &[
+				((100_000u64 >> 7*8) & 0xff) as u8,
+				((100_000u64 >> 6*8) & 0xff) as u8,
+				((100_000u64 >> 5*8) & 0xff) as u8,
+				((100_000u64 >> 4*8) & 0xff) as u8,
+				((100_000u64 >> 3*8) & 0xff) as u8,
+				((100_000u64 >> 2*8) & 0xff) as u8,
+				((100_000u64 >> 1*8) & 0xff) as u8,
+				((100_000u64 >> 0*8) & 0xff) as u8,
+				0, 0, 0, 123]);
+		},
+		_ => panic!("Unexpected event"),
+	}
 }
 
 #[test]
@@ -7140,6 +7196,8 @@ fn test_bump_penalty_txn_on_revoked_htlcs() {
 
 	// Broadcast set of revoked txn on A
 	let header_128 = connect_blocks(&nodes[0].block_notifier, 128, 0, true, header.bitcoin_hash());
+	expect_pending_htlcs_forwardable_ignore!(nodes[0]);
+
 	let header_129 = BlockHeader { version: 0x20000000, prev_blockhash: header_128, merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 	nodes[0].block_notifier.block_connected(&Block { header: header_129, txdata: vec![revoked_local_txn[0].clone(), revoked_htlc_txn[0].clone(), revoked_htlc_txn[1].clone()] }, 129);
 	let first;
@@ -7472,6 +7530,8 @@ fn test_bump_txn_sanitize_tracking_maps() {
 
 	// Broadcast set of revoked txn on A
 	let header_128 = connect_blocks(&nodes[0].block_notifier, 128, 0,  false, Default::default());
+	expect_pending_htlcs_forwardable_ignore!(nodes[0]);
+
 	let header_129 = BlockHeader { version: 0x20000000, prev_blockhash: header_128, merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 	nodes[0].block_notifier.block_connected(&Block { header: header_129, txdata: vec![revoked_local_txn[0].clone()] }, 129);
 	check_closed_broadcast!(nodes[0], false);

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -55,6 +55,9 @@ pub enum Event {
 	/// ChannelManager::fail_htlc_backwards to free up resources for this HTLC.
 	/// The amount paid should be considered 'incorrect' when it is less than or more than twice
 	/// the amount expected.
+	/// If you fail to call either ChannelManager::claim_funds or
+	/// ChannelManager::fail_htlc_backwards within the HTLC's timeout, the HTLC will be
+	/// automatically failed.
 	PaymentReceived {
 		/// The hash for which the preimage should be handed to the ChannelManager.
 		payment_hash: PaymentHash,


### PR DESCRIPTION
This was broken out from the rest of #441 as @valentinewallace  pointed out that it wasn't strictly necessary and #441 was big. I am tagging it 0.0.11 because it is *kinda* necessary, just not strictly. Namely, if we get a partial payment, but not a full one, we really need to fail back the partial bits before the channel has to go to chain for it. Based on #441, and also includes another test that makes sense in #441 but requires some of the refactors that were already in here so might as well wait.