### PR TITLE
Making message size limit an exportable constant

### DIFF
--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -35,3 +35,5 @@ mod functional_tests;
 mod chanmon_update_fail_tests;
 #[cfg(test)]
 mod reorg_tests;
+
+pub use self::wire::LN_MAX_MSG_LEN;

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -36,4 +36,4 @@ mod chanmon_update_fail_tests;
 #[cfg(test)]
 mod reorg_tests;
 
-pub use self::wire::LN_MAX_MSG_LEN;
+pub use self::peer_channel_encryptor::LN_MAX_MSG_LEN;

--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -421,7 +421,7 @@ impl PeerChannelEncryptor {
 				*rn += 1;
 				Ok(byte_utils::slice_to_be16(&res))
 			},
-			_ => panic!("Tried to encrypt a message prior to noise handshake completion"),
+			_ => panic!("Tried to decrypt a message prior to noise handshake completion"),
 		}
 	}
 
@@ -429,7 +429,7 @@ impl PeerChannelEncryptor {
 	/// panics if msg.len() > 65535 + 16
 	pub fn decrypt_message(&mut self, msg: &[u8]) -> Result<Vec<u8>, LightningError> {
 		if msg.len() > LN_MAX_MSG_LEN + 16 {
-			panic!("Attempted to encrypt message longer than 65535 bytes!");
+			panic!("Attempted to decrypt message longer than 65535 + 16 bytes!");
 		}
 
 		match self.noise_state {
@@ -441,7 +441,7 @@ impl PeerChannelEncryptor {
 
 				Ok(res)
 			},
-			_ => panic!("Tried to encrypt a message prior to noise handshake completion"),
+			_ => panic!("Tried to decrypt a message prior to noise handshake completion"),
 		}
 	}
 

--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -1,5 +1,6 @@
 use ln::msgs::LightningError;
 use ln::msgs;
+use ln::wire::LN_MAX_MSG_LEN;
 
 use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -373,7 +374,7 @@ impl PeerChannelEncryptor {
 	/// Encrypts the given message, returning the encrypted version
 	/// panics if msg.len() > 65535 or Noise handshake has not finished.
 	pub fn encrypt_message(&mut self, msg: &[u8]) -> Vec<u8> {
-		if msg.len() > 65535 {
+		if msg.len() > LN_MAX_MSG_LEN {
 			panic!("Attempted to encrypt message longer than 65535 bytes!");
 		}
 
@@ -427,7 +428,7 @@ impl PeerChannelEncryptor {
 	/// Decrypts the given message.
 	/// panics if msg.len() > 65535 + 16
 	pub fn decrypt_message(&mut self, msg: &[u8]) -> Result<Vec<u8>, LightningError> {
-		if msg.len() > 65535 + 16 {
+		if msg.len() > LN_MAX_MSG_LEN + 16 {
 			panic!("Attempted to encrypt message longer than 65535 bytes!");
 		}
 

--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -1,6 +1,5 @@
 use ln::msgs::LightningError;
 use ln::msgs;
-use ln::wire::LN_MAX_MSG_LEN;
 
 use bitcoin::hashes::{Hash, HashEngine, Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -12,6 +11,11 @@ use bitcoin::secp256k1;
 
 use util::chacha20poly1305rfc::ChaCha20Poly1305RFC;
 use util::byte_utils;
+
+/// Maximum Lightning message data length according to
+/// [BOLT-8](https://github.com/lightningnetwork/lightning-rfc/blob/v1.0/08-transport.md#lightning-message-specification)
+/// and [BOLT-1](https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#lightning-message-format):
+pub const LN_MAX_MSG_LEN: usize = ::std::u16::MAX as usize; // Must be equal to 65535
 
 // Sha256("Noise_XK_secp256k1_ChaChaPoly_SHA256")
 const NOISE_CK: [u8; 32] = [0x26, 0x40, 0xf5, 0x2e, 0xeb, 0xcd, 0x9e, 0x88, 0x29, 0x58, 0x95, 0x1c, 0x79, 0x42, 0x50, 0xee, 0xdb, 0x28, 0x00, 0x2c, 0x05, 0xd7, 0xdc, 0x2e, 0xa0, 0xf1, 0x95, 0x40, 0x60, 0x42, 0xca, 0xf1];
@@ -696,6 +700,12 @@ mod tests {
 				assert_eq!(res, hex::decode("2ecd8c8a5629d0d02ab457a0fdd0f7b90a192cd46be5ecb6ca570bfc5e268338b1a16cf4ef2d36").unwrap());
 			}
 		}
+	}
+
+	#[test]
+	fn max_msg_len_limit_value() {
+		assert_eq!(LN_MAX_MSG_LEN, 65535);
+		assert_eq!(LN_MAX_MSG_LEN, ::std::u16::MAX as usize);
 	}
 
 	#[test]

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -17,10 +17,8 @@ use ln::msgs;
 use util::ser::{Readable, Writeable, Writer};
 
 /// Maximum Lightning message data length according to
-/// [BOLT-8](https://github.com/lightningnetwork/lightning-rfc/blob/v1.0/08-transport.md#lightning-message-specification):
-/// "The maximum size of any Lightning message MUST NOT exceed 65535 bytes.
-/// A maximum size of 65535 simplifies testing, makes memory management easier,
-/// and helps mitigate memory-exhaustion attacks."
+/// [BOLT-8](https://github.com/lightningnetwork/lightning-rfc/blob/v1.0/08-transport.md#lightning-message-specification)
+/// and [BOLT-1](https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#lightning-message-format):
 pub const LN_MAX_MSG_LEN: usize = std::u16::MAX as usize; // Must be equal to 65535
 
 /// A Lightning message returned by [`read`] when decoding bytes received over the wire. Each

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -21,7 +21,7 @@ use util::ser::{Readable, Writeable, Writer};
 /// "The maximum size of any Lightning message MUST NOT exceed 65535 bytes.
 /// A maximum size of 65535 simplifies testing, makes memory management easier,
 /// and helps mitigate memory-exhaustion attacks."
-pub const LN_MAX_MSG_LEN: usize = 65535;
+pub const LN_MAX_MSG_LEN: usize = std::u16::MAX as usize; // Must be equal to 65535
 
 /// A Lightning message returned by [`read`] when decoding bytes received over the wire. Each
 /// variant contains a message from [`ln::msgs`] or otherwise the message type if unknown.
@@ -317,6 +317,12 @@ mod tests {
 
 	// Big-endian wire encoding of Pong message (type = 19, byteslen = 2).
 	const ENCODED_PONG: [u8; 6] = [0u8, 19u8, 0u8, 2u8, 0u8, 0u8];
+
+	#[test]
+	fn max_msg_len() {
+		assert_eq!(LN_MAX_MSG_LEN, 65535);
+		assert_eq!(LN_MAX_MSG_LEN, std::u16::MAX as usize);
+	}
 
 	#[test]
 	fn read_empty_buffer() {

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -16,11 +16,6 @@
 use ln::msgs;
 use util::ser::{Readable, Writeable, Writer};
 
-/// Maximum Lightning message data length according to
-/// [BOLT-8](https://github.com/lightningnetwork/lightning-rfc/blob/v1.0/08-transport.md#lightning-message-specification)
-/// and [BOLT-1](https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#lightning-message-format):
-pub const LN_MAX_MSG_LEN: usize = std::u16::MAX as usize; // Must be equal to 65535
-
 /// A Lightning message returned by [`read`] when decoding bytes received over the wire. Each
 /// variant contains a message from [`ln::msgs`] or otherwise the message type if unknown.
 ///
@@ -315,12 +310,6 @@ mod tests {
 
 	// Big-endian wire encoding of Pong message (type = 19, byteslen = 2).
 	const ENCODED_PONG: [u8; 6] = [0u8, 19u8, 0u8, 2u8, 0u8, 0u8];
-
-	#[test]
-	fn max_msg_len() {
-		assert_eq!(LN_MAX_MSG_LEN, 65535);
-		assert_eq!(LN_MAX_MSG_LEN, std::u16::MAX as usize);
-	}
 
 	#[test]
 	fn read_empty_buffer() {

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -16,6 +16,13 @@
 use ln::msgs;
 use util::ser::{Readable, Writeable, Writer};
 
+/// Maximum Lightning message data length according to
+/// [BOLT-8](https://github.com/lightningnetwork/lightning-rfc/blob/v1.0/08-transport.md#lightning-message-specification):
+/// "The maximum size of any Lightning message MUST NOT exceed 65535 bytes.
+/// A maximum size of 65535 simplifies testing, makes memory management easier,
+/// and helps mitigate memory-exhaustion attacks."
+pub const LN_MAX_MSG_LEN: usize = 65535;
+
 /// A Lightning message returned by [`read`] when decoding bytes received over the wire. Each
 /// variant contains a message from [`ln::msgs`] or otherwise the message type if unknown.
 ///


### PR DESCRIPTION
It's always better to have all magic numbers defined in specs in form of global constants rather than in-code literals