### PR TITLE
Bump MSRV to 1.30.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ jobs:
       matrix:
         toolchain: [ stable,
                      beta,
-                     # 1.22.0 is MSRV for rust-lightning in general:
-                     1.22.0,
+                     # 1.30.0 is MSRV for Rust-Lightning
+                     1.30.0,
                      # 1.34.2 is Debian stable
                      1.34.2,
                      # 1.39.0 is MSRV for lightning-net-tokio and generates coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: rust
 rust:
   - stable
   - beta
-  # 1.22.0 is MSRV for rust-lightning in general:
-  - 1.22.0
+  # 1.30.0 is MSRV for rust-lightning in general:
+  - 1.30.0
   # 1.34.2 is Debian stable
   - 1.34.2
   # 1.39.0 is MSRV for lightning-net-tokio and generates coverage

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,8 @@ be covered by functional tests.
 When refactoring, structure your PR to make it easy to review and don't
 hestitate to split it into multiple small, focused PRs.
 
-The Minimal Supported Rust Version is 1.22.0 (enforced by our Travis).
+The Minimal Supported Rust Version is 1.30.0 (enforced by our Travis and
+GitHub Actions).
 
 Commits should cover both the issue fixed and the solution's rationale.
 These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind.


### PR DESCRIPTION
We wanted to bump to 1.29 to continue to support mrustc bootstrapping, but on 1.29
there's a bug preventing us from compiling the lightning package only, thus parts
of lightning-net-tokio cause a compilation error.

The advantage of bumping the MSRV is an improved borrow checker which should
enable improved code quality, and not having jump through weird hoops sometimes
to get 1.22 working.

Maybe this is a good compromise in the meantime, and we can always bump more later?

It'd make part of #667 a bit nicer (though admittedly it's possible there's a workaround to my current hack for 1.22, and I'm just too tired of 1.22 to find it lol). I'm OK to revisit bumping MSRV later if it's preferred though.

Related to #471 