### PR TITLE
Export various fields and structures

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -18,6 +18,9 @@ max_level_error = []
 max_level_warn = []
 max_level_info = []
 max_level_debug = []
+# Allow signing of local transactions that may have been revoked or will be revoked, for functional testing (e.g. justice tx handling).
+# This is unsafe to use in production because it may result in the counterparty publishing taking our funds.
+unsafe_revoked_tx_signing = []
 
 [dependencies]
 bitcoin = "0.23"

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -247,7 +247,7 @@ pub trait ChannelKeys : Send+Clone {
 	/// transactions which will be broadcasted later, after the channel has moved on to a newer
 	/// state. Thus, needs its own method as sign_local_commitment may enforce that we only ever
 	/// get called once.
-	#[cfg(test)]
+	#[cfg(any(test,feature = "unsafe_revoked_tx_signing"))]
 	fn unsafe_sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()>;
 
 	/// Create a signature for each HTLC transaction spending a local commitment transaction.
@@ -508,7 +508,7 @@ impl ChannelKeys for InMemoryChannelKeys {
 		Ok(local_commitment_tx.get_local_sig(&self.funding_key, &channel_funding_redeemscript, self.channel_value_satoshis, secp_ctx))
 	}
 
-	#[cfg(test)]
+	#[cfg(any(test,feature = "unsafe_revoked_tx_signing"))]
 	fn unsafe_sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()> {
 		let funding_pubkey = PublicKey::from_secret_key(secp_ctx, &self.funding_key);
 		let remote_channel_pubkeys = &self.accepted_channel_data.as_ref().expect("must accept before signing").remote_channel_pubkeys;

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -600,7 +600,7 @@ impl LocalCommitmentTransaction {
 
 	/// Generate a new LocalCommitmentTransaction based on a raw commitment transaction,
 	/// remote signature and both parties keys
-	pub(crate) fn new_missing_local_sig(unsigned_tx: Transaction, their_sig: Signature, our_funding_key: &PublicKey, their_funding_key: &PublicKey, local_keys: TxCreationKeys, feerate_per_kw: u32, htlc_data: Vec<(HTLCOutputInCommitment, Option<Signature>)>) -> LocalCommitmentTransaction {
+	pub fn new_missing_local_sig(unsigned_tx: Transaction, their_sig: Signature, our_funding_key: &PublicKey, their_funding_key: &PublicKey, local_keys: TxCreationKeys, feerate_per_kw: u32, htlc_data: Vec<(HTLCOutputInCommitment, Option<Signature>)>) -> LocalCommitmentTransaction {
 		if unsigned_tx.input.len() != 1 { panic!("Tried to store a commitment transaction that had input count != 1!"); }
 		if unsigned_tx.input[0].witness.len() != 0 { panic!("Tried to store a signed commitment transaction?"); }
 

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -1849,7 +1849,7 @@ impl<ChanSigner: ChannelKeys> ChannelMonitor<ChanSigner> {
 	/// Unsafe test-only version of get_latest_local_commitment_txn used by our test framework
 	/// to bypass LocalCommitmentTransaction state update lockdown after signature and generate
 	/// revoked commitment transaction.
-	#[cfg(test)]
+	#[cfg(any(test,feature = "unsafe_revoked_tx_signing"))]
 	pub fn unsafe_get_latest_local_commitment_txn<L: Deref>(&mut self, logger: &L) -> Vec<Transaction> where L::Target: Logger {
 		log_trace!(logger, "Getting signed copy of latest local commitment transaction!");
 		if let Some(commitment_tx) = self.onchain_tx_handler.get_fully_signed_copy_local_tx(&self.funding_redeemscript) {

--- a/lightning/src/ln/channelmonitor.rs
+++ b/lightning/src/ln/channelmonitor.rs
@@ -175,10 +175,8 @@ pub struct SimpleManyChannelMonitor<Key, ChanSigner: ChannelKeys, T: Deref, F: D
         L::Target: Logger,
         C::Target: ChainWatchInterface,
 {
-	#[cfg(test)] // Used in ChannelManager tests to manipulate channels directly
+	/// The monitors
 	pub monitors: Mutex<HashMap<Key, ChannelMonitor<ChanSigner>>>,
-	#[cfg(not(test))]
-	monitors: Mutex<HashMap<Key, ChannelMonitor<ChanSigner>>>,
 	chain_monitor: C,
 	broadcaster: T,
 	logger: L,

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -939,7 +939,7 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 		}
 	}
 
-	#[cfg(test)]
+	#[cfg(any(test, feature="unsafe_revoked_tx_signing"))]
 	pub(super) fn get_fully_signed_copy_local_tx(&mut self, funding_redeemscript: &Script) -> Option<Transaction> {
 		if let Some(ref mut local_commitment) = self.local_commitment {
 			let local_commitment = local_commitment.clone();
@@ -979,7 +979,7 @@ impl<ChanSigner: ChannelKeys> OnchainTxHandler<ChanSigner> {
 		htlc_tx
 	}
 
-	#[cfg(test)]
+	#[cfg(any(test,feature = "unsafe_revoked_tx_signing"))]
 	pub(super) fn unsafe_get_fully_signed_htlc_tx(&mut self, outp: &::bitcoin::OutPoint, preimage: &Option<PaymentPreimage>) -> Option<Transaction> {
 		let latest_had_sigs = self.local_htlc_sigs.is_some();
 		let prev_had_sigs = self.prev_local_htlc_sigs.is_some();

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -93,7 +93,7 @@ impl ChannelKeys for EnforcingChannelKeys {
 		Ok(self.inner.sign_local_commitment(local_commitment_tx, secp_ctx).unwrap())
 	}
 
-	#[cfg(test)]
+	#[cfg(any(test,feature = "unsafe_revoked_tx_signing"))]
 	fn unsafe_sign_local_commitment<T: secp256k1::Signing + secp256k1::Verification>(&self, local_commitment_tx: &LocalCommitmentTransaction, secp_ctx: &Secp256k1<T>) -> Result<Signature, ()> {
 		Ok(self.inner.unsafe_sign_local_commitment(local_commitment_tx, secp_ctx).unwrap())
 	}


### PR DESCRIPTION
This is for discussion purposes at this time.  This is a set of patches we maintain on top of master in order to let [Rust Lightning Signer](https://gitlab.com/lightning-signer/rust-lightning-signer) do various things, including:

- access to `TxCreationKeys` ~~fields and~~ constructor, so that we can use it to call various `InMemoryChannelKeys` methods
- access to `LocalCommitmentTransaction` constructor for `InMemoryChannelKeys` use
- export the unsafe methods for testing use, gated by a new feature named "unsafe"
- access to node and channel announcement fields so that the contents can be checked by the signer
