### PR TITLE
Add default implementation for tracking metadata

### DIFF
--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -10,6 +10,7 @@ use ln::features::InitFeatures;
 use ln::msgs;
 use ln::msgs::{ChannelMessageHandler, ErrorAction, RoutingMessageHandler};
 use routing::router::get_route;
+use routing::network_graph::DefaultMetadata;
 use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsProvider};
 use util::errors::APIError;
 
@@ -34,7 +35,8 @@ fn test_simple_monitor_permanent_update_fail() {
 
 	*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::PermanentFailure);
 	let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-	let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+	let default_metadata = DefaultMetadata::new();
+	let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 	unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_1, &None), true, APIError::ChannelUnavailable {..}, {});
 	check_added_monitors!(nodes[0], 2);
 
@@ -71,7 +73,8 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_1, &None), false, APIError::MonitorUpdateFailed, {});
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -118,7 +121,8 @@ fn do_test_simple_monitor_temporary_update_fail(disconnect: bool) {
 	{
 		*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_2, &None), false, APIError::MonitorUpdateFailed, {});
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -184,7 +188,8 @@ fn do_test_monitor_temporary_update_fail(disconnect_count: usize) {
 	{
 		*nodes[0].chan_monitor.update_ret.lock().unwrap() = Err(ChannelMonitorUpdateErr::TemporaryFailure);
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		unwrap_send_err!(nodes[0].node.send_payment(&route, payment_hash_2, &None), false, APIError::MonitorUpdateFailed, {});
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -515,7 +520,8 @@ fn test_monitor_update_fail_cs() {
 	let (payment_preimage, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, our_payment_hash, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -604,7 +610,8 @@ fn test_monitor_update_fail_no_rebroadcast() {
 	let (payment_preimage_1, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, our_payment_hash, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -655,7 +662,8 @@ fn test_monitor_update_raa_while_paused() {
 	let (payment_preimage_1, our_payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, our_payment_hash_1, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -664,7 +672,8 @@ fn test_monitor_update_raa_while_paused() {
 	let (payment_preimage_2, our_payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[1].net_graph_msg_handler;
-		let route = get_route(&nodes[1].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[1].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[1].node.send_payment(&route, our_payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[1], 1);
 	}
@@ -756,7 +765,8 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -783,7 +793,8 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 	let (_, payment_hash_3) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[2].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_3, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -832,7 +843,8 @@ fn do_test_monitor_update_fail_raa(test_ignore_second_cs: bool) {
 		// Try to route another payment backwards from 2 to make sure 1 holds off on responding
 		let (payment_preimage_4, payment_hash_4) = get_payment_preimage_hash!(nodes[0]);
 		let net_graph_msg_handler = &nodes[2].net_graph_msg_handler;
-		let route = get_route(&nodes[2].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[2].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[2].node.send_payment(&route, payment_hash_4, &None).unwrap();
 		check_added_monitors!(nodes[2], 1);
 
@@ -1086,7 +1098,8 @@ fn raa_no_response_awaiting_raa_state() {
 	// generation during RAA while in monitor-update-failed state.
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 		nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
@@ -1140,7 +1153,8 @@ fn raa_no_response_awaiting_raa_state() {
 	// commitment transaction states) whereas here we can explicitly check for it.
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_3, &None).unwrap();
 		check_added_monitors!(nodes[0], 0);
 		assert!(nodes[0].node.get_and_clear_pending_msg_events().is_empty());
@@ -1232,7 +1246,8 @@ fn claim_while_disconnected_monitor_update_fail() {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -1328,7 +1343,8 @@ fn monitor_failed_no_reestablish_response() {
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -1402,7 +1418,8 @@ fn first_message_on_recv_ordering() {
 	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -1427,7 +1444,8 @@ fn first_message_on_recv_ordering() {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -1507,7 +1525,8 @@ fn test_monitor_update_fail_claim() {
 	let (_, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[2].net_graph_msg_handler;
-		let route = get_route(&nodes[2].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[2].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[2].node.send_payment(&route, payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[2], 1);
 	}
@@ -1592,7 +1611,8 @@ fn test_monitor_update_on_pending_forwards() {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[2].net_graph_msg_handler;
-		let route = get_route(&nodes[2].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[2].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[2].node.send_payment(&route, payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[2], 1);
 	}
@@ -1655,7 +1675,8 @@ fn monitor_update_claim_fail_no_response() {
 	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(nodes[0]);
 	{
 		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
-		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &Vec::new(), 1000000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 		nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
 		check_added_monitors!(nodes[0], 1);
 	}
@@ -1820,7 +1841,8 @@ fn test_path_paused_mpp() {
 
 	let (payment_preimage, payment_hash) = get_payment_preimage_hash!(&nodes[0]);
 	let payment_secret = PaymentSecret([0xdb; 32]);
-	let mut route = get_route(&nodes[0].node.get_our_node_id(), &nodes[0].net_graph_msg_handler, &nodes[3].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV, &logger).unwrap();
+	let default_metadata = DefaultMetadata::new();
+	let mut route = get_route(&nodes[0].node.get_our_node_id(), &nodes[0].net_graph_msg_handler, &nodes[3].node.get_our_node_id(), None, &[], 100000, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 
 	// Set us up to take multiple routes, one 0 -> 1 -> 3 and one 0 -> 2 -> 3:
 	let path = route.paths[0].clone();

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -6,7 +6,7 @@ use chain::transaction::OutPoint;
 use ln::channelmanager::{ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
 use ln::channelmonitor::{ChannelMonitor, ManyChannelMonitor};
 use routing::router::{Route, get_route};
-use routing::network_graph::{NetGraphMsgHandler, NetworkGraph};
+use routing::network_graph::{NetGraphMsgHandler, NetworkGraph, DefaultMetadata};
 use ln::features::InitFeatures;
 use ln::msgs;
 use ln::msgs::{ChannelMessageHandler,RoutingMessageHandler};
@@ -953,7 +953,8 @@ pub const TEST_FINAL_CLTV: u32 = 32;
 pub fn route_payment<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64) -> (PaymentPreimage, PaymentHash) {
 	let net_graph_msg_handler = &origin_node.net_graph_msg_handler;
 	let logger = test_utils::TestLogger::new();
-	let route = get_route(&origin_node.node.get_our_node_id(), net_graph_msg_handler, &expected_route.last().unwrap().node.get_our_node_id(), None, &Vec::new(), recv_value, TEST_FINAL_CLTV, &logger).unwrap();
+	let default_metadata = DefaultMetadata::new();
+	let route = get_route(&origin_node.node.get_our_node_id(), net_graph_msg_handler, &expected_route.last().unwrap().node.get_our_node_id(), None, &Vec::new(), recv_value, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 	assert_eq!(route.paths.len(), 1);
 	assert_eq!(route.paths[0].len(), expected_route.len());
 	for (node, hop) in expected_route.iter().zip(route.paths[0].iter()) {
@@ -966,7 +967,8 @@ pub fn route_payment<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route:
 pub fn route_over_limit<'a, 'b, 'c>(origin_node: &Node<'a, 'b, 'c>, expected_route: &[&Node<'a, 'b, 'c>], recv_value: u64)  {
 	let logger = test_utils::TestLogger::new();
 	let net_graph_msg_handler = &origin_node.net_graph_msg_handler;
-	let route = get_route(&origin_node.node.get_our_node_id(), net_graph_msg_handler, &expected_route.last().unwrap().node.get_our_node_id(), None, &Vec::new(), recv_value, TEST_FINAL_CLTV, &logger).unwrap();
+	let default_metadata = DefaultMetadata::new();
+	let route = get_route(&origin_node.node.get_our_node_id(), net_graph_msg_handler, &expected_route.last().unwrap().node.get_our_node_id(), None, &Vec::new(), recv_value, TEST_FINAL_CLTV, &logger, default_metadata).unwrap();
 	assert_eq!(route.paths.len(), 1);
 	assert_eq!(route.paths[0].len(), expected_route.len());
 	for (node, hop) in expected_route.iter().zip(route.paths[0].iter()) {

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -453,7 +453,7 @@ impl RouteFeePenalty for DefaultMetadata {
 		if self.failed_channels.get(&chan_id) == None {
 			return 0;
 		} else {
-			return u64::MAX;
+			return u64::max_value();
 		}
 	}
 

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -432,11 +432,11 @@ impl Readable for NodeInfo {
 pub trait UpdateMetadata {
 	/// Adds a failed route to track. If we see the route again, we'll reject it or we can take
 	/// some action (like set its fee to make route-finding not find that route again)
-	fn add_failed_route(&mut self, route: Vec<Vec<RouteHop>>);
+	fn add_failed_route(&mut self, route: Vec<RouteHop>);
 	/// If a route starts working again, then we can take it off the failed route list.
-	fn remove_failed_route(&mut self, route: Vec<Vec<RouteHop>>);
+	fn remove_failed_route(&mut self, route: Vec<RouteHop>);
 	/// Returns true if a route is on the failed routes list, false otherwise.
-	fn check_route(&self, route: Vec<Vec<RouteHop>>) -> bool;
+	fn check_route(&self, route: Vec<RouteHop>) -> bool;
 	/// Sets the channel fee penalty being tracked in the Metadata object.
 	fn set_channel_fee_penalty(&mut self, chan_id: u64, fee_penalty: u64);
 	/// Gets a channel's fee penalty based on its channel_id (as stored in a NetworkGraph object).
@@ -449,18 +449,18 @@ pub trait UpdateMetadata {
 pub struct DefaultMetadata {
 	/// A lits of failed routes. Referenced by the failed route trackers, and sets channel fee
 	/// penalty to a high number if in trait
-	failed_routes: Vec<Vec<Vec<RouteHop>>>,
+	failed_routes: Vec<Vec<RouteHop>>,
 	/// Minimum fee willing to be paid to avoid using a given channel. Often, this is updated when
 	/// a channel ends up on a failed route.
 	channel_fee_penalty: BTreeMap<u64, u64>,
 }
 
 impl UpdateMetadata for DefaultMetadata {
-	fn add_failed_route(&mut self, route: Vec<Vec<RouteHop>>) { self.failed_routes.push(route); }
-	fn remove_failed_route(&mut self, route: Vec<Vec<RouteHop>>) {
+	fn add_failed_route(&mut self, route: Vec<RouteHop>) { self.failed_routes.push(route); }
+	fn remove_failed_route(&mut self, route: Vec<RouteHop>) {
 		self.failed_routes.retain(|item| item != &route);
 	}
-	fn check_route(&self, route: Vec<Vec<RouteHop>>) -> bool {
+	fn check_route(&self, route: Vec<RouteHop>) -> bool {
 		self.failed_routes.contains(&route)
 	}
 	fn set_channel_fee_penalty(&mut self, chan_id: u64, fee_penalty: u64) { self.channel_fee_penalty.insert(chan_id, fee_penalty); }
@@ -481,13 +481,13 @@ pub trait NetworkTracker<T: UpdateMetadata = DefaultMetadata> {
 	}
 
 	/// Store routes that have previously failed by adding them to a list being held in Metadata
-	fn track_previously_failed_route(&self, mut network_metadata: T, failed_route: Vec<Vec<RouteHop>>) {
+	fn track_previously_failed_route(&self, mut network_metadata: T, failed_route: Vec<RouteHop>) {
 		network_metadata.add_failed_route(failed_route);
 	}
 
 	/// Returns true if this route was attempted previously and failed by searching in Metadata's
 	/// failed routes
-	fn check_route_for_previous_failure(&self, network_metadata: T, route: Vec<Vec<RouteHop>>) -> bool {
+	fn check_route_for_previous_failure(&self, network_metadata: T, route: Vec<RouteHop>) -> bool {
 		network_metadata.check_route(route)
 	}
 }

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -430,12 +430,7 @@ impl Readable for NodeInfo {
 
 /// Allows for updating user's network metadata.
 pub trait UpdateMetadata {
-	/// Adds a failed route to track. If we see the route again, we'll reject it or we can take
-	/// some action (like set its fee to make route-finding not find that route again)
-	fn add_failed_route(&mut self, route: Vec<RouteHop>);
-	/// If a route starts working again, then we can take it off the failed route list.
-	fn remove_failed_route(&mut self, route: Vec<RouteHop>);
-	/// Returns true if a route is on the failed routes list, false otherwise.
+	/// Checks if a route has failed previously
 	fn check_route(&self, route: Vec<RouteHop>) -> bool;
 	/// Sets the channel fee penalty being tracked in the Metadata object.
 	fn set_channel_fee_penalty(&mut self, chan_id: u64, fee_penalty: u64);
@@ -456,10 +451,6 @@ pub struct DefaultMetadata {
 }
 
 impl UpdateMetadata for DefaultMetadata {
-	fn add_failed_route(&mut self, route: Vec<RouteHop>) { self.failed_routes.push(route); }
-	fn remove_failed_route(&mut self, route: Vec<RouteHop>) {
-		self.failed_routes.retain(|item| item != &route);
-	}
 	fn check_route(&self, route: Vec<RouteHop>) -> bool {
 		self.failed_routes.contains(&route)
 	}
@@ -478,11 +469,6 @@ pub trait NetworkTracker<T: UpdateMetadata = DefaultMetadata> {
 		} else {
 			return 0;
 		}
-	}
-
-	/// Store routes that have previously failed by adding them to a list being held in Metadata
-	fn track_previously_failed_route(&self, mut network_metadata: T, failed_route: Vec<RouteHop>) {
-		network_metadata.add_failed_route(failed_route);
 	}
 
 	/// Returns true if this route was attempted previously and failed by searching in Metadata's

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -431,7 +431,7 @@ impl Readable for NodeInfo {
 /// Allows for updating user's network metadata.
 pub trait RouteFeePenalty {
 	/// Gets a channel's fee penalty based on its channel_id (as stored in a NetworkGraph object).
-	fn get_channel_fee_penalty(&self, chan_id: u64) -> Option<&u64>;
+	fn get_channel_fee_penalty(&self, chan_id: u64) -> u64;
 	/// Informs metadata object that a route has successfully executed its payment.
 	fn route_succeeded(&mut self, route: Vec<RouteHop>);
 }
@@ -447,11 +447,11 @@ pub struct DefaultMetadata {
 }
 
 impl RouteFeePenalty for DefaultMetadata {
-	fn get_channel_fee_penalty(&self, chan_id: u64) -> Option<&u64> {
+	fn get_channel_fee_penalty(&self, chan_id: u64) -> u64 {
 		if self.failed_channels.get(&chan_id) == None {
-			return Some(&0);
+			return 0;
 		} else {
-			return Some(&u64::MAX);
+			return u64::MAX;
 		}
 	}
 	fn route_succeeded(&mut self, route: Vec<RouteHop>) {
@@ -477,12 +477,7 @@ impl RouteFeePenalty for DefaultMetadata {
 pub trait NetworkTracker<T: RouteFeePenalty = DefaultMetadata> {
 	/// Return score for a given channel by using user-defined channel_scorers
 	fn calculate_minimum_fee_penalty_for_channel(&self, chan_id: u64, network_metadata: T) -> u64 {
-		let chan_score = network_metadata.get_channel_fee_penalty(chan_id);
-		if chan_score != None {
-			return *chan_score.unwrap();
-		} else {
-			return 0;
-		}
+		return network_metadata.get_channel_fee_penalty(chan_id);
 	}
 }
 

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -448,6 +448,13 @@ pub struct DefaultMetadata {
 	failed_channels: BTreeMap<u64, u64>,
 }
 
+impl DefaultMetadata {
+	/// Instantiates an instance of DefaultMetadata
+	pub fn new() -> DefaultMetadata {
+		DefaultMetadata { failed_channels: std::collections::BTreeMap::new() }
+	}
+}
+
 impl RouteFeePenalty for DefaultMetadata {
 	fn get_channel_fee_penalty(&self, chan_id: u64) -> u64 {
 		if self.failed_channels.get(&chan_id) == None {

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -461,9 +461,7 @@ impl RouteFeePenalty for DefaultMetadata {
 		for route_hop in route {
 			let chan_id = route_hop.short_channel_id;
 			let successes_needed = self.failed_channels.get(&chan_id);
-			if successes_needed == None {
-				self.failed_channels.insert(chan_id, 5);
-			} else {
+			if successes_needed != None {
 				let dec_successes_needed = successes_needed.unwrap() - 1;
 				if dec_successes_needed > 0 {
 					self.failed_channels.insert(chan_id, dec_successes_needed);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -224,7 +224,10 @@ pub fn get_route<C: Deref, L: Deref, N: RouteFeePenalty>(our_node_id: &PublicKey
 			if $starting_fee_msat as u64 + final_value_msat >= $directional_info.htlc_minimum_msat {
 				let proportional_fee_millions = ($starting_fee_msat + final_value_msat).checked_mul($directional_info.fees.proportional_millionths as u64);
 				if let Some(new_fee) = proportional_fee_millions.and_then(|part| {
-						($directional_info.fees.base_msat as u64).checked_add(net_metadata.get_channel_fee_penalty($chan_id.clone()) + part/1000000) })
+						($directional_info.fees.base_msat as u64).checked_add(
+							net_metadata.get_channel_fee_penalty($chan_id.clone()).checked_add(part).unwrap()/1000000
+						) 
+					})
 				{
 					let mut total_fee = $starting_fee_msat as u64;
 					let hm_entry = dist.entry(&$src_node_id);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -9,7 +9,7 @@ use chain::chaininterface::ChainWatchInterface;
 use ln::channelmanager;
 use ln::features::{ChannelFeatures, NodeFeatures};
 use ln::msgs::{DecodeError,ErrorAction,LightningError};
-use routing::network_graph::{NetGraphMsgHandler, RoutingFees};
+use routing::network_graph::{NetGraphMsgHandler, RoutingFees, RouteFeePenalty};
 use util::ser::{Writeable, Readable};
 use util::logger::Logger;
 
@@ -162,7 +162,7 @@ struct DummyDirectionalChannelInfo {
 /// equal), however the enabled/disabled bit on such channels as well as the htlc_minimum_msat
 /// *is* checked as they may change based on the receiving node.
 pub fn get_route<C: Deref, L: Deref>(our_node_id: &PublicKey, net_graph_msg_handler: &NetGraphMsgHandler<C, L>, target: &PublicKey, first_hops: Option<&[channelmanager::ChannelDetails]>,
-	last_hops: &[RouteHint], final_value_msat: u64, final_cltv: u32, logger: L) -> Result<Route, LightningError> where C::Target: ChainWatchInterface, L::Target: Logger {
+	last_hops: &[RouteHint], final_value_msat: u64, final_cltv: u32, logger: L, net_metadata: impl RouteFeePenalty) -> Result<Route, LightningError> where C::Target: ChainWatchInterface, L::Target: Logger {
 	// TODO: Obviously *only* using total fee cost sucks. We should consider weighting by
 	// uptime/success in using a node in the past.
 	if *target == *our_node_id {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -405,6 +405,7 @@ mod tests {
 	use chain::chaininterface;
 	use routing::router::{NetGraphMsgHandler, RoutingFees};
 	use routing::router::{get_route, RouteHint};
+	use routing::network_graph::DefaultMetadata;
 	use ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 	use ln::msgs::{ErrorAction, LightningError, UnsignedChannelAnnouncement, ChannelAnnouncement, RoutingMessageHandler,
 	   NodeAnnouncement, UnsignedNodeAnnouncement, ChannelUpdate, UnsignedChannelUpdate};
@@ -816,7 +817,8 @@ mod tests {
 		add_or_update_node(&net_graph_msg_handler, &secp_ctx, node6_privkey, NodeFeatures::from_le_bytes(id_to_feature_flags!(6)), 0);
 
 		// Simple route to 3 via 2
-		let route = get_route(&our_id, &net_graph_msg_handler, &node3, None, &Vec::new(), 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node3, None, &Vec::new(), 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 2);
 
 		assert_eq!(route.paths[0][0].pubkey, node2);
@@ -859,7 +861,8 @@ mod tests {
 		});
 
 		// If all the channels require some features we don't understand, route should fail
-		if let Err(LightningError{err, action: ErrorAction::IgnoreError}) = get_route(&our_id, &net_graph_msg_handler, &node3, None, &Vec::new(), 100, 42, Arc::clone(&logger)) {
+		let default_metadata = DefaultMetadata::new();
+		if let Err(LightningError{err, action: ErrorAction::IgnoreError}) = get_route(&our_id, &net_graph_msg_handler, &node3, None, &Vec::new(), 100, 42, Arc::clone(&logger), default_metadata) {
 			assert_eq!(err, "Failed to find a path to the given destination");
 		} else { panic!(); }
 
@@ -875,7 +878,8 @@ mod tests {
 			inbound_capacity_msat: 0,
 			is_live: true,
 		}];
-		let route = get_route(&our_id, &net_graph_msg_handler, &node3, Some(&our_chans),  &Vec::new(), 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node3, Some(&our_chans),  &Vec::new(), 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 2);
 
 		assert_eq!(route.paths[0][0].pubkey, node8);
@@ -939,7 +943,8 @@ mod tests {
 			inbound_capacity_msat: 0,
 			is_live: true,
 		}];
-		let route = get_route(&our_id, &net_graph_msg_handler, &node3, Some(&our_chans), &Vec::new(), 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node3, Some(&our_chans), &Vec::new(), 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 2);
 
 		assert_eq!(route.paths[0][0].pubkey, node8);
@@ -966,7 +971,8 @@ mod tests {
 		// the node_announcement.
 
 		// Route to 1 via 2 and 3 because our channel to 1 is disabled
-		let route = get_route(&our_id, &net_graph_msg_handler, &node1, None, &Vec::new(), 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node1, None, &Vec::new(), 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 3);
 
 		assert_eq!(route.paths[0][0].pubkey, node2);
@@ -1002,7 +1008,8 @@ mod tests {
 			inbound_capacity_msat: 0,
 			is_live: true,
 		}];
-		let route = get_route(&our_id, &net_graph_msg_handler, &node3, Some(&our_chans), &Vec::new(), 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node3, Some(&our_chans), &Vec::new(), 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 2);
 
 		assert_eq!(route.paths[0][0].pubkey, node8);
@@ -1047,7 +1054,8 @@ mod tests {
 			});
 
 		// Simple test across 2, 3, 5, and 4 via a last_hop channel
-		let route = get_route(&our_id, &net_graph_msg_handler, &node7, None, &last_hops, 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node7, None, &last_hops, 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 5);
 
 		assert_eq!(route.paths[0][0].pubkey, node2);
@@ -1099,7 +1107,8 @@ mod tests {
 			inbound_capacity_msat: 0,
 			is_live: true,
 		}];
-		let route = get_route(&our_id, &net_graph_msg_handler, &node7, Some(&our_chans), &last_hops, 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node7, Some(&our_chans), &last_hops, 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 2);
 
 		assert_eq!(route.paths[0][0].pubkey, node4);
@@ -1119,7 +1128,8 @@ mod tests {
 		last_hops[0].fees.base_msat = 1000;
 
 		// Revert to via 6 as the fee on 8 goes up
-		let route = get_route(&our_id, &net_graph_msg_handler, &node7, None, &last_hops, 100, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node7, None, &last_hops, 100, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 4);
 
 		assert_eq!(route.paths[0][0].pubkey, node2);
@@ -1153,7 +1163,8 @@ mod tests {
 		assert_eq!(route.paths[0][3].channel_features.le_flags(), &Vec::new()); // We can't learn any flags from invoices, sadly
 
 		// ...but still use 8 for larger payments as 6 has a variable feerate
-		let route = get_route(&our_id, &net_graph_msg_handler, &node7, None, &last_hops, 2000, 42, Arc::clone(&logger)).unwrap();
+		let default_metadata = DefaultMetadata::new();
+		let route = get_route(&our_id, &net_graph_msg_handler, &node7, None, &last_hops, 2000, 42, Arc::clone(&logger), default_metadata).unwrap();
 		assert_eq!(route.paths[0].len(), 5);
 
 		assert_eq!(route.paths[0][0].pubkey, node2);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -221,10 +221,10 @@ pub fn get_route<C: Deref, L: Deref>(our_node_id: &PublicKey, net_graph_msg_hand
 		// $directional_info.
 		( $chan_id: expr, $src_node_id: expr, $dest_node_id: expr, $directional_info: expr, $chan_features: expr, $starting_fee_msat: expr ) => {
 			//TODO: Explore simply adding fee to hit htlc_minimum_msat
-			if $starting_fee_msat as u64 + final_value_msat >= $directional_info.htlc_minimum_msat + net_metadata.get_channel_fee_penalty($chan_id.clone()) {
+			if $starting_fee_msat as u64 + final_value_msat >= $directional_info.htlc_minimum_msat {
 				let proportional_fee_millions = ($starting_fee_msat + final_value_msat).checked_mul($directional_info.fees.proportional_millionths as u64);
 				if let Some(new_fee) = proportional_fee_millions.and_then(|part| {
-						($directional_info.fees.base_msat as u64).checked_add(part / 1000000) })
+						($directional_info.fees.base_msat as u64).checked_add(net_metadata.get_channel_fee_penalty($chan_id.clone()) + part/1000000) })
 				{
 					let mut total_fee = $starting_fee_msat as u64;
 					let hm_entry = dist.entry(&$src_node_id);

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -221,7 +221,7 @@ pub fn get_route<C: Deref, L: Deref>(our_node_id: &PublicKey, net_graph_msg_hand
 		// $directional_info.
 		( $chan_id: expr, $src_node_id: expr, $dest_node_id: expr, $directional_info: expr, $chan_features: expr, $starting_fee_msat: expr ) => {
 			//TODO: Explore simply adding fee to hit htlc_minimum_msat
-			if $starting_fee_msat as u64 + final_value_msat >= $directional_info.htlc_minimum_msat {
+			if $starting_fee_msat as u64 + final_value_msat >= $directional_info.htlc_minimum_msat + net_metadata.get_channel_fee_penalty($chan_id.clone()) {
 				let proportional_fee_millions = ($starting_fee_msat + final_value_msat).checked_mul($directional_info.fees.proportional_millionths as u64);
 				if let Some(new_fee) = proportional_fee_millions.and_then(|part| {
 						($directional_info.fees.base_msat as u64).checked_add(part / 1000000) })

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -161,8 +161,8 @@ struct DummyDirectionalChannelInfo {
 /// The fees on channels from us to next-hops are ignored (as they are assumed to all be
 /// equal), however the enabled/disabled bit on such channels as well as the htlc_minimum_msat
 /// *is* checked as they may change based on the receiving node.
-pub fn get_route<C: Deref, L: Deref>(our_node_id: &PublicKey, net_graph_msg_handler: &NetGraphMsgHandler<C, L>, target: &PublicKey, first_hops: Option<&[channelmanager::ChannelDetails]>,
-	last_hops: &[RouteHint], final_value_msat: u64, final_cltv: u32, logger: L, net_metadata: impl RouteFeePenalty) -> Result<Route, LightningError> where C::Target: ChainWatchInterface, L::Target: Logger {
+pub fn get_route<C: Deref, L: Deref, N: RouteFeePenalty>(our_node_id: &PublicKey, net_graph_msg_handler: &NetGraphMsgHandler<C, L>, target: &PublicKey, first_hops: Option<&[channelmanager::ChannelDetails]>,
+	last_hops: &[RouteHint], final_value_msat: u64, final_cltv: u32, logger: L, net_metadata: N) -> Result<Route, LightningError> where C::Target: ChainWatchInterface, L::Target: Logger {
 	// TODO: Obviously *only* using total fee cost sucks. We should consider weighting by
 	// uptime/success in using a node in the past.
 	if *target == *our_node_id {


### PR DESCRIPTION
Adds NetworkTracker trait that allows users to implement interface
between their metadata and their view of NetworkGraph. Users can
implement their own metadata structs, but at a minimum will have to
implement the UpdateMetadata trait (even if the functions do nothing).

By default, this trait uses a new struct called DefaultMetadata
which just tracks previously failed routes, and can find out if a
route has previously failed.