### PR TITLE
Don't let CI fail to check commits b/c git isn't configured in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
         run: |
           git remote add upstream https://github.com/rust-bitcoin/rust-lightning
           git fetch upstream
+          export GIT_COMMITTER_EMAIL="rl-ci@example.com"
+          export GIT_COMMITTER_NAME="RL CI"
           git rebase upstream/main
       - name: For each commit, run cargo check (including in fuzz)
         run: ci/check-each-commit.sh upstream/main


### PR DESCRIPTION
This fixes #733 by just setting a dummy git name/email before
calling `git rebase` in CI.

This PR is deliberately based on a stale version of git upstream to test it.