### PR TITLE
Clean up ChannelKeys API

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -184,11 +184,11 @@ pub trait KeysInterface: Send + Sync {
 /// Readable/Writable to serialize out a unique reference to this set of keys so
 /// that you can serialize the full ChannelManager object.
 ///
-/// (TODO: We shouldn't require that, and should have an API to get them at deser time, due mostly
-/// to the possibility of reentrancy issues by calling the user's code during our deserialization
-/// routine).
-/// TODO: We should remove Clone by instead requesting a new ChannelKeys copy when we create
-/// ChannelMonitors instead of expecting to clone the one out of the Channel into the monitors.
+// (TODO: We shouldn't require that, and should have an API to get them at deser time, due mostly
+// to the possibility of reentrancy issues by calling the user's code during our deserialization
+// routine).
+// TODO: We should remove Clone by instead requesting a new ChannelKeys copy when we create
+// ChannelMonitors instead of expecting to clone the one out of the Channel into the monitors.
 pub trait ChannelKeys : Send+Clone {
 	/// Gets the private key for the anchor tx
 	fn funding_key<'a>(&'a self) -> &'a SecretKey;
@@ -209,18 +209,18 @@ pub trait ChannelKeys : Send+Clone {
 	/// Create a signature for a remote commitment transaction and associated HTLC transactions.
 	///
 	/// Note that if signing fails or is rejected, the channel will be force-closed.
-	///
-	/// TODO: Document the things someone using this interface should enforce before signing.
-	/// TODO: Add more input vars to enable better checking (preferably removing commitment_tx and
-	/// making the callee generate it via some util function we expose)!
+	//
+	// TODO: Document the things someone using this interface should enforce before signing.
+	// TODO: Add more input vars to enable better checking (preferably removing commitment_tx and
+	// making the callee generate it via some util function we expose)!
 	fn sign_remote_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, feerate_per_kw: u64, commitment_tx: &Transaction, keys: &TxCreationKeys, htlcs: &[&HTLCOutputInCommitment], to_self_delay: u16, secp_ctx: &Secp256k1<T>) -> Result<(Signature, Vec<Signature>), ()>;
 
 	/// Create a signature for a local commitment transaction. This will only ever be called with
 	/// the same local_commitment_tx (or a copy thereof), though there are currently no guarantees
 	/// that it will not be called multiple times.
-	///
-	/// TODO: Document the things someone using this interface should enforce before signing.
-	/// TODO: Add more input vars to enable better checking (preferably removing commitment_tx and
+	//
+	// TODO: Document the things someone using this interface should enforce before signing.
+	// TODO: Add more input vars to enable better checking (preferably removing commitment_tx and
 	fn sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()>;
 
 	/// Same as sign_local_commitment, but exists only for tests to get access to local commitment

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -484,10 +484,30 @@ pub fn build_htlc_transaction(prev_hash: &Sha256dHash, feerate_per_kw: u64, to_s
 /// to broadcast. Eventually this will require a signer which is possibly external, but for now we
 /// just pass in the SecretKeys required.
 pub struct LocalCommitmentTransaction {
-	tx: Transaction,
-	pub(crate) local_keys: TxCreationKeys,
-	pub(crate) feerate_per_kw: u64,
-	pub(crate) per_htlc: Vec<(HTLCOutputInCommitment, Option<Signature>)>,
+	// TODO: We should migrate away from providing the transaction, instead providing enough to
+	// allow the ChannelKeys to construct it from scratch. Luckily we already have HTLC data here,
+	// so we're probably most of the way there.
+	/// The commitment transaction itself, in unsigned form.
+	pub unsigned_tx: Transaction,
+	/// Our counterparty's signature for the transaction, above.
+	pub their_sig: Signature,
+	// Which order the signatures should go in when constructing the final commitment tx witness.
+	// The user should be able to reconstruc this themselves, so we don't bother to expose it.
+	our_sig_first: bool,
+	/// The key derivation parameters for this commitment transaction
+	pub local_keys: TxCreationKeys,
+	/// The feerate paid per 1000-weight-unit in this commitment transaction. This value is
+	/// controlled by the channel initiator.
+	pub feerate_per_kw: u64,
+	/// The HTLCs and remote htlc signatures which were included in this commitment transaction.
+	///
+	/// Note that this includes all HTLCs, including ones which were considered dust and not
+	/// actually included in the transaction as it appears on-chain, but who's value is burned as
+	/// fees and not included in the to_local or to_remote outputs.
+	///
+	/// The remote HTLC signatures in the second element will always be set for non-dust HTLCs, ie
+	/// those for which transaction_output_index.is_some().
+	pub per_htlc: Vec<(HTLCOutputInCommitment, Option<Signature>)>,
 }
 impl LocalCommitmentTransaction {
 	#[cfg(test)]
@@ -499,16 +519,19 @@ impl LocalCommitmentTransaction {
 			},
 			script_sig: Default::default(),
 			sequence: 0,
-			witness: vec![vec![], vec![], vec![]]
+			witness: vec![]
 		};
 		let dummy_key = PublicKey::from_secret_key(&Secp256k1::new(), &SecretKey::from_slice(&[42; 32]).unwrap());
+		let dummy_sig = Secp256k1::new().sign(&secp256k1::Message::from_slice(&[42; 32]).unwrap(), &SecretKey::from_slice(&[42; 32]).unwrap());
 		Self {
-			tx: Transaction {
+			unsigned_tx: Transaction {
 				version: 2,
 				input: vec![dummy_input],
 				output: Vec::new(),
 				lock_time: 0,
 			},
+			their_sig: dummy_sig,
+			our_sig_first: false,
 			local_keys: TxCreationKeys {
 					per_commitment_point: dummy_key.clone(),
 					revocation_key: dummy_key.clone(),
@@ -524,23 +547,14 @@ impl LocalCommitmentTransaction {
 
 	/// Generate a new LocalCommitmentTransaction based on a raw commitment transaction,
 	/// remote signature and both parties keys
-	pub(crate) fn new_missing_local_sig(mut tx: Transaction, their_sig: &Signature, our_funding_key: &PublicKey, their_funding_key: &PublicKey, local_keys: TxCreationKeys, feerate_per_kw: u64, htlc_data: Vec<(HTLCOutputInCommitment, Option<Signature>)>) -> LocalCommitmentTransaction {
-		if tx.input.len() != 1 { panic!("Tried to store a commitment transaction that had input count != 1!"); }
-		if tx.input[0].witness.len() != 0 { panic!("Tried to store a signed commitment transaction?"); }
+	pub(crate) fn new_missing_local_sig(unsigned_tx: Transaction, their_sig: Signature, our_funding_key: &PublicKey, their_funding_key: &PublicKey, local_keys: TxCreationKeys, feerate_per_kw: u64, htlc_data: Vec<(HTLCOutputInCommitment, Option<Signature>)>) -> LocalCommitmentTransaction {
+		if unsigned_tx.input.len() != 1 { panic!("Tried to store a commitment transaction that had input count != 1!"); }
+		if unsigned_tx.input[0].witness.len() != 0 { panic!("Tried to store a signed commitment transaction?"); }
 
-		tx.input[0].witness.push(Vec::new()); // First is the multisig dummy
-
-		if our_funding_key.serialize()[..] < their_funding_key.serialize()[..] {
-			tx.input[0].witness.push(Vec::new());
-			tx.input[0].witness.push(their_sig.serialize_der().to_vec());
-			tx.input[0].witness[2].push(SigHashType::All as u8);
-		} else {
-			tx.input[0].witness.push(their_sig.serialize_der().to_vec());
-			tx.input[0].witness[1].push(SigHashType::All as u8);
-			tx.input[0].witness.push(Vec::new());
-		}
-
-		Self { tx,
+		Self {
+			unsigned_tx,
+			their_sig,
+			our_sig_first: our_funding_key.serialize()[..] < their_funding_key.serialize()[..],
 			local_keys,
 			feerate_per_kw,
 			per_htlc: htlc_data,
@@ -550,22 +564,7 @@ impl LocalCommitmentTransaction {
 	/// Get the txid of the local commitment transaction contained in this
 	/// LocalCommitmentTransaction
 	pub fn txid(&self) -> Sha256dHash {
-		self.tx.txid()
-	}
-
-	/// Check if LocalCommitmentTransaction has already been signed by us
-	pub(crate) fn has_local_sig(&self) -> bool {
-		if self.tx.input.len() != 1 { panic!("Commitment transactions must have input count == 1!"); }
-		if self.tx.input[0].witness.len() == 4 {
-			assert!(!self.tx.input[0].witness[1].is_empty());
-			assert!(!self.tx.input[0].witness[2].is_empty());
-			true
-		} else {
-			assert_eq!(self.tx.input[0].witness.len(), 3);
-			assert!(self.tx.input[0].witness[0].is_empty());
-			assert!(self.tx.input[0].witness[1].is_empty() || self.tx.input[0].witness[2].is_empty());
-			false
-		}
+		self.unsigned_tx.txid()
 	}
 
 	/// Gets our signature for the contained commitment transaction given our funding private key.
@@ -577,32 +576,28 @@ impl LocalCommitmentTransaction {
 	/// ChannelKeys::sign_local_commitment() calls directly.
 	/// Channel value is amount locked in funding_outpoint.
 	pub fn get_local_sig<T: secp256k1::Signing>(&self, funding_key: &SecretKey, funding_redeemscript: &Script, channel_value_satoshis: u64, secp_ctx: &Secp256k1<T>) -> Signature {
-		let sighash = hash_to_message!(&bip143::SighashComponents::new(&self.tx)
-			.sighash_all(&self.tx.input[0], funding_redeemscript, channel_value_satoshis)[..]);
+		let sighash = hash_to_message!(&bip143::SighashComponents::new(&self.unsigned_tx)
+			.sighash_all(&self.unsigned_tx.input[0], funding_redeemscript, channel_value_satoshis)[..]);
 		secp_ctx.sign(&sighash, funding_key)
 	}
 
+	pub(crate) fn add_local_sig(&self, funding_redeemscript: &Script, our_sig: Signature) -> Transaction {
+		let mut tx = self.unsigned_tx.clone();
+		// First push the multisig dummy, note that due to BIP147 (NULLDUMMY) it must be a zero-length element.
+		tx.input[0].witness.push(Vec::new());
 
-	pub(crate) fn add_local_sig(&mut self, funding_redeemscript: &Script, our_sig: Signature) {
-		if self.has_local_sig() { return; }
-
-		if self.tx.input[0].witness[1].is_empty() {
-			self.tx.input[0].witness[1] = our_sig.serialize_der().to_vec();
-			self.tx.input[0].witness[1].push(SigHashType::All as u8);
+		if self.our_sig_first {
+			tx.input[0].witness.push(our_sig.serialize_der().to_vec());
+			tx.input[0].witness.push(self.their_sig.serialize_der().to_vec());
 		} else {
-			self.tx.input[0].witness[2] = our_sig.serialize_der().to_vec();
-			self.tx.input[0].witness[2].push(SigHashType::All as u8);
+			tx.input[0].witness.push(self.their_sig.serialize_der().to_vec());
+			tx.input[0].witness.push(our_sig.serialize_der().to_vec());
 		}
+		tx.input[0].witness[1].push(SigHashType::All as u8);
+		tx.input[0].witness[2].push(SigHashType::All as u8);
 
-		self.tx.input[0].witness.push(funding_redeemscript.as_bytes().to_vec());
-	}
-
-	/// Get raw transaction without asserting if witness is complete
-	pub(crate) fn without_valid_witness(&self) -> &Transaction { &self.tx }
-	/// Get raw transaction with panics if witness is incomplete
-	pub(crate) fn with_valid_witness(&self) -> &Transaction {
-		assert!(self.has_local_sig());
-		&self.tx
+		tx.input[0].witness.push(funding_redeemscript.as_bytes().to_vec());
+		tx
 	}
 
 	/// Get a signature for each HTLC which was included in the commitment transaction (ie for
@@ -679,12 +674,14 @@ impl PartialEq for LocalCommitmentTransaction {
 }
 impl Writeable for LocalCommitmentTransaction {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
-		if let Err(e) = self.tx.consensus_encode(&mut WriterWriteAdaptor(writer)) {
+		if let Err(e) = self.unsigned_tx.consensus_encode(&mut WriterWriteAdaptor(writer)) {
 			match e {
 				encode::Error::Io(e) => return Err(e),
 				_ => panic!("local tx must have been well-formed!"),
 			}
 		}
+		self.their_sig.write(writer)?;
+		self.our_sig_first.write(writer)?;
 		self.local_keys.write(writer)?;
 		self.feerate_per_kw.write(writer)?;
 		writer.write_all(&byte_utils::be64_to_array(self.per_htlc.len() as u64))?;
@@ -697,13 +694,15 @@ impl Writeable for LocalCommitmentTransaction {
 }
 impl Readable for LocalCommitmentTransaction {
 	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
-		let tx = match Transaction::consensus_decode(reader.by_ref()) {
+		let unsigned_tx = match Transaction::consensus_decode(reader.by_ref()) {
 			Ok(tx) => tx,
 			Err(e) => match e {
 				encode::Error::Io(ioe) => return Err(DecodeError::Io(ioe)),
 				_ => return Err(DecodeError::InvalidValue),
 			},
 		};
+		let their_sig = Readable::read(reader)?;
+		let our_sig_first = Readable::read(reader)?;
 		let local_keys = Readable::read(reader)?;
 		let feerate_per_kw = Readable::read(reader)?;
 		let htlcs_count: u64 = Readable::read(reader)?;
@@ -714,12 +713,14 @@ impl Readable for LocalCommitmentTransaction {
 			per_htlc.push((htlc, sigs));
 		}
 
-		if tx.input.len() != 1 {
+		if unsigned_tx.input.len() != 1 {
 			// Ensure tx didn't hit the 0-input ambiguity case.
 			return Err(DecodeError::InvalidValue);
 		}
 		Ok(Self {
-			tx,
+			unsigned_tx,
+			their_sig,
+			our_sig_first,
 			local_keys,
 			feerate_per_kw,
 			per_htlc,

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -614,8 +614,6 @@ impl LocalCommitmentTransaction {
 		for this_htlc in self.per_htlc.iter() {
 			if this_htlc.0.transaction_output_index.is_some() {
 				let htlc_tx = build_htlc_transaction(&txid, self.feerate_per_kw, local_csv, &this_htlc.0, &self.local_keys.a_delayed_payment_key, &self.local_keys.revocation_key);
-				assert_eq!(htlc_tx.input.len(), 1);
-				assert_eq!(htlc_tx.input[0].witness.len(), 0);
 
 				let htlc_redeemscript = get_htlc_redeemscript_with_explicit_keys(&this_htlc.0, &self.local_keys.a_htlc_key, &self.local_keys.b_htlc_key, &self.local_keys.revocation_key);
 
@@ -642,8 +640,6 @@ impl LocalCommitmentTransaction {
 		// Channel should have checked that we have a remote signature for this HTLC at
 		// creation, and we should have a sensible htlc transaction:
 		assert!(this_htlc.1.is_some());
-		assert_eq!(htlc_tx.input.len(), 1);
-		assert_eq!(htlc_tx.input[0].witness.len(), 0);
 
 		let htlc_redeemscript = get_htlc_redeemscript_with_explicit_keys(&this_htlc.0, &self.local_keys.a_htlc_key, &self.local_keys.b_htlc_key, &self.local_keys.revocation_key);
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4517,7 +4517,8 @@ mod tests {
 				assert_eq!(unsigned_tx.1.len(), per_htlc.len());
 
 				localtx = LocalCommitmentTransaction::new_missing_local_sig(unsigned_tx.0.clone(), &their_signature, &PublicKey::from_secret_key(&secp_ctx, chan.local_keys.funding_key()), chan.their_funding_pubkey(), keys.clone(), chan.feerate_per_kw, per_htlc);
-				chan_keys.sign_local_commitment(&mut localtx, &chan.secp_ctx);
+				let local_sig = chan_keys.sign_local_commitment(&localtx, &chan.secp_ctx).unwrap();
+				localtx.add_local_sig(&redeemscript, local_sig);
 
 				assert_eq!(serialize(localtx.with_valid_witness())[..],
 						hex::decode($tx_hex).unwrap()[..]);

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -442,9 +442,7 @@ pub(crate) enum InputMaterial {
 		preimage: Option<PaymentPreimage>,
 		amount: u64,
 	},
-	Funding {
-		channel_value: u64,
-	}
+	Funding {}
 }
 
 impl Writeable for InputMaterial  {
@@ -471,9 +469,8 @@ impl Writeable for InputMaterial  {
 				preimage.write(writer)?;
 				writer.write_all(&byte_utils::be64_to_array(*amount))?;
 			},
-			&InputMaterial::Funding { ref channel_value } => {
+			&InputMaterial::Funding {} => {
 				writer.write_all(&[3; 1])?;
-				channel_value.write(writer)?;
 			}
 		}
 		Ok(())
@@ -520,10 +517,7 @@ impl Readable for InputMaterial {
 				}
 			},
 			3 => {
-				let channel_value = Readable::read(reader)?;
-				InputMaterial::Funding {
-					channel_value
-				}
+				InputMaterial::Funding {}
 			}
 			_ => return Err(DecodeError::InvalidValue),
 		};
@@ -1864,7 +1858,7 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 		}
 		let should_broadcast = self.would_broadcast_at_height(height);
 		if should_broadcast {
-			claimable_outpoints.push(ClaimRequest { absolute_timelock: height, aggregable: false, outpoint: BitcoinOutPoint { txid: self.funding_info.0.txid.clone(), vout: self.funding_info.0.index as u32 }, witness_data: InputMaterial::Funding { channel_value: self.channel_value_satoshis }});
+			claimable_outpoints.push(ClaimRequest { absolute_timelock: height, aggregable: false, outpoint: BitcoinOutPoint { txid: self.funding_info.0.txid.clone(), vout: self.funding_info.0.index as u32 }, witness_data: InputMaterial::Funding {}});
 		}
 		if should_broadcast {
 			if let Some(commitment_tx) = self.onchain_tx_handler.get_fully_signed_local_tx() {

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -1066,8 +1066,8 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 
 		let mut onchain_tx_handler = OnchainTxHandler::new(destination_script.clone(), keys.clone(), their_to_self_delay, logger.clone());
 
-		let local_tx_sequence = initial_local_commitment_tx.without_valid_witness().input[0].sequence as u64;
-		let local_tx_locktime = initial_local_commitment_tx.without_valid_witness().lock_time as u64;
+		let local_tx_sequence = initial_local_commitment_tx.unsigned_tx.input[0].sequence as u64;
+		let local_tx_locktime = initial_local_commitment_tx.unsigned_tx.lock_time as u64;
 		let local_commitment_tx = LocalSignedTx {
 			txid: initial_local_commitment_tx.txid(),
 			revocation_key: initial_local_commitment_tx.local_keys.revocation_key,
@@ -1249,8 +1249,8 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 			return Err(MonitorUpdateError("A local commitment tx has already been signed, no new local commitment txn can be sent to our counterparty"));
 		}
 		let txid = commitment_tx.txid();
-		let sequence = commitment_tx.without_valid_witness().input[0].sequence as u64;
-		let locktime = commitment_tx.without_valid_witness().lock_time as u64;
+		let sequence = commitment_tx.unsigned_tx.input[0].sequence as u64;
+		let locktime = commitment_tx.unsigned_tx.lock_time as u64;
 		let mut new_local_commitment_tx = LocalSignedTx {
 			txid,
 			revocation_key: commitment_tx.local_keys.revocation_key,

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -531,16 +531,11 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 						}
 						return None;
 					},
-					&InputMaterial::Funding { ref channel_value } => {
+					&InputMaterial::Funding {} => {
 						let signed_tx = self.get_fully_signed_local_tx().unwrap();
-						let mut amt_outputs = 0;
-						for outp in signed_tx.output.iter() {
-							amt_outputs += outp.value;
-						}
-						let feerate = (channel_value - amt_outputs) * 1000 / signed_tx.get_weight() as u64;
 						// Timer set to $NEVER given we can't bump tx without anchor outputs
 						log_trace!(self, "Going to broadcast Local Transaction {} claiming funding output {} from {}...", signed_tx.txid(), outp.vout, outp.txid);
-						return Some((None, feerate, signed_tx));
+						return Some((None, self.local_commitment.as_ref().unwrap().feerate_per_kw, signed_tx));
 					}
 					_ => unreachable!()
 				}

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -10,7 +10,7 @@ use bitcoin::util::bip143;
 
 use bitcoin_hashes::sha256d::Hash as Sha256dHash;
 
-use secp256k1::Secp256k1;
+use secp256k1::{Secp256k1, Signature};
 use secp256k1;
 
 use ln::msgs::DecodeError;
@@ -137,13 +137,63 @@ macro_rules! subtract_high_prio_fee {
 	}
 }
 
+impl Readable for Option<Vec<Option<(usize, Signature)>>> {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		match Readable::read(reader)? {
+			0u8 => Ok(None),
+			1u8 => {
+				let vlen: u64 = Readable::read(reader)?;
+				let mut ret = Vec::with_capacity(cmp::min(vlen as usize, MAX_ALLOC_SIZE / ::std::mem::size_of::<Option<(usize, Signature)>>()));
+				for _ in 0..vlen {
+					ret.push(match Readable::read(reader)? {
+						0u8 => None,
+						1u8 => Some((<u64 as Readable>::read(reader)? as usize, Readable::read(reader)?)),
+						_ => return Err(DecodeError::InvalidValue)
+					});
+				}
+				Ok(Some(ret))
+			},
+			_ => Err(DecodeError::InvalidValue),
+		}
+	}
+}
+
+impl Writeable for Option<Vec<Option<(usize, Signature)>>> {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
+		match self {
+			&Some(ref vec) => {
+				1u8.write(writer)?;
+				(vec.len() as u64).write(writer)?;
+				for opt in vec.iter() {
+					match opt {
+						&Some((ref idx, ref sig)) => {
+							1u8.write(writer)?;
+							(*idx as u64).write(writer)?;
+							sig.write(writer)?;
+						},
+						&None => 0u8.write(writer)?,
+					}
+				}
+			},
+			&None => 0u8.write(writer)?,
+		}
+		Ok(())
+	}
+}
+
 
 /// OnchainTxHandler receives claiming requests, aggregates them if it's sound, broadcast and
 /// do RBF bumping if possible.
 pub struct OnchainTxHandler<ChanSigner: ChannelKeys> {
 	destination_script: Script,
 	local_commitment: Option<LocalCommitmentTransaction>,
+	// local_htlc_sigs and prev_local_htlc_sigs are in the order as they appear in the commitment
+	// transaction outputs (hence the Option<>s inside the Vec). The first usize is the index in
+	// the set of HTLCs in the LocalCommitmentTransaction (including those which do not appear in
+	// the commitment transaction).
+	local_htlc_sigs: Option<Vec<Option<(usize, Signature)>>>,
 	prev_local_commitment: Option<LocalCommitmentTransaction>,
+	prev_local_htlc_sigs: Option<Vec<Option<(usize, Signature)>>>,
 	local_csv: u16,
 
 	key_storage: ChanSigner,
@@ -185,7 +235,9 @@ impl<ChanSigner: ChannelKeys + Writeable> OnchainTxHandler<ChanSigner> {
 	pub(crate) fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
 		self.destination_script.write(writer)?;
 		self.local_commitment.write(writer)?;
+		self.local_htlc_sigs.write(writer)?;
 		self.prev_local_commitment.write(writer)?;
+		self.prev_local_htlc_sigs.write(writer)?;
 
 		self.local_csv.write(writer)?;
 
@@ -231,7 +283,9 @@ impl<ChanSigner: ChannelKeys + Readable> ReadableArgs<Arc<Logger>> for OnchainTx
 		let destination_script = Readable::read(reader)?;
 
 		let local_commitment = Readable::read(reader)?;
+		let local_htlc_sigs = Readable::read(reader)?;
 		let prev_local_commitment = Readable::read(reader)?;
+		let prev_local_htlc_sigs = Readable::read(reader)?;
 
 		let local_csv = Readable::read(reader)?;
 
@@ -283,7 +337,9 @@ impl<ChanSigner: ChannelKeys + Readable> ReadableArgs<Arc<Logger>> for OnchainTx
 		Ok(OnchainTxHandler {
 			destination_script,
 			local_commitment,
+			local_htlc_sigs,
 			prev_local_commitment,
+			prev_local_htlc_sigs,
 			local_csv,
 			key_storage,
 			claimable_outpoints,
@@ -303,7 +359,9 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 		OnchainTxHandler {
 			destination_script,
 			local_commitment: None,
+			local_htlc_sigs: None,
 			prev_local_commitment: None,
+			prev_local_htlc_sigs: None,
 			local_csv,
 			key_storage,
 			pending_claim_requests: HashMap::new(),
@@ -510,19 +568,7 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 			for (_, (outp, per_outp_material)) in cached_claim_datas.per_input_material.iter().enumerate() {
 				match per_outp_material {
 					&InputMaterial::LocalHTLC { ref preimage, ref amount } => {
-						let mut htlc_tx = None;
-						if let Some(ref mut local_commitment) = self.local_commitment {
-							if local_commitment.txid() == outp.txid {
-								self.key_storage.sign_htlc_transaction(local_commitment, outp.vout, *preimage, self.local_csv, &self.secp_ctx);
-								htlc_tx = local_commitment.htlc_with_valid_witness(outp.vout).clone();
-							}
-						}
-						if let Some(ref mut prev_local_commitment) = self.prev_local_commitment {
-							if prev_local_commitment.txid() == outp.txid {
-								self.key_storage.sign_htlc_transaction(prev_local_commitment, outp.vout, *preimage, self.local_csv, &self.secp_ctx);
-								htlc_tx = prev_local_commitment.htlc_with_valid_witness(outp.vout).clone();
-							}
-						}
+						let htlc_tx = self.get_fully_signed_htlc_tx(outp, preimage);
 						if let Some(htlc_tx) = htlc_tx {
 							let feerate = (amount - htlc_tx.output[0].value) * 1000 / htlc_tx.get_weight() as u64;
 							// Timer set to $NEVER given we can't bump tx without anchor outputs
@@ -771,9 +817,45 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 		if let Some(ref local_commitment) = self.local_commitment {
 			if local_commitment.has_local_sig() { return Err(()) }
 		}
+		if self.local_htlc_sigs.is_some() || self.prev_local_htlc_sigs.is_some() {
+			return Err(());
+		}
 		self.prev_local_commitment = self.local_commitment.take();
 		self.local_commitment = Some(tx);
 		Ok(())
+	}
+
+	fn sign_latest_local_htlcs(&mut self) {
+		if let Some(ref local_commitment) = self.local_commitment {
+			if let Ok(sigs) = self.key_storage.sign_local_commitment_htlc_transactions(local_commitment, self.local_csv, &self.secp_ctx) {
+				self.local_htlc_sigs = Some(Vec::new());
+				let ret = self.local_htlc_sigs.as_mut().unwrap();
+				for (htlc_idx, (local_sig, &(ref htlc, _))) in sigs.iter().zip(local_commitment.per_htlc.iter()).enumerate() {
+					if let Some(tx_idx) = htlc.transaction_output_index {
+						if ret.len() <= tx_idx as usize { ret.resize(tx_idx as usize + 1, None); }
+						ret[tx_idx as usize] = Some((htlc_idx, local_sig.expect("Did not receive a signature for a non-dust HTLC")));
+					} else {
+						assert!(local_sig.is_none(), "Received a signature for a dust HTLC");
+					}
+				}
+			}
+		}
+	}
+	fn sign_prev_local_htlcs(&mut self) {
+		if let Some(ref local_commitment) = self.prev_local_commitment {
+			if let Ok(sigs) = self.key_storage.sign_local_commitment_htlc_transactions(local_commitment, self.local_csv, &self.secp_ctx) {
+				self.prev_local_htlc_sigs = Some(Vec::new());
+				let ret = self.prev_local_htlc_sigs.as_mut().unwrap();
+				for (htlc_idx, (local_sig, &(ref htlc, _))) in sigs.iter().zip(local_commitment.per_htlc.iter()).enumerate() {
+					if let Some(tx_idx) = htlc.transaction_output_index {
+						if ret.len() <= tx_idx as usize { ret.resize(tx_idx as usize + 1, None); }
+						ret[tx_idx as usize] = Some((htlc_idx, local_sig.expect("Did not receive a signature for a non-dust HTLC")));
+					} else {
+						assert!(local_sig.is_none(), "Received a signature for a dust HTLC");
+					}
+				}
+			}
+		}
 	}
 
 	//TODO: getting lastest local transactions should be infaillible and result in us "force-closing the channel", but we may
@@ -804,14 +886,44 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 		None
 	}
 
-	pub(super) fn get_fully_signed_htlc_tx(&mut self, txid: Sha256dHash, htlc_index: u32, preimage: Option<PaymentPreimage>) -> Option<Transaction> {
-		//TODO: store preimage in OnchainTxHandler
-		if let Some(ref mut local_commitment) = self.local_commitment {
-			if local_commitment.txid() == txid {
-				self.key_storage.sign_htlc_transaction(local_commitment, htlc_index, preimage, self.local_csv, &self.secp_ctx);
-				return local_commitment.htlc_with_valid_witness(htlc_index).clone();
+	pub(super) fn get_fully_signed_htlc_tx(&mut self, outp: &::bitcoin::OutPoint, preimage: &Option<PaymentPreimage>) -> Option<Transaction> {
+		let mut htlc_tx = None;
+		if self.local_commitment.is_some() {
+			let commitment_txid = self.local_commitment.as_ref().unwrap().txid();
+			if commitment_txid == outp.txid {
+				self.sign_latest_local_htlcs();
+				if let &Some(ref htlc_sigs) = &self.local_htlc_sigs {
+					let &(ref htlc_idx, ref htlc_sig) = htlc_sigs[outp.vout as usize].as_ref().unwrap();
+					htlc_tx = Some(self.local_commitment.as_ref().unwrap()
+						.get_signed_htlc_tx(*htlc_idx, htlc_sig, preimage, self.local_csv));
+				}
 			}
 		}
-		None
+		if self.prev_local_commitment.is_some() {
+			let commitment_txid = self.prev_local_commitment.as_ref().unwrap().txid();
+			if commitment_txid == outp.txid {
+				self.sign_prev_local_htlcs();
+				if let &Some(ref htlc_sigs) = &self.prev_local_htlc_sigs {
+					let &(ref htlc_idx, ref htlc_sig) = htlc_sigs[outp.vout as usize].as_ref().unwrap();
+					htlc_tx = Some(self.prev_local_commitment.as_ref().unwrap()
+						.get_signed_htlc_tx(*htlc_idx, htlc_sig, preimage, self.local_csv));
+				}
+			}
+		}
+		htlc_tx
+	}
+
+	#[cfg(test)]
+	pub(super) fn unsafe_get_fully_signed_htlc_tx(&mut self, outp: &::bitcoin::OutPoint, preimage: &Option<PaymentPreimage>) -> Option<Transaction> {
+		let latest_had_sigs = self.local_htlc_sigs.is_some();
+		let prev_had_sigs = self.prev_local_htlc_sigs.is_some();
+		let ret = self.get_fully_signed_htlc_tx(outp, preimage);
+		if !latest_had_sigs {
+			self.local_htlc_sigs = None;
+		}
+		if !prev_had_sigs {
+			self.prev_local_htlc_sigs = None;
+		}
+		ret
 	}
 }

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -79,13 +79,13 @@ impl ChannelKeys for EnforcingChannelKeys {
 		Ok(self.inner.sign_remote_commitment(feerate_per_kw, commitment_tx, keys, htlcs, to_self_delay, secp_ctx).unwrap())
 	}
 
-	fn sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &mut LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) {
+	fn sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()> {
 		self.inner.sign_local_commitment(local_commitment_tx, secp_ctx)
 	}
 
 	#[cfg(test)]
-	fn unsafe_sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &mut LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) {
-		self.inner.unsafe_sign_local_commitment(local_commitment_tx, secp_ctx);
+	fn unsafe_sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()> {
+		self.inner.unsafe_sign_local_commitment(local_commitment_tx, secp_ctx)
 	}
 
 	fn sign_htlc_transaction<T: secp256k1::Signing>(&self, local_commitment_tx: &mut LocalCommitmentTransaction, htlc_index: u32, preimage: Option<PaymentPreimage>, local_csv: u16, secp_ctx: &Secp256k1<T>) {

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -1,5 +1,8 @@
 //! Some utility modules live here. See individual sub-modules for more info.
 
+#[macro_use]
+pub(crate) mod fuzz_wrappers;
+
 pub mod events;
 pub mod errors;
 pub mod ser;
@@ -27,6 +30,3 @@ pub(crate) mod test_utils;
 /// machine errors and used in fuzz targets and tests.
 #[cfg(any(test, feature = "fuzztarget"))]
 pub mod enforcing_trait_impls;
-
-#[macro_use]
-pub(crate) mod fuzz_wrappers;


### PR DESCRIPTION
Based on #597, this cleans up the ChannelKeys API a bunch, closing #567. I'm not convinced the internal interfaces are quite where they need to be, but its a bit better than it was, and we can improve it as we move all signing external.