### PR TITLE
Make test output deterministic

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -28,4 +28,3 @@ features = ["bitcoinconsensus"]
 
 [dev-dependencies]
 hex = "0.3"
-rand = "0.4"

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -19,7 +19,6 @@
 #![allow(ellipsis_inclusive_range_patterns)]
 
 extern crate bitcoin;
-#[cfg(test)] extern crate rand;
 #[cfg(test)] extern crate hex;
 
 #[macro_use]

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4478,7 +4478,6 @@ mod tests {
 	use bitcoin::hashes::Hash;
 	use bitcoin::hash_types::{Txid, WPubkeyHash};
 	use std::sync::Arc;
-	use rand::{thread_rng,Rng};
 
 	struct TestFeeEstimator {
 		fee_est: u32
@@ -4533,9 +4532,7 @@ mod tests {
 		let original_fee = 253;
 		let mut fee_est = TestFeeEstimator{fee_est: original_fee };
 		let secp_ctx = Secp256k1::new();
-		let mut seed = [0; 32];
-		let mut rng = thread_rng();
-		rng.fill_bytes(&mut seed);
+		let seed = [42; 32];
 		let network = Network::Testnet;
 		let keys_provider = test_utils::TestKeysInterface::new(&seed, network);
 
@@ -4555,9 +4552,7 @@ mod tests {
 		let feeest = TestFeeEstimator{fee_est: 15000};
 		let logger = test_utils::TestLogger::new();
 		let secp_ctx = Secp256k1::new();
-		let mut seed = [0; 32];
-		let mut rng = thread_rng();
-		rng.fill_bytes(&mut seed);
+		let seed = [42; 32];
 		let network = Network::Testnet;
 		let keys_provider = test_utils::TestKeysInterface::new(&seed, network);
 

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -2544,7 +2544,6 @@ mod tests {
 	use util::test_utils::TestLogger;
 	use bitcoin::secp256k1::key::{SecretKey,PublicKey};
 	use bitcoin::secp256k1::Secp256k1;
-	use rand::{thread_rng,Rng};
 	use std::sync::Arc;
 	use chain::keysinterface::InMemoryChannelKeys;
 
@@ -2558,10 +2557,8 @@ mod tests {
 
 		let mut preimages = Vec::new();
 		{
-			let mut rng  = thread_rng();
-			for _ in 0..20 {
-				let mut preimage = PaymentPreimage([0; 32]);
-				rng.fill_bytes(&mut preimage.0[..]);
+			for i in 0..20 {
+				let preimage = PaymentPreimage([i; 32]);
 				let hash = PaymentHash(Sha256::hash(&preimage.0[..]).into_inner());
 				preimages.push((preimage, hash));
 			}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -29,8 +29,6 @@ use bitcoin::hash_types::BlockHash;
 
 use bitcoin::secp256k1::key::PublicKey;
 
-use rand::{thread_rng,Rng};
-
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::{Mutex, RwLock};
@@ -1071,11 +1069,9 @@ pub fn create_chanmon_cfgs(node_count: usize) -> Vec<TestChanMonCfg> {
 
 pub fn create_node_cfgs<'a>(node_count: usize, chanmon_cfgs: &'a Vec<TestChanMonCfg>) -> Vec<NodeCfg<'a>> {
 	let mut nodes = Vec::new();
-	let mut rng = thread_rng();
 
 	for i in 0..node_count {
-		let mut seed = [0; 32];
-		rng.fill_bytes(&mut seed);
+		let seed = [i as u8; 32];
 		let keys_manager = test_utils::TestKeysInterface::new(&seed, Network::Testnet);
 		let chan_monitor = test_utils::TestChannelMonitor::new(&chanmon_cfgs[i].chain_monitor, &chanmon_cfgs[i].tx_broadcaster, &chanmon_cfgs[i].logger, &chanmon_cfgs[i].fee_estimator);
 		nodes.push(NodeCfg { chain_monitor: &chanmon_cfgs[i].chain_monitor, logger: &chanmon_cfgs[i].logger, tx_broadcaster: &chanmon_cfgs[i].tx_broadcaster, fee_estimator: &chanmon_cfgs[i].fee_estimator, chan_monitor, keys_manager, node_seed: seed });

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -48,8 +48,6 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::Ordering;
 use std::{mem, io};
 
-use rand::{thread_rng, Rng};
-
 use ln::functional_test_utils::*;
 
 #[test]
@@ -1613,15 +1611,8 @@ fn test_chan_reserve_violation_inbound_htlc_outbound_channel() {
 	let (route, payment_hash, _) = get_route_and_payment_hash!(1000);
 	// Need to manually create the update_add_htlc message to go around the channel reserve check in send_htlc()
 	let secp_ctx = Secp256k1::new();
-	let session_priv = SecretKey::from_slice(&{
-		let mut session_key = [0; 32];
-		let mut rng = thread_rng();
-		rng.fill_bytes(&mut session_key);
-		session_key
-	}).expect("RNG is bad!");
-
+	let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
 	let cur_height = nodes[1].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
-
 	let onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route.paths[0], &session_priv).unwrap();
 	let (onion_payloads, htlc_msat, htlc_cltv) = onion_utils::build_onion_payloads(&route.paths[0], 1000, &None, cur_height).unwrap();
 	let onion_packet = onion_utils::construct_onion_packet(onion_payloads, onion_keys, [0; 32], &payment_hash);
@@ -1692,15 +1683,8 @@ fn test_chan_reserve_violation_inbound_htlc_inbound_chan() {
 
 	// Need to manually create the update_add_htlc message to go around the channel reserve check in send_htlc()
 	let secp_ctx = Secp256k1::new();
-	let session_priv = SecretKey::from_slice(&{
-		let mut session_key = [0; 32];
-		let mut rng = thread_rng();
-		rng.fill_bytes(&mut session_key);
-		session_key
-	}).expect("RNG is bad!");
-
+	let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
 	let cur_height = nodes[0].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
-
 	let onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route_2.paths[0], &session_priv).unwrap();
 	let (onion_payloads, htlc_msat, htlc_cltv) = onion_utils::build_onion_payloads(&route_2.paths[0], recv_value_2, &None, cur_height).unwrap();
 	let onion_packet = onion_utils::construct_onion_packet(onion_payloads, onion_keys, [0; 32], &our_payment_hash_1);
@@ -3176,13 +3160,7 @@ fn fail_backward_pending_htlc_upon_channel_failure() {
 		let (_, payment_hash) = get_payment_preimage_hash!(nodes[1]);
 
 		let secp_ctx = Secp256k1::new();
-		let session_priv = {
-			let mut session_key = [0; 32];
-			let mut rng = thread_rng();
-			rng.fill_bytes(&mut session_key);
-			SecretKey::from_slice(&session_key).expect("RNG is bad!")
-		};
-
+		let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
 		let current_height = nodes[1].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
 		let net_graph_msg_handler = &nodes[1].net_graph_msg_handler;
 		let route = get_route(&nodes[1].node.get_our_node_id(), net_graph_msg_handler, &nodes[0].node.get_our_node_id(), None, &Vec::new(), 50_000, TEST_FINAL_CLTV, &logger).unwrap();
@@ -5480,9 +5458,7 @@ fn test_key_derivation_params() {
 	let chanmon_cfgs = create_chanmon_cfgs(3);
 
 	// We manually create the node configuration to backup the seed.
-	let mut rng = thread_rng();
-	let mut seed = [0; 32];
-	rng.fill_bytes(&mut seed);
+	let seed = [42; 32];
 	let keys_manager = test_utils::TestKeysInterface::new(&seed, Network::Testnet);
 	let chan_monitor = test_utils::TestChannelMonitor::new(&chanmon_cfgs[0].chain_monitor, &chanmon_cfgs[0].tx_broadcaster, &chanmon_cfgs[0].logger, &chanmon_cfgs[0].fee_estimator);
 	let node = NodeCfg { chain_monitor: &chanmon_cfgs[0].chain_monitor, logger: &chanmon_cfgs[0].logger, tx_broadcaster: &chanmon_cfgs[0].tx_broadcaster, fee_estimator: &chanmon_cfgs[0].fee_estimator, chan_monitor, keys_manager, node_seed: seed };
@@ -6475,13 +6451,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 	let logger = test_utils::TestLogger::new();
 
 	let (_, our_payment_hash) = get_payment_preimage_hash!(nodes[0]);
-
-	let session_priv = SecretKey::from_slice(&{
-		let mut session_key = [0; 32];
-		let mut rng = thread_rng();
-		rng.fill_bytes(&mut session_key);
-		session_key
-	}).expect("RNG is bad!");
+	let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
 
 	let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
 	let route = get_route(&nodes[0].node.get_our_node_id(), net_graph_msg_handler, &nodes[1].node.get_our_node_id(), None, &[], 3999999, TEST_FINAL_CLTV, &logger).unwrap();

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1216,8 +1216,6 @@ mod tests {
 	use bitcoin::secp256k1::Secp256k1;
 	use bitcoin::secp256k1::key::{SecretKey, PublicKey};
 
-	use rand::{thread_rng, Rng};
-
 	use std;
 	use std::sync::{Arc, Mutex};
 	use std::sync::atomic::Ordering;
@@ -1271,18 +1269,11 @@ mod tests {
 
 	fn create_network<'a>(peer_count: usize, cfgs: &'a Vec<PeerManagerCfg>) -> Vec<PeerManager<FileDescriptor, &'a test_utils::TestChannelMessageHandler, &'a test_utils::TestRoutingMessageHandler, &'a test_utils::TestLogger>> {
 		let mut peers = Vec::new();
-		let mut rng = thread_rng();
-		let mut ephemeral_bytes = [0; 32];
-		rng.fill_bytes(&mut ephemeral_bytes);
-
 		for i in 0..peer_count {
-			let node_id = {
-				let mut key_slice = [0;32];
-				rng.fill_bytes(&mut key_slice);
-				SecretKey::from_slice(&key_slice).unwrap()
-			};
+			let node_secret = SecretKey::from_slice(&[42 + i as u8; 32]).unwrap();
+			let ephemeral_bytes = [i as u8; 32];
 			let msg_handler = MessageHandler { chan_handler: &cfgs[i].chan_handler, route_handler: &cfgs[i].routing_handler };
-			let peer = PeerManager::new(msg_handler, node_id, &ephemeral_bytes, &cfgs[i].logger);
+			let peer = PeerManager::new(msg_handler, node_secret, &ephemeral_bytes, &cfgs[i].logger);
 			peers.push(peer);
 		}
 

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -22,7 +22,7 @@ use bitcoin::hash_types::{Txid, BlockHash};
 
 use bitcoin::secp256k1::{SecretKey, PublicKey, Secp256k1, Signature};
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{cmp, mem};
@@ -344,7 +344,7 @@ impl keysinterface::KeysInterface for TestKeysInterface {
 
 impl TestKeysInterface {
 	pub fn new(seed: &[u8; 32], network: Network) -> Self {
-		let now = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
+		let now = Duration::from_secs(genesis_block(network).header.time as u64);
 		Self {
 			backing: keysinterface::KeysManager::new(seed, network, now.as_secs(), now.subsec_nanos()),
 			override_session_priv: Mutex::new(None),


### PR DESCRIPTION
Tests use sources of randomness to produce seeds, preimages, secrets,
and ephemeral data. However, this makes comparing logs between different
test runs difficult. Remove uses of random number generators and the
current time in favor of fixed values in order to make the test output
deterministic.