### PR TITLE
Drop ChannelKeys Private Key Methods

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -197,10 +197,6 @@ impl Readable for SpendableOutputDescriptor {
 pub trait ChannelKeys : Send+Clone {
 	/// Gets the local secret key for blinded revocation pubkey
 	fn revocation_base_key<'a>(&'a self) -> &'a SecretKey;
-	/// Gets the local secret key used in the to_remote output of remote commitment tx (ie the
-	/// output to us in transactions our counterparty broadcasts).
-	/// Also as part of obscured commitment number.
-	fn payment_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local secret key used in HTLC-Success/HTLC-Timeout txn and to_local output
 	fn delayed_payment_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local htlc secret key used in commitment tx htlc outputs
@@ -415,7 +411,6 @@ impl InMemoryChannelKeys {
 
 impl ChannelKeys for InMemoryChannelKeys {
 	fn revocation_base_key(&self) -> &SecretKey { &self.revocation_base_key }
-	fn payment_key(&self) -> &SecretKey { &self.payment_key }
 	fn delayed_payment_base_key(&self) -> &SecretKey { &self.delayed_payment_base_key }
 	fn htlc_base_key(&self) -> &SecretKey { &self.htlc_base_key }
 	fn commitment_seed(&self) -> &[u8; 32] { &self.commitment_seed }

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -195,8 +195,6 @@ impl Readable for SpendableOutputDescriptor {
 // TODO: We should remove Clone by instead requesting a new ChannelKeys copy when we create
 // ChannelMonitors instead of expecting to clone the one out of the Channel into the monitors.
 pub trait ChannelKeys : Send+Clone {
-	/// Gets the local secret key for blinded revocation pubkey
-	fn revocation_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local secret key used in HTLC-Success/HTLC-Timeout txn and to_local output
 	fn delayed_payment_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local htlc secret key used in commitment tx htlc outputs
@@ -410,7 +408,6 @@ impl InMemoryChannelKeys {
 }
 
 impl ChannelKeys for InMemoryChannelKeys {
-	fn revocation_base_key(&self) -> &SecretKey { &self.revocation_base_key }
 	fn delayed_payment_base_key(&self) -> &SecretKey { &self.delayed_payment_base_key }
 	fn htlc_base_key(&self) -> &SecretKey { &self.htlc_base_key }
 	fn commitment_seed(&self) -> &[u8; 32] { &self.commitment_seed }

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -345,17 +345,17 @@ pub trait KeysInterface: Send + Sync {
 /// A simple implementation of ChannelKeys that just keeps the private keys in memory.
 pub struct InMemoryChannelKeys {
 	/// Private key of anchor tx
-	funding_key: SecretKey,
+	pub funding_key: SecretKey,
 	/// Local secret key for blinded revocation pubkey
-	revocation_base_key: SecretKey,
+	pub revocation_base_key: SecretKey,
 	/// Local secret key used for our balance in remote-broadcasted commitment transactions
-	payment_key: SecretKey,
+	pub payment_key: SecretKey,
 	/// Local secret key used in HTLC tx
-	delayed_payment_base_key: SecretKey,
+	pub delayed_payment_base_key: SecretKey,
 	/// Local htlc secret key used in commitment tx htlc outputs
-	htlc_base_key: SecretKey,
+	pub htlc_base_key: SecretKey,
 	/// Commitment seed
-	commitment_seed: [u8; 32],
+	pub commitment_seed: [u8; 32],
 	/// Local public keys and basepoints
 	pub(crate) local_channel_pubkeys: ChannelPublicKeys,
 	/// Remote public keys and base points

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -195,8 +195,6 @@ impl Readable for SpendableOutputDescriptor {
 // TODO: We should remove Clone by instead requesting a new ChannelKeys copy when we create
 // ChannelMonitors instead of expecting to clone the one out of the Channel into the monitors.
 pub trait ChannelKeys : Send+Clone {
-	/// Gets the local secret key used in HTLC-Success/HTLC-Timeout txn and to_local output
-	fn delayed_payment_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local htlc secret key used in commitment tx htlc outputs
 	fn htlc_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the commitment seed
@@ -408,7 +406,6 @@ impl InMemoryChannelKeys {
 }
 
 impl ChannelKeys for InMemoryChannelKeys {
-	fn delayed_payment_base_key(&self) -> &SecretKey { &self.delayed_payment_base_key }
 	fn htlc_base_key(&self) -> &SecretKey { &self.htlc_base_key }
 	fn commitment_seed(&self) -> &[u8; 32] { &self.commitment_seed }
 	fn pubkeys<'a>(&'a self) -> &'a ChannelPublicKeys { &self.local_channel_pubkeys }

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -195,8 +195,6 @@ impl Readable for SpendableOutputDescriptor {
 // TODO: We should remove Clone by instead requesting a new ChannelKeys copy when we create
 // ChannelMonitors instead of expecting to clone the one out of the Channel into the monitors.
 pub trait ChannelKeys : Send+Clone {
-	/// Gets the private key for the anchor tx
-	fn funding_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local secret key for blinded revocation pubkey
 	fn revocation_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the local secret key used in the to_remote output of remote commitment tx (ie the
@@ -416,7 +414,6 @@ impl InMemoryChannelKeys {
 }
 
 impl ChannelKeys for InMemoryChannelKeys {
-	fn funding_key(&self) -> &SecretKey { &self.funding_key }
 	fn revocation_base_key(&self) -> &SecretKey { &self.revocation_base_key }
 	fn payment_key(&self) -> &SecretKey { &self.payment_key }
 	fn delayed_payment_base_key(&self) -> &SecretKey { &self.delayed_payment_base_key }

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -195,8 +195,6 @@ impl Readable for SpendableOutputDescriptor {
 // TODO: We should remove Clone by instead requesting a new ChannelKeys copy when we create
 // ChannelMonitors instead of expecting to clone the one out of the Channel into the monitors.
 pub trait ChannelKeys : Send+Clone {
-	/// Gets the local htlc secret key used in commitment tx htlc outputs
-	fn htlc_base_key<'a>(&'a self) -> &'a SecretKey;
 	/// Gets the commitment seed
 	fn commitment_seed<'a>(&'a self) -> &'a [u8; 32];
 	/// Gets the local channel public keys and basepoints
@@ -406,7 +404,6 @@ impl InMemoryChannelKeys {
 }
 
 impl ChannelKeys for InMemoryChannelKeys {
-	fn htlc_base_key(&self) -> &SecretKey { &self.htlc_base_key }
 	fn commitment_seed(&self) -> &[u8; 32] { &self.commitment_seed }
 	fn pubkeys<'a>(&'a self) -> &'a ChannelPublicKeys { &self.local_channel_pubkeys }
 	fn key_derivation_params(&self) -> (u64, u64) { self.key_derivation_params }

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -766,15 +766,14 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 
 	fn get_commitment_transaction_number_obscure_factor(&self) -> u64 {
 		let mut sha = Sha256::engine();
-		let our_payment_point = PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.payment_key());
 
 		let their_payment_point = &self.their_pubkeys.as_ref().unwrap().payment_point.serialize();
 		if self.channel_outbound {
-			sha.input(&our_payment_point.serialize());
+			sha.input(&self.local_keys.pubkeys().payment_point.serialize());
 			sha.input(their_payment_point);
 		} else {
 			sha.input(their_payment_point);
-			sha.input(&our_payment_point.serialize());
+			sha.input(&self.local_keys.pubkeys().payment_point.serialize());
 		}
 		let res = Sha256::from_engine(sha).into_inner();
 
@@ -3317,7 +3316,7 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 			max_accepted_htlcs: OUR_MAX_HTLCS,
 			funding_pubkey: local_keys.funding_pubkey,
 			revocation_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.revocation_base_key()),
-			payment_point: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.payment_key()),
+			payment_point: local_keys.payment_point,
 			delayed_payment_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.delayed_payment_base_key()),
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.htlc_base_key()),
 			first_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &local_commitment_secret),
@@ -3351,7 +3350,7 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 			max_accepted_htlcs: OUR_MAX_HTLCS,
 			funding_pubkey: local_keys.funding_pubkey,
 			revocation_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.revocation_base_key()),
-			payment_point: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.payment_key()),
+			payment_point: local_keys.payment_point,
 			delayed_payment_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.delayed_payment_base_key()),
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.htlc_base_key()),
 			first_per_commitment_point: PublicKey::from_secret_key(&self.secp_ctx, &local_commitment_secret),

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1108,11 +1108,11 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 	fn build_remote_transaction_keys(&self) -> Result<TxCreationKeys, ChannelError> {
 		//TODO: Ensure that the payment_key derived here ends up in the library users' wallet as we
 		//may see payments to it!
-		let revocation_basepoint = PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.revocation_base_key());
+		let revocation_basepoint = &self.local_keys.pubkeys().revocation_basepoint;
 		let htlc_basepoint = PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.htlc_base_key());
 		let their_pubkeys = self.their_pubkeys.as_ref().unwrap();
 
-		Ok(secp_check!(TxCreationKeys::new(&self.secp_ctx, &self.their_cur_commitment_point.unwrap(), &their_pubkeys.delayed_payment_basepoint, &their_pubkeys.htlc_basepoint, &revocation_basepoint, &htlc_basepoint), "Remote tx keys generation got bogus keys"))
+		Ok(secp_check!(TxCreationKeys::new(&self.secp_ctx, &self.their_cur_commitment_point.unwrap(), &their_pubkeys.delayed_payment_basepoint, &their_pubkeys.htlc_basepoint, revocation_basepoint, &htlc_basepoint), "Remote tx keys generation got bogus keys"))
 	}
 
 	/// Gets the redeemscript for the funding transaction output (ie the funding transaction output
@@ -3315,7 +3315,7 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 			to_self_delay: self.our_to_self_delay,
 			max_accepted_htlcs: OUR_MAX_HTLCS,
 			funding_pubkey: local_keys.funding_pubkey,
-			revocation_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.revocation_base_key()),
+			revocation_basepoint: local_keys.revocation_basepoint,
 			payment_point: local_keys.payment_point,
 			delayed_payment_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.delayed_payment_base_key()),
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.htlc_base_key()),
@@ -3349,7 +3349,7 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 			to_self_delay: self.our_to_self_delay,
 			max_accepted_htlcs: OUR_MAX_HTLCS,
 			funding_pubkey: local_keys.funding_pubkey,
-			revocation_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.revocation_base_key()),
+			revocation_basepoint: local_keys.revocation_basepoint,
 			payment_point: local_keys.payment_point,
 			delayed_payment_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.delayed_payment_base_key()),
 			htlc_basepoint: PublicKey::from_secret_key(&self.secp_ctx, self.local_keys.htlc_base_key()),

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -1641,7 +1641,7 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 					self.remote_payment_script = {
 						// Note that the Network here is ignored as we immediately drop the address for the
 						// script_pubkey version
-						let payment_hash160 = WPubkeyHash::hash(&PublicKey::from_secret_key(&self.secp_ctx, &self.keys.payment_key()).serialize());
+						let payment_hash160 = WPubkeyHash::hash(&self.keys.pubkeys().payment_point.serialize());
 						Builder::new().push_opcode(opcodes::all::OP_PUSHBYTES_0).push_slice(&payment_hash160[..]).into_script()
 					};
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -4293,10 +4293,10 @@ macro_rules! check_spendable_outputs {
 									};
 									let secp_ctx = Secp256k1::new();
 									let keys = $keysinterface.derive_channel_keys($chan_value, key_derivation_params.0, key_derivation_params.1);
-									let remotepubkey = PublicKey::from_secret_key(&secp_ctx, &keys.payment_key());
+									let remotepubkey = keys.pubkeys().payment_point;
 									let witness_script = Address::p2pkh(&::bitcoin::PublicKey{compressed: true, key: remotepubkey}, Network::Testnet).script_pubkey();
 									let sighash = Message::from_slice(&bip143::SighashComponents::new(&spend_tx).sighash_all(&spend_tx.input[0], &witness_script, output.value)[..]).unwrap();
-									let remotesig = secp_ctx.sign(&sighash, &keys.payment_key());
+									let remotesig = secp_ctx.sign(&sighash, &keys.inner.payment_key);
 									spend_tx.input[0].witness.push(remotesig.serialize_der().to_vec());
 									spend_tx.input[0].witness[0].push(SigHashType::All as u8);
 									spend_tx.input[0].witness.push(remotepubkey.serialize().to_vec());

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -3850,8 +3850,8 @@ fn test_invalid_channel_announcement() {
 	macro_rules! sign_msg {
 		($unsigned_msg: expr) => {
 			let msghash = Message::from_slice(&Sha256dHash::hash(&$unsigned_msg.encode()[..])[..]).unwrap();
-			let as_bitcoin_sig = secp_ctx.sign(&msghash, &as_chan.get_local_keys().inner.funding_key());
-			let bs_bitcoin_sig = secp_ctx.sign(&msghash, &bs_chan.get_local_keys().inner.funding_key());
+			let as_bitcoin_sig = secp_ctx.sign(&msghash, &as_chan.get_local_keys().inner.funding_key);
+			let bs_bitcoin_sig = secp_ctx.sign(&msghash, &bs_chan.get_local_keys().inner.funding_key);
 			let as_node_sig = secp_ctx.sign(&msghash, &nodes[0].keys_manager.get_node_secret());
 			let bs_node_sig = secp_ctx.sign(&msghash, &nodes[1].keys_manager.get_node_secret());
 			chan_announcement = msgs::ChannelAnnouncement {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -4321,7 +4321,7 @@ macro_rules! check_spendable_outputs {
 									};
 									let secp_ctx = Secp256k1::new();
 									let keys = $keysinterface.derive_channel_keys($chan_value, key_derivation_params.0, key_derivation_params.1);
-									if let Ok(delayed_payment_key) = chan_utils::derive_private_key(&secp_ctx, &per_commitment_point, keys.delayed_payment_base_key()) {
+									if let Ok(delayed_payment_key) = chan_utils::derive_private_key(&secp_ctx, &per_commitment_point, &keys.inner.delayed_payment_base_key) {
 
 										let delayed_payment_pubkey = PublicKey::from_secret_key(&secp_ctx, &delayed_payment_key);
 										let witness_script = chan_utils::get_revokeable_redeemscript(remote_revocation_pubkey, *to_self_delay, &delayed_payment_pubkey);

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -35,8 +35,6 @@ impl EnforcingChannelKeys {
 impl EnforcingChannelKeys {
 	fn check_keys<T: secp256k1::Signing + secp256k1::Verification>(&self, secp_ctx: &Secp256k1<T>,
 	                                                               keys: &TxCreationKeys) {
-		let htlc_base = PublicKey::from_secret_key(secp_ctx, &self.inner.htlc_base_key());
-
 		let remote_points = self.inner.remote_channel_pubkeys.as_ref().unwrap();
 
 		let keys_expected = TxCreationKeys::new(secp_ctx,
@@ -44,13 +42,12 @@ impl EnforcingChannelKeys {
 		                                        &remote_points.delayed_payment_basepoint,
 		                                        &remote_points.htlc_basepoint,
 		                                        &self.inner.pubkeys().revocation_basepoint,
-		                                        &htlc_base).unwrap();
+		                                        &self.inner.pubkeys().htlc_basepoint).unwrap();
 		if keys != &keys_expected { panic!("derived different per-tx keys") }
 	}
 }
 
 impl ChannelKeys for EnforcingChannelKeys {
-	fn htlc_base_key(&self) -> &SecretKey { self.inner.htlc_base_key() }
 	fn commitment_seed(&self) -> &[u8; 32] { self.inner.commitment_seed() }
 	fn pubkeys<'a>(&'a self) -> &'a ChannelPublicKeys { self.inner.pubkeys() }
 	fn key_derivation_params(&self) -> (u64, u64) { self.inner.key_derivation_params() }

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -35,7 +35,6 @@ impl EnforcingChannelKeys {
 impl EnforcingChannelKeys {
 	fn check_keys<T: secp256k1::Signing + secp256k1::Verification>(&self, secp_ctx: &Secp256k1<T>,
 	                                                               keys: &TxCreationKeys) {
-		let revocation_base = PublicKey::from_secret_key(secp_ctx, &self.inner.revocation_base_key());
 		let htlc_base = PublicKey::from_secret_key(secp_ctx, &self.inner.htlc_base_key());
 
 		let remote_points = self.inner.remote_channel_pubkeys.as_ref().unwrap();
@@ -44,14 +43,13 @@ impl EnforcingChannelKeys {
 		                                        &keys.per_commitment_point,
 		                                        &remote_points.delayed_payment_basepoint,
 		                                        &remote_points.htlc_basepoint,
-		                                        &revocation_base,
+		                                        &self.inner.pubkeys().revocation_basepoint,
 		                                        &htlc_base).unwrap();
 		if keys != &keys_expected { panic!("derived different per-tx keys") }
 	}
 }
 
 impl ChannelKeys for EnforcingChannelKeys {
-	fn revocation_base_key(&self) -> &SecretKey { self.inner.revocation_base_key() }
 	fn delayed_payment_base_key(&self) -> &SecretKey { self.inner.delayed_payment_base_key() }
 	fn htlc_base_key(&self) -> &SecretKey { self.inner.htlc_base_key() }
 	fn commitment_seed(&self) -> &[u8; 32] { self.inner.commitment_seed() }

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -50,7 +50,6 @@ impl EnforcingChannelKeys {
 }
 
 impl ChannelKeys for EnforcingChannelKeys {
-	fn delayed_payment_base_key(&self) -> &SecretKey { self.inner.delayed_payment_base_key() }
 	fn htlc_base_key(&self) -> &SecretKey { self.inner.htlc_base_key() }
 	fn commitment_seed(&self) -> &[u8; 32] { self.inner.commitment_seed() }
 	fn pubkeys<'a>(&'a self) -> &'a ChannelPublicKeys { self.inner.pubkeys() }

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -52,7 +52,6 @@ impl EnforcingChannelKeys {
 
 impl ChannelKeys for EnforcingChannelKeys {
 	fn revocation_base_key(&self) -> &SecretKey { self.inner.revocation_base_key() }
-	fn payment_key(&self) -> &SecretKey { self.inner.payment_key() }
 	fn delayed_payment_base_key(&self) -> &SecretKey { self.inner.delayed_payment_base_key() }
 	fn htlc_base_key(&self) -> &SecretKey { self.inner.htlc_base_key() }
 	fn commitment_seed(&self) -> &[u8; 32] { self.inner.commitment_seed() }

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -51,7 +51,6 @@ impl EnforcingChannelKeys {
 }
 
 impl ChannelKeys for EnforcingChannelKeys {
-	fn funding_key(&self) -> &SecretKey { self.inner.funding_key() }
 	fn revocation_base_key(&self) -> &SecretKey { self.inner.revocation_base_key() }
 	fn payment_key(&self) -> &SecretKey { self.inner.payment_key() }
 	fn delayed_payment_base_key(&self) -> &SecretKey { self.inner.delayed_payment_base_key() }


### PR DESCRIPTION
This isn't quite sufficient for a secure external signer, as we still expose commitment_seed(), but its a nice cleanup after #610 did all the heavy lifting and its a good step.