### PR TITLE
Add ChannelScore struct (WIP)

### DIFF
--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -770,7 +770,7 @@ macro_rules! expect_payment_failed {
 		let events = $node.node.get_and_clear_pending_events();
 		assert_eq!(events.len(), 1);
 		match events[0] {
-			Event::PaymentFailed { ref payment_hash, rejected_by_dest, ref error_code, ref error_data } => {
+			Event::PaymentFailed { ref payment_hash, rejected_by_dest, faultive_node: _, ref error_code, ref error_data } => {
 				assert_eq!(*payment_hash, $expected_payment_hash);
 				assert_eq!(rejected_by_dest, $rejected_by_dest);
 				assert!(error_code.is_some());

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5658,7 +5658,7 @@ fn run_onion_failure_test_with_fail_intercept<F1,F2,F3>(_name: &str, test_case: 
 
 	let events = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 1);
-	if let &Event::PaymentFailed { payment_hash:_, ref rejected_by_dest, ref error_code, error_data: _ } = &events[0] {
+	if let &Event::PaymentFailed { payment_hash:_, ref rejected_by_dest, faultive_node: _, ref error_code, error_data: _ } = &events[0] {
 		assert_eq!(*rejected_by_dest, !expected_retryable);
 		assert_eq!(*error_code, expected_error_code);
 	} else {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -300,20 +300,20 @@ pub fn get_route<C: Deref, L: Deref>(our_node_id: &PublicKey, net_graph_msg_hand
 				for chan_id in $node.channels.iter() {
 					let chan = network.get_channels().get(chan_id).unwrap();
 					if !chan.features.requires_unknown_bits() {
-						if chan.node_one == *$node_id {
-							// ie $node is one, ie next hop in A* is two, via the two_to_one channel
-							if first_hops.is_none() || chan.node_two != *our_node_id {
-								if let Some(two_to_one) = chan.two_to_one.as_ref() {
-									if two_to_one.enabled {
-										add_entry!(chan_id, chan.node_two, chan.node_one, two_to_one, chan.features, $fee_to_target_msat);
+						if chan.node_alice == *$node_id {
+							// ie $node is one, ie next hop in A* is two, via the bob_to_alice channel
+							if first_hops.is_none() || chan.node_bob != *our_node_id {
+								if let Some(bob_to_alice) = chan.bob_to_alice.as_ref() {
+									if bob_to_alice.enabled {
+										add_entry!(chan_id, chan.node_bob, chan.node_alice, bob_to_alice, chan.features, $fee_to_target_msat);
 									}
 								}
 							}
 						} else {
-							if first_hops.is_none() || chan.node_one != *our_node_id {
-								if let Some(one_to_two) = chan.one_to_two.as_ref() {
-									if one_to_two.enabled {
-										add_entry!(chan_id, chan.node_one, chan.node_two, one_to_two, chan.features, $fee_to_target_msat);
+							if first_hops.is_none() || chan.node_alice != *our_node_id {
+								if let Some(alice_to_bob) = chan.alice_to_bob.as_ref() {
+									if alice_to_bob.enabled {
+										add_entry!(chan_id, chan.node_alice, chan.node_bob, alice_to_bob, chan.features, $fee_to_target_msat);
 									}
 								}
 

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -98,6 +98,8 @@ pub enum Event {
 		/// the payment has failed, not just the route in question. If this is not set, you may
 		/// retry the payment via a different route.
 		rejected_by_dest: bool,
+		/// Indicates the node responsible for the failure in the event of NodeFailure event.
+		faultive_node: Option<PublicKey>,
 #[cfg(test)]
 		error_code: Option<u16>,
 #[cfg(test)]
@@ -145,7 +147,7 @@ impl Writeable for Event {
 				3u8.write(writer)?;
 				payment_preimage.write(writer)?;
 			},
-			&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest,
+			&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest, ref faultive_node,
 				#[cfg(test)]
 				ref error_code,
 				#[cfg(test)]
@@ -154,6 +156,7 @@ impl Writeable for Event {
 				4u8.write(writer)?;
 				payment_hash.write(writer)?;
 				rejected_by_dest.write(writer)?;
+				faultive_node.write(writer)?;
 				#[cfg(test)]
 				error_code.write(writer)?;
 				#[cfg(test)]
@@ -194,6 +197,7 @@ impl MaybeReadable for Event {
 			4u8 => Ok(Some(Event::PaymentFailed {
 					payment_hash: Readable::read(reader)?,
 					rejected_by_dest: Readable::read(reader)?,
+					faultive_node: Readable::read(reader)?,
 					#[cfg(test)]
 					error_code: Readable::read(reader)?,
 					#[cfg(test)]


### PR DESCRIPTION
Addressing issue #482 

Adds ChannelScore struct to network_graph.rs, a couple methods that handle `PaymentSent/Failed` events by setting their sent/failed `channel_score` fields within the `DirectionalChannelInfo`'s stored in `ChannelInfo`. Most of the added code was the test which involved creating a dummy `NetworkGraph` object, which accounts for most of the 500+ lines of added code.

Lastly, the fields in `DirectionalChannelInfo` were renamed from `one` and `two` to `alice` and `bob` to make them a bit easier to read.