### PR TITLE
Update CI to run on Macos and Windows in addition to Ubuntu.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,17 +34,23 @@ jobs:
           override: true
           profile: minimal
       - name: Build on Rust ${{ matrix.toolchain }} with net-tokio
-        if: matrix.build-net-tokio
+        if: "matrix.build-net-tokio && !matrix.coverage"
+        run: cargo build --verbose --color always
+      - name: Build on Rust ${{ matrix.toolchain }} with net-tokio and full code-linking for coverage generation
+        if: matrix.coverage
         run: RUSTFLAGS="-C link-dead-code" cargo build --verbose --color always
       - name: Build on Rust ${{ matrix.toolchain }}
         if: "! matrix.build-net-tokio"
-        run: RUSTFLAGS="-C link-dead-code" cargo build --verbose  --color always -p lightning
+        run: cargo build --verbose  --color always -p lightning
       - name: Test on Rust ${{ matrix.toolchain }} with net-tokio
-        if: matrix.build-net-tokio
+        if: "matrix.build-net-tokio && !matrix.coverage"
+        run: cargo test --verbose --color always
+      - name: Test on Rust ${{ matrix.toolchain }} with net-tokio and full code-linking for coverage generation
+        if: matrix.coverage
         run: RUSTFLAGS="-C link-dead-code" cargo test --verbose --color always
       - name: Test on Rust ${{ matrix.toolchain }}
         if: "! matrix.build-net-tokio"
-        run: RUSTFLAGS="-C link-dead-code" cargo test --verbose --color always  -p lightning
+        run: cargo test --verbose --color always  -p lightning
       - name: Install deps for kcov
         if: matrix.coverage
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
+        platform: [ ubuntu-latest ]
         toolchain: [ stable,
                      beta,
                      # 1.30.0 is MSRV for Rust-Lightning
@@ -17,12 +18,18 @@ jobs:
         include:
           - toolchain: stable
             build-net-tokio: true
+          - toolchain: stable
+            platform: macos-latest
+            build-net-tokio: true
+          - toolchain: stable
+            platform: windows-latest
+            build-net-tokio: true
           - toolchain: beta
             build-net-tokio: true
           - toolchain: 1.39.0
             build-net-tokio: true
             coverage: true
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,6 @@ jobs:
           - toolchain: 1.39.0
             build-net-tokio: true
             coverage: true
-          - toolchain: 1.34.2
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code


### PR DESCRIPTION
We only run Macos and Windows on Rust stable, for efficient CI.

TODO:
- [ ] make bindings testing cross-platform, too (but allow it to fail)