### PR TITLE
Fix build warnings

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -620,6 +620,6 @@ impl KeysInterface for KeysManager {
 		let child_privkey = self.channel_id_master_key.ckd_priv(&self.secp_ctx, ChildNumber::from_hardened_idx(child_ix as u32).expect("key space exhausted")).expect("Your RNG is busted");
 		sha.input(&child_privkey.private_key.key[..]);
 
-		(Sha256::from_engine(sha).into_inner())
+		Sha256::from_engine(sha).into_inner()
 	}
 }

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -696,6 +696,7 @@ impl Error for DecodeError {
 			DecodeError::InvalidValue => "Nonsense bytes didn't map to the type they were interpreted as",
 			DecodeError::ShortRead => "Packet extended beyond the provided bytes",
 			DecodeError::BadLengthDescriptor => "A length descriptor in the packet didn't describe the later data correctly",
+			#[allow(deprecated)]
 			DecodeError::Io(ref e) => e.description(),
 		}
 	}

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -702,6 +702,7 @@ impl Error for DecodeError {
 }
 impl fmt::Display for DecodeError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		#[allow(deprecated)]
 		f.write_str(self.description())
 	}
 }


### PR DESCRIPTION
I have noticed few build warnings on master and I thought I'd give a go at suppressing them. So far I have not changed any software behaviour, just removed unused parentheses and removed the warning using an `allow` attribute.

I have justified the used of the `allow` attribute in the commit.
Do you prefer justifying the use of `allow` attribute with in code comments?

Also, I assume that we are keeping the used of `description()` in purpose. Let me know if you'd prefer to see an implementation and use of the `Display` trait instead (as per Rust's recommendation).

I have not removed the warning `warning: field is never read: 'logger'` for `ChainWatchInterfaceUtil` and `KeysManager` because indeed, it is never read and I cannot seem to grasp why this field is present.

Some guidance would be greatly appreciated 🙂