### PR TITLE
ChannelKeys - separate commitment revocation from getting the per-commitment point

### DIFF
--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -497,8 +497,8 @@ pub fn build_htlc_transaction(prev_hash: &Txid, feerate_per_kw: u32, to_self_del
 
 #[derive(Clone)]
 /// We use this to track local commitment transactions and put off signing them until we are ready
-/// to broadcast. Eventually this will require a signer which is possibly external, but for now we
-/// just pass in the SecretKeys required.
+/// to broadcast. This class can be used inside a signer implementation to generate a signature
+/// given the relevant secret key.
 pub struct LocalCommitmentTransaction {
 	// TODO: We should migrate away from providing the transaction, instead providing enough to
 	// allow the ChannelKeys to construct it from scratch. Luckily we already have HTLC data here,

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -1612,7 +1612,7 @@ fn test_fee_spike_violation_fails_htlc() {
 		let chan_keys = local_chan.get_local_keys();
 		let pubkeys = chan_keys.pubkeys();
 		(pubkeys.revocation_basepoint, pubkeys.htlc_basepoint, pubkeys.payment_point,
-		 chan_keys.commitment_secret(INITIAL_COMMITMENT_NUMBER), chan_keys.commitment_secret(INITIAL_COMMITMENT_NUMBER - 2))
+		 chan_keys.release_commitment_secret(INITIAL_COMMITMENT_NUMBER), chan_keys.release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 2))
 	};
 	let (remote_delayed_payment_basepoint, remote_htlc_basepoint, remote_payment_point, remote_secret1) = {
 		let chan_lock = nodes[1].node.channel_state.lock().unwrap();
@@ -1620,7 +1620,7 @@ fn test_fee_spike_violation_fails_htlc() {
 		let chan_keys = remote_chan.get_local_keys();
 		let pubkeys = chan_keys.pubkeys();
 		(pubkeys.delayed_payment_basepoint, pubkeys.htlc_basepoint, pubkeys.payment_point,
-		 chan_keys.commitment_secret(INITIAL_COMMITMENT_NUMBER - 1))
+		 chan_keys.release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 1))
 	};
 
 	// Assemble the set of keys we can use for signatures for our commitment_signed message.
@@ -8132,8 +8132,8 @@ fn test_counterparty_raa_skip_no_crash() {
 	let local_keys = &guard.by_id.get_mut(&channel_id).unwrap().local_keys;
 	const INITIAL_COMMITMENT_NUMBER: u64 = (1 << 48) - 1;
 	let next_per_commitment_point = PublicKey::from_secret_key(&Secp256k1::new(),
-		&SecretKey::from_slice(&local_keys.commitment_secret(INITIAL_COMMITMENT_NUMBER - 2)).unwrap());
-	let per_commitment_secret = local_keys.commitment_secret(INITIAL_COMMITMENT_NUMBER);
+		&SecretKey::from_slice(&local_keys.release_commitment_secret(INITIAL_COMMITMENT_NUMBER - 2)).unwrap());
+	let per_commitment_secret = local_keys.release_commitment_secret(INITIAL_COMMITMENT_NUMBER);
 
 	nodes[1].node.handle_revoke_and_ack(&nodes[0].node.get_our_node_id(),
 		&msgs::RevokeAndACK { channel_id, per_commitment_secret, next_per_commitment_point });

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -48,7 +48,15 @@ impl EnforcingChannelKeys {
 }
 
 impl ChannelKeys for EnforcingChannelKeys {
-	fn commitment_secret(&self, idx: u64) -> [u8; 32] { self.inner.commitment_secret(idx) }
+	fn get_per_commitment_point<T: secp256k1::Signing + secp256k1::Verification>(&self, idx: u64, secp_ctx: &Secp256k1<T>) -> PublicKey {
+		self.inner.get_per_commitment_point(idx, secp_ctx)
+	}
+
+	fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {
+		// TODO: enforce the ChannelKeys contract - error here if we already signed this commitment
+		self.inner.release_commitment_secret(idx)
+	}
+
 	fn pubkeys(&self) -> &ChannelPublicKeys { self.inner.pubkeys() }
 	fn key_derivation_params(&self) -> (u64, u64) { self.inner.key_derivation_params() }
 
@@ -71,6 +79,8 @@ impl ChannelKeys for EnforcingChannelKeys {
 	}
 
 	fn sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()> {
+		// TODO: enforce the ChannelKeys contract - error if this commitment was already revoked
+		// TODO: need the commitment number
 		Ok(self.inner.sign_local_commitment(local_commitment_tx, secp_ctx).unwrap())
 	}
 


### PR DESCRIPTION
The commitment secret is sensitive - it can be used by an attacker to steal funds if the node also signs the same transaction. In general, the signer should be considered more secure - it will, for example, be implemented in secure hardware. It should not give the rest of the node access to data which can be used by an attacker and it should enforce policy which prevents attacks.