### PR TITLE
Do not test any block-contents-rescan cases

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -45,7 +45,7 @@ use ln::msgs::DecodeError;
 /// spend on-chain. The information needed to do this is provided in this enum, including the
 /// outpoint describing which txid and output index is available, the full output which exists at
 /// that txid/index, and any keys or other information required to sign.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SpendableOutputDescriptor {
 	/// An output to a script which was provided via KeysInterface, thus you should already know
 	/// how to spend it. No keys are provided as rust-lightning was never given any keys - only the

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5038,23 +5038,32 @@ fn test_static_spendable_outputs_justice_tx_revoked_htlc_timeout_tx() {
 
 	let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
 	assert_eq!(node_txn.len(), 4); // ChannelMonitor: justice tx on revoked commitment, justice tx on revoked HTLC-timeout, adjusted justice tx, ChannelManager: local commitment tx
+	// The first transaction generated is bogus - it spends both outputs of revoked_local_txn[0]
+	// including the one already spent by revoked_htlc_txn[0]. That's OK, we'll spend with valid
+	// transactions next...
 	assert_eq!(node_txn[0].input.len(), 2);
 	check_spends!(node_txn[0], revoked_local_txn[0]);
+
 	check_spends!(node_txn[1], chan_1.3);
+
 	assert_eq!(node_txn[2].input.len(), 1);
 	check_spends!(node_txn[2], revoked_htlc_txn[0]);
 	assert_eq!(node_txn[3].input.len(), 1);
 	check_spends!(node_txn[3], revoked_local_txn[0]);
 
 	let header_1 = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	nodes[1].block_notifier.block_connected(&Block { header: header_1, txdata: vec![node_txn[0].clone(), node_txn[2].clone()] }, 1);
+	nodes[1].block_notifier.block_connected(&Block { header: header_1, txdata: vec![node_txn[2].clone(), node_txn[3].clone()] }, 1);
 	connect_blocks(&nodes[1].block_notifier, ANTI_REORG_DELAY - 1, 1, true, header.block_hash());
 
-	// Check B's ChannelMonitor was able to generate the right spendable output descriptor
+	// Note that nodes[1]'s tx_broadcaster is still locked, so if we get here the channelmonitor
+	// didn't try to generate any new transactions.
+
+	// Check B's ChannelMonitor was able to generate the right spendable output descriptor which
+	// allows the user to spend the newly-confirmed outputs.
 	let spend_txn = check_spendable_outputs!(nodes[1], 1, node_cfgs[1].keys_manager, 100000);
 	assert_eq!(spend_txn.len(), 2);
-	check_spends!(spend_txn[0], node_txn[0]);
-	check_spends!(spend_txn[1], node_txn[2]);
+	check_spends!(spend_txn[0], node_txn[2]);
+	check_spends!(spend_txn[1], node_txn[3]);
 }
 
 #[test]

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 /// Note that while Writeable and Readable are implemented for Event, you probably shouldn't use
 /// them directly as they don't round-trip exactly (for example FundingGenerationReady is never
 /// written as it makes no sense to respond to it after reconnecting to peers).
+#[derive(Debug)]
 pub enum Event {
 	/// Used to indicate that the client should generate a funding transaction with the given
 	/// parameters and then call ChannelManager::funding_transaction_generated.


### PR DESCRIPTION
This is in preparation for #649 removing support for block rescan wholesale, fixing the tests which rely on it and are overly-specific. It doesn't really address the fact that the tests are over-specific (though does address a few cases where we're confirming double-spends in blocks in tests), but should at least make it so that #649 can make progress.