### PR TITLE
Improve type safety for message failures

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1577,9 +1577,14 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> ChannelMan
 											htlc_id: prev_htlc_id,
 											incoming_packet_shared_secret: forward_info.incoming_shared_secret,
 										});
-										failed_forwards.push((htlc_source, forward_info.payment_hash,
-											HTLCFailReason::Reason { failure_code: 0x4000 | 10, data: Vec::new() }
+										failed_forwards.push((
+											htlc_source,
+											forward_info.payment_hash,
+											HTLCFailReason::TypedReason(
+												MessageFailure::UnknownNextPeer,
+											),
 										));
+
 									},
 									HTLCForwardInfo::FailHTLC { .. } => {
 										// Channel went away before we could fail it. This implies

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -868,7 +868,13 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> ChannelMan
 			}
 		};
 		for htlc_source in failed_htlcs.drain(..) {
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_source.0, &htlc_source.1, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
+			self.fail_htlc_backwards_internal(
+				self.channel_state.lock().unwrap(),
+				htlc_source.0,
+				&htlc_source.1,
+				HTLCFailReason::TypedReason(MessageFailure::PermanentChannelFailure),
+			);
+
 		}
 		let chan_update = if let Some(chan) = chan_option {
 			if let Ok(update) = self.get_channel_update(&chan) {
@@ -891,7 +897,12 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> ChannelMan
 		let (funding_txo_option, monitor_update, mut failed_htlcs) = shutdown_res;
 		log_trace!(self, "Finishing force-closure of channel {} HTLCs to fail", failed_htlcs.len());
 		for htlc_source in failed_htlcs.drain(..) {
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_source.0, &htlc_source.1, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
+			self.fail_htlc_backwards_internal(
+				self.channel_state.lock().unwrap(),
+				htlc_source.0,
+				&htlc_source.1,
+				HTLCFailReason::TypedReason(MessageFailure::PermanentChannelFailure)
+			);
 		}
 		if let Some(funding_txo) = funding_txo_option {
 			// There isn't anything we can do if we get an update failure - we're already
@@ -2441,7 +2452,12 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> ChannelMan
 			}
 		};
 		for htlc_source in dropped_htlcs.drain(..) {
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_source.0, &htlc_source.1, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
+			self.fail_htlc_backwards_internal(
+				self.channel_state.lock().unwrap(),
+				htlc_source.0,
+				&htlc_source.1,
+				HTLCFailReason::TypedReason(MessageFailure::PermanentChannelFailure)
+			);
 		}
 		if let Some(chan) = chan_option {
 			if let Ok(update) = self.get_channel_update(&chan) {
@@ -2942,7 +2958,12 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> events::Me
 					self.claim_funds_internal(self.channel_state.lock().unwrap(), htlc_update.source, preimage);
 				} else {
 					log_trace!(self, "Failing HTLC with hash {} from our monitor", log_bytes!(htlc_update.payment_hash.0));
-					self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_update.source, &htlc_update.payment_hash, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
+					self.fail_htlc_backwards_internal(
+						self.channel_state.lock().unwrap(),
+						htlc_update.source,
+						&htlc_update.payment_hash,
+						HTLCFailReason::TypedReason(MessageFailure::PermanentChannelFailure)
+					);
 				}
 			}
 		}
@@ -2972,7 +2993,12 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref> events::Ev
 					self.claim_funds_internal(self.channel_state.lock().unwrap(), htlc_update.source, preimage);
 				} else {
 					log_trace!(self, "Failing HTLC with hash {} from our monitor", log_bytes!(htlc_update.payment_hash.0));
-					self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_update.source, &htlc_update.payment_hash, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
+					self.fail_htlc_backwards_internal(
+						self.channel_state.lock().unwrap(),
+						htlc_update.source,
+						&htlc_update.payment_hash,
+						HTLCFailReason::TypedReason(MessageFailure::PermanentChannelFailure)
+					);
 				}
 			}
 		}
@@ -3827,7 +3853,12 @@ impl<'a, ChanSigner: ChannelKeys + Readable, M: Deref, T: Deref, K: Deref, F: De
 		};
 
 		for htlc_source in failed_htlcs.drain(..) {
-			channel_manager.fail_htlc_backwards_internal(channel_manager.channel_state.lock().unwrap(), htlc_source.0, &htlc_source.1, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
+			channel_manager.fail_htlc_backwards_internal(
+				channel_manager.channel_state.lock().unwrap(),
+				htlc_source.0,
+				&htlc_source.1,
+				HTLCFailReason::TypedReason(MessageFailure::PermanentChannelFailure)
+			);
 		}
 
 		//TODO: Broadcast channel update for closed channels, but only after we've made a

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5408,12 +5408,10 @@ impl Writeable for BogusOnionHopData {
 fn test_onion_failure() {
 	use ln::msgs::ChannelUpdate;
 	use ln::channelmanager::CLTV_FAR_FAR_AWAY;
+	use ln::onion_utils::{NODE, PERM, UPDATE};
 	use secp256k1;
 
 	const BADONION: u16 = 0x8000;
-	const PERM: u16 = 0x4000;
-	const NODE: u16 = 0x2000;
-	const UPDATE: u16 = 0x1000;
 
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -317,6 +317,7 @@ pub(super) fn build_first_hop_failure_packet(shared_secret: &[u8], failure_type:
 #[derive(Clone)]
 pub(crate) enum MessageFailure {
 	IncorrectOrUnknownPaymentDetails { htlc_msat: u64, height: u32 },
+	PermanentChannelFailure,
 }
 
 impl MessageFailure {
@@ -324,6 +325,7 @@ impl MessageFailure {
 		use ln::onion_utils::MessageFailure::*;
 		match *self {
 			IncorrectOrUnknownPaymentDetails { .. } => 0x4000 | 15,
+			PermanentChannelFailure => 0x4000 | 8,
 		}
 	}
 
@@ -334,7 +336,8 @@ impl MessageFailure {
 				let mut data = byte_utils::be64_to_array(htlc_msat).to_vec();
 				data.extend_from_slice(&byte_utils::be32_to_array(height));
 				data
-			}
+			},
+			&PermanentChannelFailure => Vec::new()
 		}
 	}
 }

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -318,6 +318,7 @@ pub(super) fn build_first_hop_failure_packet(shared_secret: &[u8], failure_type:
 pub(crate) enum MessageFailure {
 	IncorrectOrUnknownPaymentDetails { htlc_msat: u64, height: u32 },
 	PermanentChannelFailure,
+	UnknownNextPeer,
 }
 
 impl MessageFailure {
@@ -326,6 +327,7 @@ impl MessageFailure {
 		match *self {
 			IncorrectOrUnknownPaymentDetails { .. } => 0x4000 | 15,
 			PermanentChannelFailure => 0x4000 | 8,
+			UnknownNextPeer => 0x4000 | 10,
 		}
 	}
 
@@ -337,7 +339,8 @@ impl MessageFailure {
 				data.extend_from_slice(&byte_utils::be32_to_array(height));
 				data
 			},
-			&PermanentChannelFailure => Vec::new()
+			&PermanentChannelFailure => Vec::new(),
+			&UnknownNextPeer => Vec::new()
 		}
 	}
 }


### PR DESCRIPTION
_Follow-up of #596_

Edit: Ready for review.

This a step towards a safer handling of failure code and associated data by using  a new `MessageFailure` enum instead of serialising the code and data on call site.

I see several ways to follow-up with this change:
1. Deserialise all possible message failures to `MessageFailure`, allowing the removal of the `HTLCFailReason::Reason` variant.
2. Continue to replace call site assignment of code value with instantiation of `MessageFailure` variables.

One downside of this solution is that I had to clone `ChannelUpdate`. Let me know if you'd prefer I optimise this before merging.