### PR TITLE
ChannelManager persistence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "lightning-block-sync",
     "lightning-net-tokio",
     "lightning-persister",
+    "background-processor",
 ]
 
 # Our tests do actual crypo and lots of work, the tradeoff for -O1 is well worth it.

--- a/background-processor/Cargo.toml
+++ b/background-processor/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "background-processor"
+version = "0.1.0"
+authors = ["Valentine Wallace <vwallace@protonmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bitcoin = "0.24"
+lightning = { version = "0.0.12", path = "../lightning", features = ["allow_wallclock_use"] }
+lightning-persister = { version = "0.0.1", path = "../lightning-persister" }
+
+[dev-dependencies]
+lightning = { version = "0.0.12", path = "../lightning", features = ["_test_utils"] }

--- a/background-processor/src/lib.rs
+++ b/background-processor/src/lib.rs
@@ -1,0 +1,294 @@
+#[macro_use] extern crate lightning;
+
+use lightning::chain;
+use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
+use lightning::chain::keysinterface::{ChannelKeys, KeysInterface};
+use lightning::ln::channelmanager::ChannelManager;
+use lightning::util::logger::Logger;
+use lightning::util::ser::Writeable;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+/// BackgroundProcessor takes care of tasks that (1) need to happen periodically to keep
+/// Rust-Lightning running properly, and (2) either can or should be run in the background. Its
+/// responsibilities are:
+/// * Monitoring whether the ChannelManager needs to be re-persisted to disk, and if so,
+///   writing it to disk/backups by invoking the callback given to it at startup.
+///   ChannelManager persistence should be done in the background.
+/// * Calling `ChannelManager::timer_chan_freshness_every_min()` every minute (can be done in the
+///   background).
+///
+/// Note that if ChannelManager persistence fails and the persisted manager becomes out-of-date,
+/// then there is a risk of channels force-closing on startup when the manager realizes it's
+/// outdated. However, as long as `ChannelMonitor` backups are sound, no funds besides those used
+/// for unilateral chain closure fees are at risk.
+pub struct BackgroundProcessor {
+	stop_thread: Arc<AtomicBool>,
+	/// May be used to retrieve and handle the error if `BackgroundProcessor`'s thread
+	/// exits due to an error while persisting.
+	pub thread_handle: JoinHandle<Result<(), std::io::Error>>,
+}
+
+#[cfg(not(test))]
+const CHAN_FRESHNESS_TIMER: u64 = 60;
+#[cfg(test)]
+const CHAN_FRESHNESS_TIMER: u64 = 1;
+
+impl BackgroundProcessor {
+	/// Start a background thread that takes care of responsibilities enumerated in the top-level
+	/// documentation.
+	///
+	/// If `persist_manager` returns an error, then this thread will return said error (and `start()`
+	/// will need to be called again to restart the `BackgroundProcessor`). Users should wait on
+	/// [`thread_handle`]'s `join()` method to be able to tell if and when an error is returned, or
+	/// implement `persist_manager` such that an error is never returned to the `BackgroundProcessor`
+	///
+	/// `persist_manager` is responsible for writing out the `ChannelManager` to disk, and/or uploading
+	/// to one or more backup services. See [`ChannelManager::write`] for writing out a `ChannelManager`.
+	/// See [`FilesystemPersister::persist_manager`] for Rust-Lightning's provided implementation.
+	///
+	/// [`thread_handle`]: struct.BackgroundProcessor.html#structfield.thread_handle
+	/// [`ChannelManager::write`]: ../lightning/ln/channelmanager/struct.ChannelManager.html#method.write
+	/// [`FilesystemPersister::persist_manager`]: ../lightning_persister/struct.FilesystemPersister.html#impl
+	pub fn start<PM, ChanSigner, M, T, K, F, L>(persist_manager: PM, manager: Arc<ChannelManager<ChanSigner, Arc<M>, Arc<T>, Arc<K>, Arc<F>, Arc<L>>>, logger: Arc<L>) -> Self
+	where ChanSigner: 'static + ChannelKeys + Writeable,
+	      M: 'static + chain::Watch<Keys=ChanSigner>,
+	      T: 'static + BroadcasterInterface,
+	      K: 'static + KeysInterface<ChanKeySigner=ChanSigner>,
+	      F: 'static + FeeEstimator,
+	      L: 'static + Logger,
+	      PM: 'static + Send + Fn(&ChannelManager<ChanSigner, Arc<M>, Arc<T>, Arc<K>, Arc<F>, Arc<L>>) -> Result<(), std::io::Error>,
+	{
+		let stop_thread = Arc::new(AtomicBool::new(false));
+		let stop_thread_clone = stop_thread.clone();
+		let handle = thread::spawn(move || -> Result<(), std::io::Error> {
+			let mut current_time = Instant::now();
+			loop {
+				let updates_available = manager.wait_timeout(Duration::from_millis(100));
+				if updates_available {
+					persist_manager(&*manager)?;
+				}
+				// Exit the loop if the background processor was requested to stop.
+				if stop_thread.load(Ordering::Acquire) == true {
+					log_trace!(logger, "Terminating background processor.");
+					return Ok(())
+				}
+				if current_time.elapsed().as_secs() > CHAN_FRESHNESS_TIMER {
+					log_trace!(logger, "Calling manager's timer_chan_freshness_every_min");
+					manager.timer_chan_freshness_every_min();
+					current_time = Instant::now();
+				}
+			}
+		});
+		Self {
+			stop_thread: stop_thread_clone,
+			thread_handle: handle,
+		}
+	}
+
+	/// Stop `BackgroundProcessor`'s thread.
+	pub fn stop(self) -> Result<(), std::io::Error> {
+		self.stop_thread.store(true, Ordering::Release);
+		self.thread_handle.join().unwrap()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use bitcoin::blockdata::constants::genesis_block;
+	use bitcoin::blockdata::transaction::{Transaction, TxOut};
+	use bitcoin::network::constants::Network;
+	use lightning::chain;
+	use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
+	use lightning::chain::chainmonitor;
+	use lightning::chain::keysinterface::{ChannelKeys, InMemoryChannelKeys, KeysInterface, KeysManager};
+	use lightning::chain::transaction::OutPoint;
+	use lightning::get_event_msg;
+	use lightning::ln::channelmanager::{ChannelManager, SimpleArcChannelManager};
+	use lightning::ln::features::InitFeatures;
+	use lightning::ln::msgs::ChannelMessageHandler;
+	use lightning::util::config::UserConfig;
+	use lightning::util::events::{Event, EventsProvider, MessageSendEventsProvider, MessageSendEvent};
+	use lightning::util::logger::Logger;
+	use lightning::util::ser::Writeable;
+	use lightning::util::test_utils;
+	use lightning_persister::FilesystemPersister;
+	use std::fs;
+	use std::path::PathBuf;
+	use std::sync::{Arc, Mutex};
+	use std::time::Duration;
+	use super::BackgroundProcessor;
+
+	type ChainMonitor = chainmonitor::ChainMonitor<InMemoryChannelKeys, Arc<test_utils::TestChainSource>, Arc<test_utils::TestBroadcaster>, Arc<test_utils::TestFeeEstimator>, Arc<test_utils::TestLogger>, Arc<FilesystemPersister>>;
+
+	struct Node {
+		node: SimpleArcChannelManager<ChainMonitor, test_utils::TestBroadcaster, test_utils::TestFeeEstimator, test_utils::TestLogger>,
+		persister: Arc<FilesystemPersister>,
+		logger: Arc<test_utils::TestLogger>,
+	}
+
+	impl Drop for Node {
+		fn drop(&mut self) {
+			let data_dir = self.persister.get_data_dir();
+			match fs::remove_dir_all(data_dir.clone()) {
+				Err(e) => println!("Failed to remove test persister directory {}: {}", data_dir, e),
+				_ => {}
+			}
+		}
+	}
+
+	fn get_full_filepath(filepath: String, filename: String) -> String {
+		let mut path = PathBuf::from(filepath);
+		path.push(filename);
+		path.to_str().unwrap().to_string()
+	}
+
+	fn create_nodes(num_nodes: usize, persist_dir: String) -> Vec<Node> {
+		let mut nodes = Vec::new();
+		for i in 0..num_nodes {
+			let tx_broadcaster = Arc::new(test_utils::TestBroadcaster{txn_broadcasted: Mutex::new(Vec::new())});
+			let fee_estimator = Arc::new(test_utils::TestFeeEstimator { sat_per_kw: 253 });
+			let chain_source = Arc::new(test_utils::TestChainSource::new(Network::Testnet));
+			let logger = Arc::new(test_utils::TestLogger::with_id(format!("node {}", i)));
+			let persister = Arc::new(FilesystemPersister::new(format!("{}_persister_{}", persist_dir, i)));
+			let seed = [i as u8; 32];
+			let network = Network::Testnet;
+			let now = Duration::from_secs(genesis_block(network).header.time as u64);
+			let keys_manager = Arc::new(KeysManager::new(&seed, now.as_secs(), now.subsec_nanos()));
+			let chain_monitor = Arc::new(chainmonitor::ChainMonitor::new(Some(chain_source.clone()), tx_broadcaster.clone(), logger.clone(), fee_estimator.clone(), persister.clone()));
+			let manager = Arc::new(ChannelManager::new(Network::Testnet, fee_estimator.clone(), chain_monitor.clone(), tx_broadcaster, logger.clone(), keys_manager.clone(), UserConfig::default(), i));
+			let node = Node { node: manager, persister, logger };
+			nodes.push(node);
+		}
+		nodes
+	}
+
+	macro_rules! open_channel {
+		($node_a: expr, $node_b: expr, $channel_value: expr) => {{
+			$node_a.node.create_channel($node_b.node.get_our_node_id(), $channel_value, 100, 42, None).unwrap();
+			$node_b.node.handle_open_channel(&$node_a.node.get_our_node_id(), InitFeatures::known(), &get_event_msg!($node_a, MessageSendEvent::SendOpenChannel, $node_b.node.get_our_node_id()));
+			$node_a.node.handle_accept_channel(&$node_b.node.get_our_node_id(), InitFeatures::known(), &get_event_msg!($node_b, MessageSendEvent::SendAcceptChannel, $node_a.node.get_our_node_id()));
+			let events = $node_a.node.get_and_clear_pending_events();
+			assert_eq!(events.len(), 1);
+			let (temporary_channel_id, tx, funding_output) = match events[0] {
+				Event::FundingGenerationReady { ref temporary_channel_id, ref channel_value_satoshis, ref output_script, user_channel_id } => {
+					assert_eq!(*channel_value_satoshis, $channel_value);
+					assert_eq!(user_channel_id, 42);
+
+					let tx = Transaction { version: 1 as i32, lock_time: 0, input: Vec::new(), output: vec![TxOut {
+						value: *channel_value_satoshis, script_pubkey: output_script.clone(),
+					}]};
+					let funding_outpoint = OutPoint { txid: tx.txid(), index: 0 };
+					(*temporary_channel_id, tx, funding_outpoint)
+				},
+				_ => panic!("Unexpected event"),
+			};
+
+			$node_a.node.funding_transaction_generated(&temporary_channel_id, funding_output);
+			$node_b.node.handle_funding_created(&$node_a.node.get_our_node_id(), &get_event_msg!($node_a, MessageSendEvent::SendFundingCreated, $node_b.node.get_our_node_id()));
+			$node_a.node.handle_funding_signed(&$node_b.node.get_our_node_id(), &get_event_msg!($node_b, MessageSendEvent::SendFundingSigned, $node_a.node.get_our_node_id()));
+			tx
+		}}
+	}
+
+	#[test]
+	fn test_background_processor() {
+		// Test that when a new channel is created, the ChannelManager needs to be re-persisted with
+		// updates. Also test that when new updates are available, the manager signals that it needs
+		// re-persistence and is successfully re-persisted.
+		let nodes = create_nodes(2, "test_background_processor".to_string());
+
+		// Initiate the background processors to watch each node.
+		let data_dir = nodes[0].persister.get_data_dir();
+		let callback = move |node: &ChannelManager<InMemoryChannelKeys, Arc<ChainMonitor>, Arc<test_utils::TestBroadcaster>, Arc<KeysManager>, Arc<test_utils::TestFeeEstimator>, Arc<test_utils::TestLogger>>| FilesystemPersister::persist_manager(data_dir.clone(), node);
+		let bg_processor = BackgroundProcessor::start(callback, nodes[0].node.clone(), nodes[0].logger.clone());
+
+		// Go through the channel creation process until each node should have something persisted.
+		let tx = open_channel!(nodes[0], nodes[1], 100000);
+
+		macro_rules! check_persisted_data {
+			($node: expr, $filepath: expr, $expected_bytes: expr) => {
+				match $node.write(&mut $expected_bytes) {
+					Ok(()) => {
+						loop {
+							match std::fs::read($filepath) {
+								Ok(bytes) => {
+									if bytes == $expected_bytes {
+										break
+									} else {
+										continue
+									}
+								},
+								Err(_) => continue
+							}
+						}
+					},
+					Err(e) => panic!("Unexpected error: {}", e)
+				}
+			}
+		}
+
+		// Check that the initial channel manager data is persisted as expected.
+		let filepath = get_full_filepath("test_background_processor_persister_0".to_string(), "manager".to_string());
+		let mut expected_bytes = Vec::new();
+		check_persisted_data!(nodes[0].node, filepath.clone(), expected_bytes);
+		loop {
+			if !nodes[0].node.get_persistence_condvar_value() { break }
+		}
+
+		// Force-close the channel.
+		nodes[0].node.force_close_channel(&OutPoint { txid: tx.txid(), index: 0 }.to_channel_id()).unwrap();
+
+		// Check that the force-close updates are persisted.
+		let mut expected_bytes = Vec::new();
+		check_persisted_data!(nodes[0].node, filepath.clone(), expected_bytes);
+		loop {
+			if !nodes[0].node.get_persistence_condvar_value() { break }
+		}
+
+		assert!(bg_processor.stop().is_ok());
+	}
+
+	#[test]
+	fn test_chan_freshness_called() {
+		// Test that ChannelManager's `timer_chan_freshness_every_min` is called every
+		// `CHAN_FRESHNESS_TIMER`.
+		let nodes = create_nodes(1, "test_chan_freshness_called".to_string());
+		let data_dir = nodes[0].persister.get_data_dir();
+		let callback = move |node: &ChannelManager<InMemoryChannelKeys, Arc<ChainMonitor>, Arc<test_utils::TestBroadcaster>, Arc<KeysManager>, Arc<test_utils::TestFeeEstimator>, Arc<test_utils::TestLogger>>| FilesystemPersister::persist_manager(data_dir.clone(), node);
+		let bg_processor = BackgroundProcessor::start(callback, nodes[0].node.clone(), nodes[0].logger.clone());
+		loop {
+			let log_entries = nodes[0].logger.lines.lock().unwrap();
+			let desired_log = "Calling manager's timer_chan_freshness_every_min".to_string();
+			if log_entries.get(&("background_processor".to_string(), desired_log)).is_some() {
+				break
+			}
+		}
+
+		assert!(bg_processor.stop().is_ok());
+	}
+
+	#[test]
+	fn test_persist_error() {
+		// Test that if we encounter an error during manager persistence, the thread panics.
+		fn persist_manager<ChanSigner, M, T, K, F, L>(_data: &ChannelManager<ChanSigner, Arc<M>, Arc<T>, Arc<K>, Arc<F>, Arc<L>>) -> Result<(), std::io::Error>
+		where ChanSigner: 'static + ChannelKeys + Writeable,
+		      M: 'static + chain::Watch<Keys=ChanSigner>,
+		      T: 'static + BroadcasterInterface,
+		      K: 'static + KeysInterface<ChanKeySigner=ChanSigner>,
+		      F: 'static + FeeEstimator,
+		      L: 'static + Logger,
+		{
+			Err(std::io::Error::new(std::io::ErrorKind::Other, "test"))
+		}
+
+		let nodes = create_nodes(2, "test_persist_error".to_string());
+		let bg_processor = BackgroundProcessor::start(persist_manager, nodes[0].node.clone(), nodes[0].logger.clone());
+		open_channel!(nodes[0], nodes[1], 100000);
+
+		let _ = bg_processor.thread_handle.join().unwrap().expect_err("Errored persisting manager: test");
+	}
+}

--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -12,6 +12,9 @@ bitcoin = "0.24"
 lightning = { version = "0.0.12", path = "../lightning" }
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winbase"] }
+
 [dev-dependencies.bitcoin]
 version = "0.24"
 features = ["bitcoinconsensus"]

--- a/lightning-persister/src/lib.rs
+++ b/lightning-persister/src/lib.rs
@@ -1,8 +1,11 @@
+mod util;
+
 extern crate lightning;
 extern crate bitcoin;
 extern crate libc;
 
 use bitcoin::hashes::hex::ToHex;
+use crate::util::DiskWriteable;
 use lightning::chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateErr};
 use lightning::chain::channelmonitor;
 use lightning::chain::keysinterface::ChannelKeys;
@@ -10,7 +13,6 @@ use lightning::chain::transaction::OutPoint;
 use lightning::util::ser::Writeable;
 use std::fs;
 use std::io::Error;
-use std::path::{Path, PathBuf};
 
 #[cfg(test)]
 use {
@@ -21,9 +23,6 @@ use {
 	std::collections::HashMap,
 	std::io::Cursor
 };
-
-#[cfg(not(target_os = "windows"))]
-use std::os::unix::io::AsRawFd;
 
 /// FilesystemPersister persists channel data on disk, where each channel's
 /// data is stored in a file named after its funding outpoint.
@@ -41,13 +40,9 @@ pub struct FilesystemPersister {
 	path_to_channel_data: String,
 }
 
-trait DiskWriteable {
-	fn write(&self, writer: &mut fs::File) -> Result<(), Error>;
-}
-
 impl<ChanSigner: ChannelKeys> DiskWriteable for ChannelMonitor<ChanSigner> {
-	fn write(&self, writer: &mut fs::File) -> Result<(), Error> {
-		Writeable::write(self, writer)
+	fn write_to_file(&self, writer: &mut fs::File) -> Result<(), Error> {
+		self.write(writer)
 	}
 }
 
@@ -58,41 +53,6 @@ impl FilesystemPersister {
 		return Self {
 			path_to_channel_data,
 		}
-	}
-
-	fn get_full_filepath(&self, funding_txo: OutPoint) -> String {
-		let mut path = PathBuf::from(&self.path_to_channel_data);
-		path.push(format!("{}_{}", funding_txo.txid.to_hex(), funding_txo.index));
-		path.to_str().unwrap().to_string()
-	}
-
-	// Utility to write a file to disk.
-	fn write_channel_data(&self, funding_txo: OutPoint, monitor: &dyn DiskWriteable) -> std::io::Result<()> {
-		fs::create_dir_all(&self.path_to_channel_data)?;
-		// Do a crazy dance with lots of fsync()s to be overly cautious here...
-		// We never want to end up in a state where we've lost the old data, or end up using the
-		// old data on power loss after we've returned.
-		// The way to atomically write a file on Unix platforms is:
-		// open(tmpname), write(tmpfile), fsync(tmpfile), close(tmpfile), rename(), fsync(dir)
-		let filename = self.get_full_filepath(funding_txo);
-		let tmp_filename = format!("{}.tmp", filename.clone());
-
-		{
-			// Note that going by rust-lang/rust@d602a6b, on MacOS it is only safe to use
-			// rust stdlib 1.36 or higher.
-			let mut f = fs::File::create(&tmp_filename)?;
-			monitor.write(&mut f)?;
-			f.sync_all()?;
-		}
-		fs::rename(&tmp_filename, &filename)?;
-		// Fsync the parent directory on Unix.
-		#[cfg(not(target_os = "windows"))]
-		{
-			let path = Path::new(&filename).parent().unwrap();
-			let dir_file = fs::OpenOptions::new().read(true).open(path)?;
-			unsafe { libc::fsync(dir_file.as_raw_fd()); }
-		}
-		Ok(())
 	}
 
 	#[cfg(test)]
@@ -132,25 +92,15 @@ impl FilesystemPersister {
 
 impl<ChanSigner: ChannelKeys + Send + Sync> channelmonitor::Persist<ChanSigner> for FilesystemPersister {
 	fn persist_new_channel(&self, funding_txo: OutPoint, monitor: &ChannelMonitor<ChanSigner>) -> Result<(), ChannelMonitorUpdateErr> {
-		self.write_channel_data(funding_txo, monitor)
+		let filename = format!("{}_{}", funding_txo.txid.to_hex(), funding_txo.index);
+		util::write_to_file(self.path_to_channel_data.clone(), filename, monitor)
 		  .map_err(|_| ChannelMonitorUpdateErr::PermanentFailure)
 	}
 
 	fn update_persisted_channel(&self, funding_txo: OutPoint, _update: &ChannelMonitorUpdate, monitor: &ChannelMonitor<ChanSigner>) -> Result<(), ChannelMonitorUpdateErr> {
-		self.write_channel_data(funding_txo, monitor)
+		let filename = format!("{}_{}", funding_txo.txid.to_hex(), funding_txo.index);
+		util::write_to_file(self.path_to_channel_data.clone(), filename, monitor)
 		  .map_err(|_| ChannelMonitorUpdateErr::PermanentFailure)
-	}
-}
-
-#[cfg(test)]
-impl Drop for FilesystemPersister {
-	fn drop(&mut self) {
-		// We test for invalid directory names, so it's OK if directory removal
-		// fails.
-		match fs::remove_dir_all(&self.path_to_channel_data) {
-			Err(e) => println!("Failed to remove test persister directory: {}", e),
-			_ => {}
-		}
 	}
 }
 
@@ -162,8 +112,6 @@ mod tests {
 	use bitcoin::blockdata::block::{Block, BlockHeader};
 	use bitcoin::hashes::hex::FromHex;
 	use bitcoin::Txid;
-	use DiskWriteable;
-	use Error;
 	use lightning::chain::channelmonitor::{Persist, ChannelMonitorUpdateErr};
 	use lightning::chain::transaction::OutPoint;
 	use lightning::{check_closed_broadcast, check_added_monitors};
@@ -171,20 +119,22 @@ mod tests {
 	use lightning::ln::functional_test_utils::*;
 	use lightning::ln::msgs::ErrorAction;
 	use lightning::util::events::{MessageSendEventsProvider, MessageSendEvent};
-	use lightning::util::ser::Writer;
 	use lightning::util::test_utils;
 	use std::fs;
-	use std::io;
 	#[cfg(target_os = "windows")]
 	use {
 		lightning::get_event_msg,
 		lightning::ln::msgs::ChannelMessageHandler,
 	};
 
-	struct TestWriteable{}
-	impl DiskWriteable for TestWriteable {
-		fn write(&self, writer: &mut fs::File) -> Result<(), Error> {
-			writer.write_all(&[42; 1])
+	impl Drop for FilesystemPersister {
+		fn drop(&mut self) {
+			// We test for invalid directory names, so it's OK if directory removal
+			// fails.
+			match fs::remove_dir_all(&self.path_to_channel_data) {
+				Err(e) => println!("Failed to remove test persister directory: {}", e),
+				_ => {}
+			}
 		}
 	}
 
@@ -254,88 +204,6 @@ mod tests {
 
 		// Make sure everything is persisted as expected after close.
 		check_persisted_data!(11);
-	}
-
-	// Test that if the persister's path to channel data is read-only, writing
-	// data to it fails. Windows ignores the read-only flag for folders, so this
-	// test is Unix-only.
-	#[cfg(not(target_os = "windows"))]
-	#[test]
-	fn test_readonly_dir() {
-		let persister = FilesystemPersister::new("test_readonly_dir_persister".to_string());
-		let test_writeable = TestWriteable{};
-		let test_txo = OutPoint {
-			txid: Txid::from_hex("8984484a580b825b9972d7adb15050b3ab624ccd731946b3eeddb92f4e7ef6be").unwrap(),
-			index: 0
-		};
-		// Create the persister's directory and set it to read-only.
-		let path = &persister.path_to_channel_data;
-		fs::create_dir_all(path).unwrap();
-		let mut perms = fs::metadata(path).unwrap().permissions();
-		perms.set_readonly(true);
-		fs::set_permissions(path, perms).unwrap();
-		match persister.write_channel_data(test_txo, &test_writeable) {
-			Err(e) => assert_eq!(e.kind(), io::ErrorKind::PermissionDenied),
-			_ => panic!("Unexpected error message")
-		}
-	}
-
-	// Test failure to rename in the process of atomically creating a channel
-	// monitor's file. We induce this failure by making the `tmp` file a
-	// directory.
-	// Explanation: given "from" = the file being renamed, "to" = the
-	// renamee that already exists: Windows should fail because it'll fail
-	// whenever "to" is a directory, and Unix should fail because if "from" is a
-	// file, then "to" is also required to be a file.
-	#[test]
-	fn test_rename_failure() {
-		let persister = FilesystemPersister::new("test_rename_failure".to_string());
-		let test_writeable = TestWriteable{};
-		let txid_hex = "8984484a580b825b9972d7adb15050b3ab624ccd731946b3eeddb92f4e7ef6be";
-		let outp_idx = 0;
-		let test_txo = OutPoint {
-			txid: Txid::from_hex(txid_hex).unwrap(),
-			index: outp_idx,
-		};
-		// Create the channel data file and make it a directory.
-		let path = &persister.path_to_channel_data;
-		fs::create_dir_all(format!("{}/{}_{}", path, txid_hex, outp_idx)).unwrap();
-		match persister.write_channel_data(test_txo, &test_writeable) {
-			Err(e) => {
-				#[cfg(not(target_os = "windows"))]
-				assert_eq!(e.kind(), io::ErrorKind::Other);
-				#[cfg(target_os = "windows")]
-				assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
-			}
-			_ => panic!("Unexpected error message")
-		}
-	}
-
-	// Test failure to create the temporary file in the persistence process.
-	// We induce this failure by having the temp file already exist and be a
-	// directory.
-	#[test]
-	fn test_tmp_file_creation_failure() {
-		let persister = FilesystemPersister::new("test_tmp_file_creation_failure".to_string());
-		let test_writeable = TestWriteable{};
-		let txid_hex = "8984484a580b825b9972d7adb15050b3ab624ccd731946b3eeddb92f4e7ef6be";
-		let outp_idx = 0;
-		let test_txo = OutPoint {
-			txid: Txid::from_hex(txid_hex).unwrap(),
-			index: outp_idx,
-		};
-		// Create the tmp file and make it a directory.
-		let path = &persister.path_to_channel_data;
-		fs::create_dir_all(format!("{}/{}_{}.tmp", path, txid_hex, outp_idx)).unwrap();
-		match persister.write_channel_data(test_txo, &test_writeable) {
-			Err(e) => {
-				#[cfg(not(target_os = "windows"))]
-				assert_eq!(e.kind(), io::ErrorKind::Other);
-				#[cfg(target_os = "windows")]
-				assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
-			}
-			_ => panic!("Unexpected error message")
-		}
 	}
 
 	// Test that if the persister's path to channel data is read-only, writing a

--- a/lightning-persister/src/util.rs
+++ b/lightning-persister/src/util.rs
@@ -1,0 +1,149 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[cfg(not(target_os = "windows"))]
+use std::os::unix::io::AsRawFd;
+
+pub(crate) trait DiskWriteable {
+	fn write_to_file(&self, writer: &mut fs::File) -> Result<(), std::io::Error>;
+}
+
+pub fn get_full_filepath(filepath: String, filename: String) -> String {
+	let mut path = PathBuf::from(filepath);
+	path.push(filename);
+	path.to_str().unwrap().to_string()
+}
+
+#[allow(bare_trait_objects)]
+pub(crate) fn write_to_file<D: DiskWriteable>(path: String, filename: String, data: &D) -> std::io::Result<()> {
+	fs::create_dir_all(path.clone())?;
+	// Do a crazy dance with lots of fsync()s to be overly cautious here...
+	// We never want to end up in a state where we've lost the old data, or end up using the
+	// old data on power loss after we've returned.
+	// The way to atomically write a file on Unix platforms is:
+	// open(tmpname), write(tmpfile), fsync(tmpfile), close(tmpfile), rename(), fsync(dir)
+	let filename_with_path = get_full_filepath(path, filename);
+	let tmp_filename = format!("{}.tmp", filename_with_path);
+
+	{
+		// Note that going by rust-lang/rust@d602a6b, on MacOS it is only safe to use
+		// rust stdlib 1.36 or higher.
+		let mut f = fs::File::create(&tmp_filename)?;
+		data.write_to_file(&mut f)?;
+		f.sync_all()?;
+	}
+	fs::rename(&tmp_filename, &filename_with_path)?;
+	// Fsync the parent directory on Unix.
+	#[cfg(not(target_os = "windows"))]
+	{
+		let path = Path::new(&filename_with_path).parent().unwrap();
+		let dir_file = fs::OpenOptions::new().read(true).open(path)?;
+		unsafe { libc::fsync(dir_file.as_raw_fd()); }
+	}
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{DiskWriteable, get_full_filepath, write_to_file};
+	use std::fs;
+	use std::io;
+	use std::io::Write;
+
+	struct TestWriteable{}
+	impl DiskWriteable for TestWriteable {
+		fn write_to_file(&self, writer: &mut fs::File) -> Result<(), io::Error> {
+			writer.write_all(&[42; 1])
+		}
+	}
+
+	// Test that if the persister's path to channel data is read-only, writing
+	// data to it fails. Windows ignores the read-only flag for folders, so this
+	// test is Unix-only.
+	#[cfg(not(target_os = "windows"))]
+	#[test]
+	fn test_readonly_dir() {
+		let test_writeable = TestWriteable{};
+		let filename = "test_readonly_dir_persister_filename".to_string();
+		let path = "test_readonly_dir_persister_dir";
+		fs::create_dir_all(path.to_string()).unwrap();
+		let mut perms = fs::metadata(path.to_string()).unwrap().permissions();
+		perms.set_readonly(true);
+		fs::set_permissions(path.to_string(), perms).unwrap();
+		match write_to_file(path.to_string(), filename, &test_writeable) {
+			Err(e) => assert_eq!(e.kind(), io::ErrorKind::PermissionDenied),
+			_ => panic!("Unexpected error message")
+		}
+	}
+
+	// Test failure to rename in the process of atomically creating a channel
+	// monitor's file. We induce this failure by making the `tmp` file a
+	// directory.
+	// Explanation: given "from" = the file being renamed, "to" = the
+	// renamee that already exists: Windows should fail because it'll fail
+	// whenever "to" is a directory, and Unix should fail because if "from" is a
+	// file, then "to" is also required to be a file.
+	#[test]
+	fn test_rename_failure() {
+		let test_writeable = TestWriteable{};
+		let filename = "test_rename_failure_filename";
+		let path = "test_rename_failure_dir";
+		// Create the channel data file and make it a directory.
+		fs::create_dir_all(get_full_filepath(path.to_string(), filename.to_string())).unwrap();
+		match write_to_file(path.to_string(), filename.to_string(), &test_writeable) {
+			Err(e) => {
+				#[cfg(not(target_os = "windows"))]
+				assert_eq!(e.kind(), io::ErrorKind::Other);
+				#[cfg(target_os = "windows")]
+				assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
+			}
+			_ => panic!("Unexpected error message")
+		}
+		fs::remove_dir_all(path).unwrap();
+	}
+
+	#[test]
+	fn test_diskwriteable_failure() {
+		struct FailingWriteable {}
+		impl DiskWriteable for FailingWriteable {
+			fn write_to_file(&self, _writer: &mut fs::File) -> Result<(), std::io::Error> {
+				Err(std::io::Error::new(std::io::ErrorKind::Other, "expected failure"))
+			}
+		}
+
+		let filename = "test_diskwriteable_failure";
+		let path = "test_diskwriteable_failure_dir";
+		let test_writeable = FailingWriteable{};
+		match write_to_file(path.to_string(), filename.to_string(), &test_writeable) {
+			Err(e) => {
+				assert_eq!(e.kind(), std::io::ErrorKind::Other);
+				assert_eq!(e.get_ref().unwrap().to_string(), "expected failure");
+			},
+			_ => panic!("unexpected result")
+		}
+		fs::remove_dir_all(path).unwrap();
+	}
+
+	// Test failure to create the temporary file in the persistence process.
+	// We induce this failure by having the temp file already exist and be a
+	// directory.
+	#[test]
+	fn test_tmp_file_creation_failure() {
+		let test_writeable = TestWriteable{};
+		let filename = "test_tmp_file_creation_failure_filename".to_string();
+		let path = "test_tmp_file_creation_failure_dir".to_string();
+
+		// Create the tmp file and make it a directory.
+		let tmp_path = get_full_filepath(path.clone(), format!("{}.tmp", filename.clone()));
+		fs::create_dir_all(tmp_path).unwrap();
+		match write_to_file(path, filename, &test_writeable) {
+			Err(e) => {
+				#[cfg(not(target_os = "windows"))]
+				assert_eq!(e.kind(), io::ErrorKind::Other);
+				#[cfg(target_os = "windows")]
+				assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
+			}
+			_ => panic!("Unexpected error message")
+		}
+	}
+}

--- a/lightning-persister/src/util.rs
+++ b/lightning-persister/src/util.rs
@@ -17,7 +17,7 @@ pub(crate) trait DiskWriteable {
 	fn write_to_file(&self, writer: &mut fs::File) -> Result<(), std::io::Error>;
 }
 
-pub fn get_full_filepath(filepath: String, filename: String) -> String {
+pub(crate) fn get_full_filepath(filepath: String, filename: String) -> String {
 	let mut path = PathBuf::from(filepath);
 	path.push(filename);
 	path.to_str().unwrap().to_string()

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -11,6 +11,7 @@ Still missing tons of error-handling. See GitHub issues for suggested projects i
 """
 
 [features]
+allow_wallclock_use = []
 fuzztarget = ["bitcoin/fuzztarget", "regex"]
 # Internal test utilities exposed to other repo crates
 _test_utils = ["hex", "regex"]
@@ -38,3 +39,6 @@ features = ["bitcoinconsensus"]
 [dev-dependencies]
 hex = "0.3"
 regex = "0.1.80"
+
+[package.metadata.docs.rs]
+features = ["allow_wallclock_use"] # When https://github.com/rust-lang/rust/issues/43781 complies with our MSVR, we can add nice banners in the docs for the methods behind this feature-gate.

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -155,12 +155,17 @@ macro_rules! log_spendable {
 	}
 }
 
+/// Create a new Record and log it. You probably don't want to use this macro directly,
+/// but it needs to be exported so `log_trace` etc can use it in external crates.
+#[macro_export]
 macro_rules! log_internal {
 	($logger: expr, $lvl:expr, $($arg:tt)+) => (
-		$logger.log(&::util::logger::Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()));
+		$logger.log(&$crate::util::logger::Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()));
 	);
 }
 
+/// Log an error.
+#[macro_export]
 macro_rules! log_error {
 	($logger: expr, $($arg:tt)*) => (
 		#[cfg(not(any(feature = "max_level_off")))]
@@ -189,6 +194,8 @@ macro_rules! log_debug {
 	)
 }
 
+/// Log a trace log.
+#[macro_export]
 macro_rules! log_trace {
 	($logger: expr, $($arg:tt)*) => (
 		#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug")))]

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -25,8 +25,10 @@ pub(crate) mod transaction_utils;
 
 #[macro_use]
 pub(crate) mod ser_macros;
+
+/// Logging macro utilities.
 #[macro_use]
-pub(crate) mod macro_logger;
+pub mod macro_logger;
 
 // These have to come after macro_logger to build
 pub mod logger;


### PR DESCRIPTION
Closes #743. 

Current todos:

- [x] abstract out utilities for writing to disk/forming platform-agnostic filepaths, etc
- [x] rename `FilesystemPersister` to `MonitorPersister`? Or somehow align the names of the two persisters
- [x] make the manager persister test Windows-friendly
- [x] add more unit tests, currently there's just one integration test
- [x] make sure the `ChannelManager` signals for a new update whenever it needs to, and doesn't signal when it doesn't need to