### PR TITLE
Fix passing -O1 to build from `cargo test`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,13 @@ members = [
     "lightning-net-tokio",
 ]
 
-# Our tests do actual crypo and lots of work, the tradeoff for -O1 is well worth it
-[profile.test]
-opt-level = 1
-
+# Our tests do actual crypo and lots of work, the tradeoff for -O1 is well worth it.
+# Ideally we would only do this in profile.test, but profile.test only applies to
+# the test binary, not dependencies, which means most of the critical code still
+# gets compiled as -O0. See
+# https://doc.rust-lang.org/cargo/reference/profiles.html#profile-selection
 [profile.dev]
+opt-level = 1
 panic = "abort"
 
 [profile.release]


### PR DESCRIPTION
In 9e03087d6acbc876a5ad1c9b9d8746bf18d5ca86 we started setting
`opt-level` only on profile.test and not profile.dev. When that
commit was authored I tested only that rustc was being called with
opt-level set in its flags, not that the resulted run ran at the
speed I expected. It seems profile.test isn't applied properly to
dependencies or so, resulting in tests running much slower than
they do at profile.dev.opt-level=1.