### PR TITLE
Move relayed HTLC htlc_minimum_msat policy check from incoming channel to outgoing one

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3158,11 +3158,6 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 		);
 	}
 
-	/// Allowed in any state (including after shutdown)
-	pub fn get_their_htlc_minimum_msat(&self) -> u64 {
-		self.our_htlc_minimum_msat
-	}
-
 	pub fn get_value_satoshis(&self) -> u64 {
 		self.channel_value_satoshis
 	}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1185,7 +1185,7 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> 
 				{
 					let mut res = Vec::with_capacity(8 + 128);
 					if let Some(chan_update) = chan_update {
-						if code == 0x1000 | 12 {
+						if code == 0x1000 | 12 { // fee_insufficient
 							res.extend_from_slice(&byte_utils::be64_to_array(msg.amount_msat));
 						}
 						else if code == 0x1000 | 13 {
@@ -1585,12 +1585,12 @@ impl<ChanSigner: ChannelKeys, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> 
 										incoming_packet_shared_secret: incoming_shared_secret,
 									});
 									if amt_to_forward < chan.get().get_our_htlc_minimum_msat() {
-										let mut data = Vec::with_capacity(8 + 128);
+										let mut data = Vec::with_capacity(8 + 128); // 8-bytes-htlc_msat + 2-byte-length + length-byte-channel_update
 										data.extend_from_slice(&byte_utils::be64_to_array(amt_to_forward));
 										let chan_update = self.get_channel_update(chan.get()).unwrap();
 										data.extend_from_slice(&chan_update.encode_with_len()[..]);
 										failed_forwards.push((htlc_source, payment_hash,
-											HTLCFailReason::Reason { failure_code: 0x1000 | 11, data }
+											HTLCFailReason::Reason { failure_code: 0x1000 | 11, data } // amount_below_minimum
 										));
 										continue;
 									}


### PR DESCRIPTION
A forwarded packet must conform to our HTLC relay policy, this includes
compliance with our outgoing channel policy, as announced previously to
upstream peer.
    
Previously, we checked HTLC acceptance with regards to htlc_minimum_msat
on our incoming channel in decode_update_add_htlc_onion(). This is a
misinterpretation of BOLT specs as we already proceed to the same check
in update_add_htlc(). This check must be done on our outgoing channel,
as thus it is moved in process_pending_htlc_forwards() before to call
send_htlc(). This latter function still verify upstream peer's
htlc_minimum_msat before to decide on forwarding HTLC.
    
Modify run_onion_failure_test_with_fail_intercept to test onion packet
failure by intermediate node at HTLC forwarding processing, previously
 uncovered by onion failure test framework API.

While reworking our naming nomenclature (#633), I spotted that `get_their_htlc_minimum_msat` was in fact returning our `htlc_minimum_msat`. Thinking as first it was a bug, it seems to me this method was used to implement a redundant check and we were actually missing one on the outgoing channel. Spec is quite obscure (`The HTLC amount was below the htlc_minimum_msat of the [outgoing] channel from the processing node.`) but correct.