### PR TITLE
Thread fuzz test cases

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -37,6 +37,10 @@ members = ["."]
 lto = true
 codegen-units = 1
 
+# When testing a large fuzz corpus, -O1 offers a nice speedup
+[profile.dev]
+opt-level = 1
+
 [lib]
 name = "lightning_fuzz"
 path = "src/lib.rs"

--- a/fuzz/src/bin/chanmon_consistency_target.rs
+++ b/fuzz/src/bin/chanmon_consistency_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	chanmon_consistency_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		chanmon_consistency_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/chanmon_consistency") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			chanmon_consistency_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						chanmon_consistency_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/chanmon_deser_target.rs
+++ b/fuzz/src/bin/chanmon_deser_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	chanmon_deser_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		chanmon_deser_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/chanmon_deser") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			chanmon_deser_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						chanmon_deser_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/full_stack_target.rs
+++ b/fuzz/src/bin/full_stack_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	full_stack_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		full_stack_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/full_stack") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			full_stack_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						full_stack_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_accept_channel_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_accept_channel_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_accept_channel_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_accept_channel") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_accept_channel_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_accept_channel_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_announcement_signatures_target.rs
+++ b/fuzz/src/bin/msg_announcement_signatures_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_announcement_signatures_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_announcement_signatures_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_announcement_signatures") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_announcement_signatures_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_announcement_signatures_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_channel_announcement_target.rs
+++ b/fuzz/src/bin/msg_channel_announcement_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_channel_announcement_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_channel_announcement_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_channel_announcement") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_channel_announcement_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_channel_announcement_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_channel_reestablish_target.rs
+++ b/fuzz/src/bin/msg_channel_reestablish_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_channel_reestablish_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_channel_reestablish_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_channel_reestablish") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_channel_reestablish_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_channel_reestablish_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_channel_update_target.rs
+++ b/fuzz/src/bin/msg_channel_update_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_channel_update_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_channel_update_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_channel_update") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_channel_update_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_channel_update_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_closing_signed_target.rs
+++ b/fuzz/src/bin/msg_closing_signed_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_closing_signed_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_closing_signed_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_closing_signed") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_closing_signed_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_closing_signed_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_commitment_signed_target.rs
+++ b/fuzz/src/bin/msg_commitment_signed_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_commitment_signed_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_commitment_signed_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_commitment_signed") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_commitment_signed_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_commitment_signed_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
+++ b/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_decoded_onion_error_packet") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_decoded_onion_error_packet_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_decoded_onion_error_packet_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_error_message_target.rs
+++ b/fuzz/src/bin/msg_error_message_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_error_message_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_error_message_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_error_message") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_error_message_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_error_message_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_funding_created_target.rs
+++ b/fuzz/src/bin/msg_funding_created_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_funding_created_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_funding_created_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_funding_created") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_funding_created_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_funding_created_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_funding_locked_target.rs
+++ b/fuzz/src/bin/msg_funding_locked_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_funding_locked_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_funding_locked_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_funding_locked") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_funding_locked_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_funding_locked_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_funding_signed_target.rs
+++ b/fuzz/src/bin/msg_funding_signed_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_funding_signed_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_funding_signed_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_funding_signed") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_funding_signed_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_funding_signed_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_init_target.rs
+++ b/fuzz/src/bin/msg_init_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_init_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_init_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_init") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_init_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_init_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_node_announcement_target.rs
+++ b/fuzz/src/bin/msg_node_announcement_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_node_announcement_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_node_announcement_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_node_announcement") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_node_announcement_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_node_announcement_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_onion_hop_data_target.rs
+++ b/fuzz/src/bin/msg_onion_hop_data_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_onion_hop_data_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_onion_hop_data_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_onion_hop_data") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_onion_hop_data_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_onion_hop_data_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_open_channel_target.rs
+++ b/fuzz/src/bin/msg_open_channel_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_open_channel_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_open_channel_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_open_channel") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_open_channel_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_open_channel_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_ping_target.rs
+++ b/fuzz/src/bin/msg_ping_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_ping_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_ping_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_ping") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_ping_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_ping_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_pong_target.rs
+++ b/fuzz/src/bin/msg_pong_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_pong_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_pong_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_pong") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_pong_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_pong_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_shutdown_target.rs
+++ b/fuzz/src/bin/msg_shutdown_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_shutdown_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_shutdown_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_shutdown") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_shutdown_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_shutdown_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_update_add_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_add_htlc_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_update_add_htlc_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_update_add_htlc_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_update_add_htlc") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_update_add_htlc_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_update_add_htlc_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_update_fail_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_htlc_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_update_fail_htlc_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_update_fail_htlc_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_update_fail_htlc") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_update_fail_htlc_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_update_fail_htlc_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_update_fail_malformed_htlc") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_update_fail_malformed_htlc_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_update_fail_malformed_htlc_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_update_fee_target.rs
+++ b/fuzz/src/bin/msg_update_fee_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_update_fee_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_update_fee_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_update_fee") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_update_fee_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_update_fee_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/msg_update_fulfill_htlc") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			msg_update_fulfill_htlc_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						msg_update_fulfill_htlc_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/peer_crypt_target.rs
+++ b/fuzz/src/bin/peer_crypt_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	peer_crypt_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		peer_crypt_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/peer_crypt") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			peer_crypt_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						peer_crypt_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/router_target.rs
+++ b/fuzz/src/bin/router_target.rs
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	router_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		router_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/router") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			router_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						router_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/bin/target_template.txt
+++ b/fuzz/src/bin/target_template.txt
@@ -45,15 +45,48 @@ fn main() {
 
 #[test]
 fn run_test_cases() {
-	let mut data: Vec<u8> = vec![0];
-	TARGET_NAME_run(data.as_ptr(), data.len());
+	use lightning_fuzz::utils::test_logger::StringBuffer;
+
+	use std::sync::{atomic, Arc};
+	{
+		let data: Vec<u8> = vec![0];
+		TARGET_NAME_run(data.as_ptr(), data.len());
+	}
+	let mut threads = Vec::new();
+	let threads_running = Arc::new(atomic::AtomicUsize::new(0));
 	if let Ok(tests) = fs::read_dir("test_cases/TARGET_NAME") {
 		for test in tests {
-			data.clear();
+			let mut data: Vec<u8> = Vec::new();
 			let path = test.unwrap().path();
-			println!("Running test {}...", path.file_name().unwrap().to_str().unwrap());
-			fs::File::open(path).unwrap().read_to_end(&mut data).unwrap();
-			TARGET_NAME_run(data.as_ptr(), data.len());
+			fs::File::open(&path).unwrap().read_to_end(&mut data).unwrap();
+			threads_running.fetch_add(1, atomic::Ordering::AcqRel);
+
+			let thread_count_ref = Arc::clone(&threads_running);
+			let main_thread_ref = std::thread::current();
+			threads.push((path.file_name().unwrap().to_str().unwrap().to_string(),
+				std::thread::spawn(move || {
+					let string_logger = StringBuffer::new();
+
+					let panic_logger = string_logger.clone();
+					let res = if ::std::panic::catch_unwind(move || {
+						TARGET_NAME_test(&data, panic_logger);
+					}).is_err() {
+						Some(string_logger.into_string())
+					} else { None };
+					thread_count_ref.fetch_sub(1, atomic::Ordering::AcqRel);
+					main_thread_ref.unpark();
+					res
+				})
+			));
+			while threads_running.load(atomic::Ordering::Acquire) > 32 {
+				std::thread::park();
+			}
+		}
+	}
+	for (test, thread) in threads.drain(..) {
+		if let Some(output) = thread.join().unwrap() {
+			println!("Output of {}:\n{}", test, output);
+			panic!();
 		}
 	}
 }

--- a/fuzz/src/chanmon_deser.rs
+++ b/fuzz/src/chanmon_deser.rs
@@ -24,8 +24,8 @@ impl Writer for VecWriter {
 }
 
 #[inline]
-pub fn do_test(data: &[u8]) {
-	let logger = Arc::new(test_logger::TestLogger::new("".to_owned()));
+pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
+	let logger = Arc::new(test_logger::TestLogger::new("".to_owned(), out));
 	if let Ok((latest_block_hash, monitor)) = <(Sha256dHash, channelmonitor::ChannelMonitor<EnforcingChannelKeys>)>::read(&mut Cursor::new(data), logger.clone()) {
 		let mut w = VecWriter(Vec::new());
 		monitor.write_for_disk(&mut w).unwrap();
@@ -37,7 +37,11 @@ pub fn do_test(data: &[u8]) {
 	}
 }
 
+pub fn chanmon_deser_test<Out: test_logger::Output>(data: &[u8], out: Out) {
+	do_test(data, out);
+}
+
 #[no_mangle]
 pub extern "C" fn chanmon_deser_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	do_test(unsafe { std::slice::from_raw_parts(data, datalen) }, test_logger::DevNull{});
 }

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -561,15 +561,19 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 	}
 }
 
+pub fn full_stack_test<Out: test_logger::Output>(data: &[u8], out: Out) {
+	let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new("".to_owned(), out));
+	do_test(data, &logger);
+}
+
 #[no_mangle]
 pub extern "C" fn full_stack_run(data: *const u8, datalen: usize) {
-	let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new("".to_owned()));
+	let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new("".to_owned(), test_logger::DevNull {}));
 	do_test(unsafe { std::slice::from_raw_parts(data, datalen) }, &logger);
 }
 
 #[cfg(test)]
 mod tests {
-	use utils::test_logger;
 	use lightning::util::logger::{Logger, Record};
 	use std::collections::HashMap;
 	use std::sync::{Arc, Mutex};

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -4,7 +4,7 @@ extern crate lightning;
 extern crate secp256k1;
 extern crate hex;
 
-mod utils;
+pub mod utils;
 
 pub mod chanmon_deser;
 pub mod chanmon_consistency;

--- a/fuzz/src/msg_targets/msg_accept_channel.rs
+++ b/fuzz/src/msg_targets/msg_accept_channel.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_accept_channel_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::AcceptChannel, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_accept_channel_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::AcceptChannel, data);
 }

--- a/fuzz/src/msg_targets/msg_announcement_signatures.rs
+++ b/fuzz/src/msg_targets/msg_announcement_signatures.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_announcement_signatures_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::AnnouncementSignatures, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_announcement_signatures_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::AnnouncementSignatures, data);
 }

--- a/fuzz/src/msg_targets/msg_channel_announcement.rs
+++ b/fuzz/src/msg_targets/msg_channel_announcement.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_channel_announcement_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_exact!(msgs::ChannelAnnouncement, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_channel_announcement_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_exact!(msgs::ChannelAnnouncement, data);
 }

--- a/fuzz/src/msg_targets/msg_channel_reestablish.rs
+++ b/fuzz/src/msg_targets/msg_channel_reestablish.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_channel_reestablish_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::ChannelReestablish, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_channel_reestablish_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::ChannelReestablish, data);
 }

--- a/fuzz/src/msg_targets/msg_channel_update.rs
+++ b/fuzz/src/msg_targets/msg_channel_update.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_channel_update_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_exact!(msgs::ChannelUpdate, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_channel_update_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_exact!(msgs::ChannelUpdate, data);
 }

--- a/fuzz/src/msg_targets/msg_closing_signed.rs
+++ b/fuzz/src/msg_targets/msg_closing_signed.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_closing_signed_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::ClosingSigned, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_closing_signed_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::ClosingSigned, data);
 }

--- a/fuzz/src/msg_targets/msg_commitment_signed.rs
+++ b/fuzz/src/msg_targets/msg_commitment_signed.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_commitment_signed_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::CommitmentSigned, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_commitment_signed_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::CommitmentSigned, data);
 }

--- a/fuzz/src/msg_targets/msg_decoded_onion_error_packet.rs
+++ b/fuzz/src/msg_targets/msg_decoded_onion_error_packet.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_decoded_onion_error_packet_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::DecodedOnionErrorPacket, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_decoded_onion_error_packet_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::DecodedOnionErrorPacket, data);
 }

--- a/fuzz/src/msg_targets/msg_error_message.rs
+++ b/fuzz/src/msg_targets/msg_error_message.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_error_message_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_hole!(msgs::ErrorMessage, data, 32, 2);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_error_message_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_hole!(msgs::ErrorMessage, data, 32, 2);
 }

--- a/fuzz/src/msg_targets/msg_funding_created.rs
+++ b/fuzz/src/msg_targets/msg_funding_created.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_funding_created_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::FundingCreated, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_funding_created_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::FundingCreated, data);
 }

--- a/fuzz/src/msg_targets/msg_funding_locked.rs
+++ b/fuzz/src/msg_targets/msg_funding_locked.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_funding_locked_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::FundingLocked, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_funding_locked_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::FundingLocked, data);
 }

--- a/fuzz/src/msg_targets/msg_funding_signed.rs
+++ b/fuzz/src/msg_targets/msg_funding_signed.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_funding_signed_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::FundingSigned, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_funding_signed_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::FundingSigned, data);
 }

--- a/fuzz/src/msg_targets/msg_init.rs
+++ b/fuzz/src/msg_targets/msg_init.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_init_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_simple!(msgs::Init, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_init_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_simple!(msgs::Init, data);
 }

--- a/fuzz/src/msg_targets/msg_node_announcement.rs
+++ b/fuzz/src/msg_targets/msg_node_announcement.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_node_announcement_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_exact!(msgs::NodeAnnouncement, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_node_announcement_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_exact!(msgs::NodeAnnouncement, data);
 }

--- a/fuzz/src/msg_targets/msg_onion_hop_data.rs
+++ b/fuzz/src/msg_targets/msg_onion_hop_data.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_onion_hop_data_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_simple!(msgs::OnionHopData, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_onion_hop_data_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_simple!(msgs::OnionHopData, data);
 }

--- a/fuzz/src/msg_targets/msg_open_channel.rs
+++ b/fuzz/src/msg_targets/msg_open_channel.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_open_channel_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::OpenChannel, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_open_channel_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::OpenChannel, data);
 }

--- a/fuzz/src/msg_targets/msg_ping.rs
+++ b/fuzz/src/msg_targets/msg_ping.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_ping_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_simple!(msgs::Ping, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_ping_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_simple!(msgs::Ping, data);
 }

--- a/fuzz/src/msg_targets/msg_pong.rs
+++ b/fuzz/src/msg_targets/msg_pong.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_pong_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_simple!(msgs::Pong, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_pong_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_simple!(msgs::Pong, data);
 }

--- a/fuzz/src/msg_targets/msg_revoke_and_ack.rs
+++ b/fuzz/src/msg_targets/msg_revoke_and_ack.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_revoke_and_ack_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::RevokeAndACK, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_revoke_and_ack_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::RevokeAndACK, data);
 }

--- a/fuzz/src/msg_targets/msg_shutdown.rs
+++ b/fuzz/src/msg_targets/msg_shutdown.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_shutdown_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::Shutdown, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_shutdown_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::Shutdown, data);
 }

--- a/fuzz/src/msg_targets/msg_target_template.txt
+++ b/fuzz/src/msg_targets/msg_target_template.txt
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn TARGET_NAME_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	TEST_MSG!(msgs::MSG_TARGET, dataEXTRA_ARGS);
 }
 
 #[no_mangle]
 pub extern "C" fn TARGET_NAME_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	TEST_MSG!(msgs::MSG_TARGET, dataEXTRA_ARGS);
 }

--- a/fuzz/src/msg_targets/msg_update_add_htlc.rs
+++ b/fuzz/src/msg_targets/msg_update_add_htlc.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_update_add_htlc_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg_hole!(msgs::UpdateAddHTLC, data, 85, 33);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_update_add_htlc_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg_hole!(msgs::UpdateAddHTLC, data, 85, 33);
 }

--- a/fuzz/src/msg_targets/msg_update_fail_htlc.rs
+++ b/fuzz/src/msg_targets/msg_update_fail_htlc.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_update_fail_htlc_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::UpdateFailHTLC, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_update_fail_htlc_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::UpdateFailHTLC, data);
 }

--- a/fuzz/src/msg_targets/msg_update_fail_malformed_htlc.rs
+++ b/fuzz/src/msg_targets/msg_update_fail_malformed_htlc.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_update_fail_malformed_htlc_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::UpdateFailMalformedHTLC, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_update_fail_malformed_htlc_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::UpdateFailMalformedHTLC, data);
 }

--- a/fuzz/src/msg_targets/msg_update_fee.rs
+++ b/fuzz/src/msg_targets/msg_update_fee.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_update_fee_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::UpdateFee, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_update_fee_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::UpdateFee, data);
 }

--- a/fuzz/src/msg_targets/msg_update_fulfill_htlc.rs
+++ b/fuzz/src/msg_targets/msg_update_fulfill_htlc.rs
@@ -4,13 +4,15 @@
 use lightning::ln::msgs;
 
 use msg_targets::utils::VecWriter;
+use utils::test_logger;
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn msg_update_fulfill_htlc_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
 	test_msg!(msgs::UpdateFulfillHTLC, data);
 }
 
 #[no_mangle]
 pub extern "C" fn msg_update_fulfill_htlc_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	let data = unsafe { std::slice::from_raw_parts(data, datalen) };
+	test_msg!(msgs::UpdateFulfillHTLC, data);
 }

--- a/fuzz/src/peer_crypt.rs
+++ b/fuzz/src/peer_crypt.rs
@@ -2,6 +2,8 @@ use lightning::ln::peer_channel_encryptor::PeerChannelEncryptor;
 
 use secp256k1::key::{PublicKey,SecretKey};
 
+use utils::test_logger;
+
 #[inline]
 fn slice_to_be16(v: &[u8]) -> u16 {
 	((v[0] as u16) << 8*1) |
@@ -73,6 +75,10 @@ pub fn do_test(data: &[u8]) {
 			}
 		}
 	}
+}
+
+pub fn peer_crypt_test<Out: test_logger::Output>(data: &[u8], _out: Out) {
+	do_test(data);
 }
 
 #[no_mangle]

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -93,7 +93,7 @@ impl ChainWatchInterface for DummyChainWatcher {
 }
 
 #[inline]
-pub fn do_test(data: &[u8]) {
+pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 	let input = Arc::new(InputData {
 		data: data.to_vec(),
 		read_pos: AtomicUsize::new(0),
@@ -150,7 +150,7 @@ pub fn do_test(data: &[u8]) {
 		}
 	}
 
-	let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new("".to_owned()));
+	let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new("".to_owned(), out));
 	let chain_monitor = Arc::new(DummyChainWatcher {
 		input: Arc::clone(&input),
 	});
@@ -232,7 +232,11 @@ pub fn do_test(data: &[u8]) {
 	}
 }
 
+pub fn router_test<Out: test_logger::Output>(data: &[u8], out: Out) {
+	do_test(data, out);
+}
+
 #[no_mangle]
 pub extern "C" fn router_run(data: *const u8, datalen: usize) {
-	do_test(unsafe { std::slice::from_raw_parts(data, datalen) });
+	do_test(unsafe { std::slice::from_raw_parts(data, datalen) }, test_logger::DevNull {});
 }

--- a/fuzz/src/utils/mod.rs
+++ b/fuzz/src/utils/mod.rs
@@ -1,1 +1,1 @@
-pub(crate) mod test_logger;
+pub mod test_logger;

--- a/fuzz/src/utils/test_logger.rs
+++ b/fuzz/src/utils/test_logger.rs
@@ -1,23 +1,55 @@
 use lightning::util::logger::{Logger, Record};
-pub struct TestLogger {
-	#[cfg(test)]
-	id: String,
+use std::sync::{Arc, Mutex};
+use std::io::Write;
+
+pub trait Output : Clone + Sync + Send + 'static {
+	fn locked_write(&self, data: &[u8]);
 }
 
-impl TestLogger {
-	pub fn new(_id: String) -> TestLogger {
-		TestLogger {
-			#[cfg(test)]
-			id: _id
-		}
+#[derive(Clone)]
+pub struct DevNull {}
+impl Output for DevNull {
+	fn locked_write(&self, _data: &[u8]) {}
+}
+#[derive(Clone)]
+pub struct StringBuffer(Arc<Mutex<String>>);
+impl Output for StringBuffer {
+	fn locked_write(&self, data: &[u8]) {
+		self.0.lock().unwrap().push_str(&String::from_utf8(data.to_vec()).unwrap());
+	}
+}
+impl StringBuffer {
+	pub fn new() -> Self {
+		Self(Arc::new(Mutex::new(String::new())))
+	}
+	pub fn into_string(self) -> String {
+		Arc::try_unwrap(self.0).unwrap().into_inner().unwrap()
 	}
 }
 
-impl Logger for TestLogger {
+pub struct TestLogger<Out : Output> {
+	id: String,
+	out: Out,
+}
+impl<Out: Output> TestLogger<Out> {
+	pub fn new(id: String, out: Out) -> TestLogger<Out> {
+		TestLogger { id, out }
+	}
+}
+
+struct LockedWriteAdapter<'a, Out: Output>(&'a Out);
+impl<'a, Out: Output> Write for LockedWriteAdapter<'a, Out> {
+	fn write(&mut self, data: &[u8]) -> Result<usize, std::io::Error> {
+		self.0.locked_write(data);
+		Ok(data.len())
+	}
+	fn flush(&mut self) -> Result<(), std::io::Error> { Ok(()) }
+}
+
+impl<Out: Output> Logger for TestLogger<Out> {
 	fn log(&self, record: &Record) {
-		#[cfg(test)]
-		println!("{:<5} {} [{} : {}, {}] {}", record.level.to_string(), self.id, record.module_path, record.file, record.line, record.args);
-		#[cfg(not(test))]
-		let _ = format!("{}", record.args);
+		write!(LockedWriteAdapter(&self.out),
+			"{:<5} {} [{} : {}, {}] {}\n", record.level.to_string(), self.id, record.module_path, record.file, record.line, record.args)
+			.unwrap();
 	}
 }


### PR DESCRIPTION
Adds threading (with logger capture) to fuzz targets so that we can
more effeciently test a failing fuzz corpus on new code changes.