### PR TITLE
Remove unnecessary todo

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4017,12 +4017,6 @@ impl<ChanSigner: ChannelKeys> Channel<ChanSigner> {
 			}
 		}
 
-		for _htlc in self.pending_outbound_htlcs.drain(..) {
-			//TODO: Do something with the remaining HTLCs
-			//(we need to have the ChannelManager monitor them so we can claim the inbound HTLCs
-			//which correspond)
-		}
-
 		self.channel_state = ChannelState::ShutdownComplete as u32;
 		self.update_time_counter += 1;
 		self.latest_monitor_update_id += 1;


### PR DESCRIPTION
The OnchainTxHandler already monitors the chain for counterparties
revealing preimages, etc, and will give the HTLCSources back to the
ChannelManager for claiming. Thus it's unnecessary for the ChannelManager
to monitor these HTLCs itself.

I had the start of a "solution" for this todo in the course of a #611 rabbit hole, then realized it's unnecessary. So figured it might be worth removing.