### PR TITLE
trivial clippy warning fixes

### DIFF
--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -518,13 +518,13 @@ impl Readable for NetworkGraph {
 
 impl fmt::Display for NetworkGraph {
 	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-		write!(f, "Network map\n[Channels]\n")?;
+		writeln!(f, "Network map\n[Channels]")?;
 		for (key, val) in self.channels.iter() {
-			write!(f, " {}: {}\n", key, val)?;
+			writeln!(f, " {}: {}", key, val)?;
 		}
-		write!(f, "[Nodes]\n")?;
+		writeln!(f, "[Nodes]")?;
 		for (key, val) in self.nodes.iter() {
-			write!(f, " {}: {}\n", log_pubkey!(key), val)?;
+			writeln!(f, " {}: {}", log_pubkey!(key), val)?;
 		}
 		Ok(())
 	}

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -80,9 +80,9 @@ pub(crate) struct DebugRoute<'a>(pub &'a Route);
 impl<'a> std::fmt::Display for DebugRoute<'a> {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
 		for (idx, p) in self.0.paths.iter().enumerate() {
-			write!(f, "path {}:\n", idx)?;
+			writeln!(f, "path {}:", idx)?;
 			for h in p.iter() {
-				write!(f, " node_id: {}, short_channel_id: {}, fee_msat: {}, cltv_expiry_delta: {}\n", log_pubkey!(h.pubkey), h.short_channel_id, h.fee_msat, h.cltv_expiry_delta)?;
+				writeln!(f, " node_id: {}, short_channel_id: {}, fee_msat: {}, cltv_expiry_delta: {}", log_pubkey!(h.pubkey), h.short_channel_id, h.fee_msat, h.cltv_expiry_delta)?;
 			}
 		}
 		Ok(())


### PR DESCRIPTION
Trvial changes to fix ~two~ one [clippy warning](https://rust-lang.github.io/rust-clippy/rust-1.39.0/index.html) : ~clippy::inconsistent_digit_grouping~ and `clippy::write_with_newline warnings`.
