### PR TITLE
Test remote fee spike buffer violation

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2519,7 +2519,7 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> 
 						_ => pending_forward_info
 					}
 				};
-				try_chan_entry!(self, chan.get_mut().update_add_htlc(&msg, pending_forward_info, create_pending_htlc_status), channel_state, chan);
+				try_chan_entry!(self, chan.get_mut().update_add_htlc(&msg, pending_forward_info, create_pending_htlc_status, &self.logger), channel_state, chan);
 			},
 			hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel", msg.channel_id))
 		}


### PR DESCRIPTION
Adds a test for [this case](https://github.com/rust-bitcoin/rust-lightning/blob/master/lightning/src/ln/channel.rs#L1848) that was missing from #577.

Because `channel.send_htlc` would prevent us from sending a payment that violates our fee spike buffer, each message from the HTLC's sender is manually constructed. Hence why the test looks pretty complicated.