### PR TITLE
Clean up and more liberally free holding cell HTLCs

### DIFF
--- a/fuzz/src/bin/chanmon_consistency_target.rs
+++ b/fuzz/src/bin/chanmon_consistency_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/chanmon_deser_target.rs
+++ b/fuzz/src/bin/chanmon_deser_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/full_stack_target.rs
+++ b/fuzz/src/bin/full_stack_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_accept_channel_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_announcement_signatures_target.rs
+++ b/fuzz/src/bin/msg_announcement_signatures_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_channel_announcement_target.rs
+++ b/fuzz/src/bin/msg_channel_announcement_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_channel_reestablish_target.rs
+++ b/fuzz/src/bin/msg_channel_reestablish_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_channel_update_target.rs
+++ b/fuzz/src/bin/msg_channel_update_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_closing_signed_target.rs
+++ b/fuzz/src/bin/msg_closing_signed_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_commitment_signed_target.rs
+++ b/fuzz/src/bin/msg_commitment_signed_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
+++ b/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_error_message_target.rs
+++ b/fuzz/src/bin/msg_error_message_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_funding_created_target.rs
+++ b/fuzz/src/bin/msg_funding_created_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_funding_locked_target.rs
+++ b/fuzz/src/bin/msg_funding_locked_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_funding_signed_target.rs
+++ b/fuzz/src/bin/msg_funding_signed_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
+++ b/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_init_target.rs
+++ b/fuzz/src/bin/msg_init_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_node_announcement_target.rs
+++ b/fuzz/src/bin/msg_node_announcement_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_onion_hop_data_target.rs
+++ b/fuzz/src/bin/msg_onion_hop_data_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_open_channel_target.rs
+++ b/fuzz/src/bin/msg_open_channel_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_ping_target.rs
+++ b/fuzz/src/bin/msg_ping_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_pong_target.rs
+++ b/fuzz/src/bin/msg_pong_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_query_channel_range_target.rs
+++ b/fuzz/src/bin/msg_query_channel_range_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_query_short_channel_ids_target.rs
+++ b/fuzz/src/bin/msg_query_short_channel_ids_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_reply_channel_range_target.rs
+++ b/fuzz/src/bin/msg_reply_channel_range_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
+++ b/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_revoke_and_ack_target.rs
+++ b/fuzz/src/bin/msg_revoke_and_ack_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_shutdown_target.rs
+++ b/fuzz/src/bin/msg_shutdown_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_add_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_add_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fail_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fee_target.rs
+++ b/fuzz/src/bin/msg_update_fee_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/peer_crypt_target.rs
+++ b/fuzz/src/bin/peer_crypt_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/router_target.rs
+++ b/fuzz/src/bin/router_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/target_template.txt
+++ b/fuzz/src/bin/target_template.txt
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -624,6 +624,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 						events::MessageSendEvent::SendFundingLocked { .. } => {
 							// Can be generated as a reestablish response
 						},
+						events::MessageSendEvent::SendAnnouncementSignatures { .. } => {
+							// Can be generated as a reestablish response
+						},
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {
 							// Can be generated due to a payment forward being rejected due to a
 							// channel having previously failed a monitor update
@@ -644,6 +647,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendRevokeAndACK { .. } => {},
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
+							events::MessageSendEvent::SendAnnouncementSignatures { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
@@ -656,6 +660,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendRevokeAndACK { .. } => {},
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
+							events::MessageSendEvent::SendAnnouncementSignatures { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
@@ -677,6 +682,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							if *node_id != drop_node_id { true } else { false }
 						},
 						events::MessageSendEvent::SendFundingLocked { .. } => false,
+						events::MessageSendEvent::SendAnnouncementSignatures { .. } => false,
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => false,
 						_ => panic!("Unhandled message event"),
 					};

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -748,23 +748,27 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 			0x06 => *monitor_c.update_ret.lock().unwrap() = Ok(()),
 
 			0x08 => {
-				if let Some((id, _)) = monitor_a.latest_monitors.lock().unwrap().get(&chan_1_funding) {
-					nodes[0].channel_monitor_updated(&chan_1_funding, *id);
+				let mon_id = monitor_a.latest_monitors.lock().unwrap().get(&chan_1_funding).map(|(id, _)| *id);
+				if let Some(id) = mon_id {
+					nodes[0].channel_monitor_updated(&chan_1_funding, id);
 				}
 			},
 			0x09 => {
-				if let Some((id, _)) = monitor_b.latest_monitors.lock().unwrap().get(&chan_1_funding) {
-					nodes[1].channel_monitor_updated(&chan_1_funding, *id);
+				let mon_id = monitor_b.latest_monitors.lock().unwrap().get(&chan_1_funding).map(|(id, _)| *id);
+				if let Some(id) = mon_id {
+					nodes[1].channel_monitor_updated(&chan_1_funding, id);
 				}
 			},
 			0x0a => {
-				if let Some((id, _)) = monitor_b.latest_monitors.lock().unwrap().get(&chan_2_funding) {
-					nodes[1].channel_monitor_updated(&chan_2_funding, *id);
+				let mon_id = monitor_b.latest_monitors.lock().unwrap().get(&chan_2_funding).map(|(id, _)| *id);
+				if let Some(id) = mon_id {
+					nodes[1].channel_monitor_updated(&chan_2_funding, id);
 				}
 			},
 			0x0b => {
-				if let Some((id, _)) = monitor_c.latest_monitors.lock().unwrap().get(&chan_2_funding) {
-					nodes[2].channel_monitor_updated(&chan_2_funding, *id);
+				let mon_id = monitor_c.latest_monitors.lock().unwrap().get(&chan_2_funding).map(|(id, _)| *id);
+				if let Some(id) = mon_id {
+					nodes[2].channel_monitor_updated(&chan_2_funding, id);
 				}
 			},
 
@@ -919,17 +923,29 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 				*monitor_b.update_ret.lock().unwrap() = Ok(());
 				*monitor_c.update_ret.lock().unwrap() = Ok(());
 
-				if let Some((id, _)) = monitor_a.latest_monitors.lock().unwrap().get(&chan_1_funding) {
-					nodes[0].channel_monitor_updated(&chan_1_funding, *id);
+				{
+					let mon_id = monitor_a.latest_monitors.lock().unwrap().get(&chan_1_funding).map(|(id, _)| *id);
+					if let Some(id) = mon_id {
+						nodes[0].channel_monitor_updated(&chan_1_funding, id);
+					}
 				}
-				if let Some((id, _)) = monitor_b.latest_monitors.lock().unwrap().get(&chan_1_funding) {
-					nodes[1].channel_monitor_updated(&chan_1_funding, *id);
+				{
+					let mon_id = monitor_b.latest_monitors.lock().unwrap().get(&chan_1_funding).map(|(id, _)| *id);
+					if let Some(id) = mon_id {
+						nodes[1].channel_monitor_updated(&chan_1_funding, id);
+					}
 				}
-				if let Some((id, _)) = monitor_b.latest_monitors.lock().unwrap().get(&chan_2_funding) {
-					nodes[1].channel_monitor_updated(&chan_2_funding, *id);
+				{
+					let mon_id = monitor_b.latest_monitors.lock().unwrap().get(&chan_2_funding).map(|(id, _)| *id);
+					if let Some(id) = mon_id {
+						nodes[1].channel_monitor_updated(&chan_2_funding, id);
+					}
 				}
-				if let Some((id, _)) = monitor_c.latest_monitors.lock().unwrap().get(&chan_2_funding) {
-					nodes[2].channel_monitor_updated(&chan_2_funding, *id);
+				{
+					let mon_id = monitor_c.latest_monitors.lock().unwrap().get(&chan_2_funding).map(|(id, _)| *id);
+					if let Some(id) = mon_id {
+						nodes[2].channel_monitor_updated(&chan_2_funding, id);
+					}
 				}
 
 				// Next, make sure peers are all connected to each other

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -29,8 +29,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hash_types::{BlockHash, WPubkeyHash};
 
 use lightning::chain;
-use lightning::chain::chainmonitor;
-use lightning::chain::channelmonitor;
+use lightning::chain::{chainmonitor, channelmonitor, Watch};
 use lightning::chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr, MonitorEvent};
 use lightning::chain::transaction::OutPoint;
 use lightning::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget, FeeEstimator};
@@ -45,7 +44,6 @@ use lightning::util::logger::Logger;
 use lightning::util::config::UserConfig;
 use lightning::util::events::{EventsProvider, MessageSendEventsProvider};
 use lightning::util::ser::{Readable, ReadableArgs, Writeable, Writer};
-use lightning::util::test_utils::OnlyReadsKeysInterface;
 use lightning::routing::router::{Route, RouteHop};
 
 
@@ -87,6 +85,7 @@ impl Writer for VecWriter {
 
 struct TestChainMonitor {
 	pub logger: Arc<dyn Logger>,
+	pub keys: Arc<KeyProvider>,
 	pub chain_monitor: Arc<chainmonitor::ChainMonitor<EnforcingSigner, Arc<dyn chain::Filter>, Arc<TestBroadcaster>, Arc<FuzzEstimator>, Arc<dyn Logger>, Arc<TestPersister>>>,
 	pub update_ret: Mutex<Result<(), channelmonitor::ChannelMonitorUpdateErr>>,
 	// If we reload a node with an old copy of ChannelMonitors, the ChannelManager deserialization
@@ -98,17 +97,18 @@ struct TestChainMonitor {
 	pub should_update_manager: atomic::AtomicBool,
 }
 impl TestChainMonitor {
-	pub fn new(broadcaster: Arc<TestBroadcaster>, logger: Arc<dyn Logger>, feeest: Arc<FuzzEstimator>, persister: Arc<TestPersister>) -> Self {
+	pub fn new(broadcaster: Arc<TestBroadcaster>, logger: Arc<dyn Logger>, feeest: Arc<FuzzEstimator>, persister: Arc<TestPersister>, keys: Arc<KeyProvider>) -> Self {
 		Self {
 			chain_monitor: Arc::new(chainmonitor::ChainMonitor::new(None, broadcaster, logger.clone(), feeest, persister)),
 			logger,
+			keys,
 			update_ret: Mutex::new(Ok(())),
 			latest_monitors: Mutex::new(HashMap::new()),
 			should_update_manager: atomic::AtomicBool::new(false),
 		}
 	}
 }
-impl chain::Watch<EnforcingSigner> for TestChainMonitor {
+impl Watch<EnforcingSigner> for TestChainMonitor {
 	fn watch_channel(&self, funding_txo: OutPoint, monitor: channelmonitor::ChannelMonitor<EnforcingSigner>) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
 		let mut ser = VecWriter(Vec::new());
 		monitor.write(&mut ser).unwrap();
@@ -127,12 +127,13 @@ impl chain::Watch<EnforcingSigner> for TestChainMonitor {
 			hash_map::Entry::Vacant(_) => panic!("Didn't have monitor on update call"),
 		};
 		let mut deserialized_monitor = <(BlockHash, channelmonitor::ChannelMonitor<EnforcingSigner>)>::
-			read(&mut Cursor::new(&map_entry.get().1), &OnlyReadsKeysInterface {}).unwrap().1;
+			read(&mut Cursor::new(&map_entry.get().1), &*self.keys).unwrap().1;
 		deserialized_monitor.update_monitor(&update, &&TestBroadcaster{}, &&FuzzEstimator{}, &self.logger).unwrap();
 		let mut ser = VecWriter(Vec::new());
 		deserialized_monitor.write(&mut ser).unwrap();
 		map_entry.insert((update.update_id, ser.0));
 		self.should_update_manager.store(true, atomic::Ordering::Relaxed);
+		assert!(self.chain_monitor.update_channel(funding_txo, update).is_ok());
 		self.update_ret.lock().unwrap().clone()
 	}
 
@@ -311,9 +312,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 	macro_rules! make_node {
 		($node_id: expr) => { {
 			let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new($node_id.to_string(), out.clone()));
-			let monitor = Arc::new(TestChainMonitor::new(broadcast.clone(), logger.clone(), fee_est.clone(), Arc::new(TestPersister{})));
-
 			let keys_manager = Arc::new(KeyProvider { node_id: $node_id, rand_bytes_id: atomic::AtomicU8::new(0), revoked_commitments: Mutex::new(HashMap::new()) });
+			let monitor = Arc::new(TestChainMonitor::new(broadcast.clone(), logger.clone(), fee_est.clone(), Arc::new(TestPersister{}), Arc::clone(&keys_manager)));
+
 			let mut config = UserConfig::default();
 			config.channel_options.fee_proportional_millionths = 0;
 			config.channel_options.announced_channel = true;
@@ -327,7 +328,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 		($ser: expr, $node_id: expr, $old_monitors: expr, $keys_manager: expr) => { {
 		    let keys_manager = Arc::clone(& $keys_manager);
 			let logger: Arc<dyn Logger> = Arc::new(test_logger::TestLogger::new($node_id.to_string(), out.clone()));
-			let chain_monitor = Arc::new(TestChainMonitor::new(broadcast.clone(), logger.clone(), fee_est.clone(), Arc::new(TestPersister{})));
+			let chain_monitor = Arc::new(TestChainMonitor::new(broadcast.clone(), logger.clone(), fee_est.clone(), Arc::new(TestPersister{}), Arc::clone(& $keys_manager)));
 
 			let mut config = UserConfig::default();
 			config.channel_options.fee_proportional_millionths = 0;
@@ -337,7 +338,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 			let mut monitors = HashMap::new();
 			let mut old_monitors = $old_monitors.latest_monitors.lock().unwrap();
 			for (outpoint, (update_id, monitor_ser)) in old_monitors.drain() {
-				monitors.insert(outpoint, <(BlockHash, ChannelMonitor<EnforcingSigner>)>::read(&mut Cursor::new(&monitor_ser), &OnlyReadsKeysInterface {}).expect("Failed to read monitor").1);
+				monitors.insert(outpoint, <(BlockHash, ChannelMonitor<EnforcingSigner>)>::read(&mut Cursor::new(&monitor_ser), &*$keys_manager).expect("Failed to read monitor").1);
 				chain_monitor.latest_monitors.lock().unwrap().insert(outpoint, (update_id, monitor_ser));
 			}
 			let mut monitor_refs = HashMap::new();
@@ -355,7 +356,11 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 				channel_monitors: monitor_refs,
 			};
 
-			(<(BlockHash, ChanMan)>::read(&mut Cursor::new(&$ser.0), read_args).expect("Failed to read manager").1, chain_monitor)
+			let res = (<(BlockHash, ChanMan)>::read(&mut Cursor::new(&$ser.0), read_args).expect("Failed to read manager").1, chain_monitor.clone());
+			for (funding_txo, mon) in monitors.drain() {
+				assert!(chain_monitor.chain_monitor.watch_channel(funding_txo, mon).is_ok());
+			}
+			res
 		} }
 	}
 

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -37,7 +37,7 @@ use lightning::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget,
 use lightning::chain::keysinterface::{KeysInterface, InMemorySigner};
 use lightning::ln::channelmanager::{ChannelManager, PaymentHash, PaymentPreimage, PaymentSecret, PaymentSendFailure, ChannelManagerReadArgs};
 use lightning::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
-use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, DecodeError, ErrorAction, UpdateAddHTLC, Init};
+use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, DecodeError, UpdateAddHTLC, Init};
 use lightning::util::enforcing_trait_impls::{EnforcingSigner, INITIAL_REVOKED_COMMITMENT_NUMBER};
 use lightning::util::errors::APIError;
 use lightning::util::events;
@@ -645,7 +645,6 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
-							events::MessageSendEvent::HandleError { action: ErrorAction::IgnoreError, .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
 					}
@@ -658,7 +657,6 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
-							events::MessageSendEvent::HandleError { action: ErrorAction::IgnoreError, .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
 					}
@@ -680,7 +678,6 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 						},
 						events::MessageSendEvent::SendFundingLocked { .. } => false,
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => false,
-						events::MessageSendEvent::HandleError { action: ErrorAction::IgnoreError, .. } => false,
 						_ => panic!("Unhandled message event"),
 					};
 					if push { msg_sink.push(event); }

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -18,11 +18,12 @@ use bitcoin::network::constants::Network;
 use chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr};
 use chain::transaction::OutPoint;
 use chain::Watch;
-use ln::channelmanager::{RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
+use ln::channelmanager::{ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
 use ln::features::InitFeatures;
 use ln::msgs;
 use ln::msgs::{ChannelMessageHandler, ErrorAction, RoutingMessageHandler};
 use routing::router::get_route;
+use util::config::UserConfig;
 use util::enforcing_trait_impls::EnforcingSigner;
 use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsProvider};
 use util::errors::APIError;
@@ -34,6 +35,8 @@ use bitcoin::hashes::Hash;
 use ln::functional_test_utils::*;
 
 use util::test_utils;
+
+use std::collections::HashMap;
 
 // If persister_fail is true, we have the persister return a PermanentFailure
 // instead of the higher-level ChainMonitor.
@@ -1971,4 +1974,200 @@ fn test_path_paused_mpp() {
 	pass_along_path(&nodes[0], &[&nodes[2], &nodes[3]], 200_000, payment_hash.clone(), Some(payment_secret), events.pop().unwrap(), true);
 
 	claim_payment_along_route_with_secret(&nodes[0], &[&[&nodes[1], &nodes[3]], &[&nodes[2], &nodes[3]]], false, payment_preimage, Some(payment_secret), 200_000);
+}
+
+fn do_channel_holding_cell_serialize(disconnect: bool, reload_a: bool) {
+	// Tests that, when we serialize a channel with AddHTLC entries in the holding cell, we
+	// properly free them on reconnect. We previously failed such HTLCs upon serialization, but
+	// that behavior was both somewhat unexpected and also broken (there was a debug assertion
+	// which failed in such a case).
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let persister: test_utils::TestPersister;
+	let new_chain_monitor: test_utils::TestChainMonitor;
+	let nodes_0_deserialized: ChannelManager<EnforcingSigner, &test_utils::TestChainMonitor, &test_utils::TestBroadcaster, &test_utils::TestKeysInterface, &test_utils::TestFeeEstimator, &test_utils::TestLogger>;
+	let mut nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let chan_id = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 15_000_000, 7_000_000_000, InitFeatures::known(), InitFeatures::known()).2;
+	let (payment_preimage_1, payment_hash_1) = get_payment_preimage_hash!(&nodes[0]);
+	let (payment_preimage_2, payment_hash_2) = get_payment_preimage_hash!(&nodes[0]);
+
+	// Do a really complicated dance to get an HTLC into the holding cell, with MonitorUpdateFailed
+	// set but AwaitingRemoteRevoke unset. When this test was written, any attempts to send an HTLC
+	// while MonitorUpdateFailed is set are immediately failed-backwards. Thus, the only way to get
+	// an AddHTLC into the holding cell is to add it while AwaitingRemoteRevoke is set but
+	// MonitorUpdateFailed is unset, and then swap the flags.
+	//
+	// We do this by:
+	//  a) routing a payment from node B to node A,
+	//  b) sending a payment from node A to node B without delivering any of the generated messages,
+	//     putting node A in AwaitingRemoteRevoke,
+	//  c) sending a second payment from node A to node B, which is immediately placed in the
+	//     holding cell,
+	//  d) claiming the first payment from B, allowing us to fail the monitor update which occurs
+	//     when we try to persist the payment preimage,
+	//  e) delivering A's commitment_signed from (b) and the resulting B revoke_and_ack message,
+	//     clearing AwaitingRemoteRevoke on node A.
+	//
+	// Note that because, at the end, MonitorUpdateFailed is still set, the HTLC generated in (c)
+	// will not be freed from the holding cell.
+	let (payment_preimage_0, payment_hash_0) = route_payment(&nodes[1], &[&nodes[0]], 100000);
+
+	let route = {
+		let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
+		get_route(&nodes[0].node.get_our_node_id(), &net_graph_msg_handler.network_graph.read().unwrap(), &nodes[1].node.get_our_node_id(), None, &Vec::new(), 100000, TEST_FINAL_CLTV, nodes[0].logger).unwrap()
+	};
+
+	nodes[0].node.send_payment(&route, payment_hash_1, &None).unwrap();
+	check_added_monitors!(nodes[0], 1);
+	let send = SendEvent::from_node(&nodes[0]);
+	assert_eq!(send.msgs.len(), 1);
+
+	nodes[0].node.send_payment(&route, payment_hash_2, &None).unwrap();
+	check_added_monitors!(nodes[0], 0);
+
+	*nodes[0].chain_monitor.update_ret.lock().unwrap() = Some(Err(ChannelMonitorUpdateErr::TemporaryFailure));
+	assert!(nodes[0].node.claim_funds(payment_preimage_0, &None, 100000));
+	check_added_monitors!(nodes[0], 1);
+
+	nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &send.msgs[0]);
+	nodes[1].node.handle_commitment_signed(&nodes[0].node.get_our_node_id(), &send.commitment_msg);
+	check_added_monitors!(nodes[1], 1);
+
+	let (raa, cs) = get_revoke_commit_msgs!(nodes[1], nodes[0].node.get_our_node_id());
+
+	nodes[0].node.handle_revoke_and_ack(&nodes[1].node.get_our_node_id(), &raa);
+	check_added_monitors!(nodes[0], 1);
+
+	if disconnect {
+		// Optionally reload nodes[0] entirely through a serialization roundtrip, otherwise just
+		// disconnect the peers. Note that the fuzzer originally found this issue because
+		// deserializing a ChannelManager in this state causes an assertion failure.
+		if reload_a {
+			let nodes_0_serialized = nodes[0].node.encode();
+			let mut chan_0_monitor_serialized = test_utils::TestVecWriter(Vec::new());
+			nodes[0].chain_monitor.chain_monitor.monitors.lock().unwrap().iter().next().unwrap().1.write(&mut chan_0_monitor_serialized).unwrap();
+
+			persister = test_utils::TestPersister::new();
+			let keys_manager = &chanmon_cfgs[0].keys_manager;
+			new_chain_monitor = test_utils::TestChainMonitor::new(Some(nodes[0].chain_source), nodes[0].tx_broadcaster.clone(), nodes[0].logger, node_cfgs[0].fee_estimator, &persister, keys_manager);
+			nodes[0].chain_monitor = &new_chain_monitor;
+			let mut chan_0_monitor_read = &chan_0_monitor_serialized.0[..];
+			let (_, mut chan_0_monitor) = <(BlockHash, ChannelMonitor<EnforcingSigner>)>::read(
+				&mut chan_0_monitor_read, keys_manager).unwrap();
+			assert!(chan_0_monitor_read.is_empty());
+
+			let mut nodes_0_read = &nodes_0_serialized[..];
+			let config = UserConfig::default();
+			nodes_0_deserialized = {
+				let mut channel_monitors = HashMap::new();
+				channel_monitors.insert(chan_0_monitor.get_funding_txo().0, &mut chan_0_monitor);
+				<(BlockHash, ChannelManager<EnforcingSigner, &test_utils::TestChainMonitor, &test_utils::TestBroadcaster, &test_utils::TestKeysInterface, &test_utils::TestFeeEstimator, &test_utils::TestLogger>)>::read(&mut nodes_0_read, ChannelManagerReadArgs {
+					default_config: config,
+					keys_manager,
+					fee_estimator: node_cfgs[0].fee_estimator,
+					chain_monitor: nodes[0].chain_monitor,
+					tx_broadcaster: nodes[0].tx_broadcaster.clone(),
+					logger: nodes[0].logger,
+					channel_monitors,
+				}).unwrap().1
+			};
+			nodes[0].node = &nodes_0_deserialized;
+			assert!(nodes_0_read.is_empty());
+
+			nodes[0].chain_monitor.watch_channel(chan_0_monitor.get_funding_txo().0.clone(), chan_0_monitor).unwrap();
+			check_added_monitors!(nodes[0], 1);
+		} else {
+			nodes[0].node.peer_disconnected(&nodes[1].node.get_our_node_id(), false);
+		}
+		nodes[1].node.peer_disconnected(&nodes[0].node.get_our_node_id(), false);
+
+		// Now reconnect the two
+		nodes[0].node.peer_connected(&nodes[1].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+		let reestablish_1 = get_chan_reestablish_msgs!(nodes[0], nodes[1]);
+		assert_eq!(reestablish_1.len(), 1);
+		nodes[1].node.peer_connected(&nodes[0].node.get_our_node_id(), &msgs::Init { features: InitFeatures::empty() });
+		let reestablish_2 = get_chan_reestablish_msgs!(nodes[1], nodes[0]);
+		assert_eq!(reestablish_2.len(), 1);
+
+		nodes[1].node.handle_channel_reestablish(&nodes[0].node.get_our_node_id(), &reestablish_1[0]);
+		let resp_1 = handle_chan_reestablish_msgs!(nodes[1], nodes[0]);
+		check_added_monitors!(nodes[1], 0);
+
+		nodes[0].node.handle_channel_reestablish(&nodes[1].node.get_our_node_id(), &reestablish_2[0]);
+		let resp_0 = handle_chan_reestablish_msgs!(nodes[0], nodes[1]);
+
+		assert!(resp_0.0.is_none());
+		assert!(resp_0.1.is_none());
+		assert!(resp_0.2.is_none());
+		assert!(resp_1.0.is_none());
+		assert!(resp_1.1.is_none());
+
+		// Check that the freshly-generated cs is equal to the original (which we will deliver in a
+		// moment).
+		if let Some(pending_cs) = resp_1.2 {
+			assert!(pending_cs.update_add_htlcs.is_empty());
+			assert!(pending_cs.update_fail_htlcs.is_empty());
+			assert!(pending_cs.update_fulfill_htlcs.is_empty());
+			assert_eq!(pending_cs.commitment_signed, cs);
+		} else { panic!(); }
+
+		// There should be no monitor updates as we are still pending awaiting a failed one.
+		check_added_monitors!(nodes[0], 0);
+		check_added_monitors!(nodes[1], 0);
+	}
+
+	// If we finish updating the monitor, we should free the holding cell right away (this did
+	// not occur prior to #756).
+	*nodes[0].chain_monitor.update_ret.lock().unwrap() = None;
+	let (funding_txo, mon_id) = nodes[0].chain_monitor.latest_monitor_update_id.lock().unwrap().get(&chan_id).unwrap().clone();
+	nodes[0].node.channel_monitor_updated(&funding_txo, mon_id);
+
+	// New outbound messages should be generated immediately.
+	check_added_monitors!(nodes[0], 1);
+	let mut events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+
+	// Deliver the pending in-flight CS
+	nodes[0].node.handle_commitment_signed(&nodes[1].node.get_our_node_id(), &cs);
+	check_added_monitors!(nodes[0], 1);
+
+	let commitment_msg = match events.pop().unwrap() {
+		MessageSendEvent::UpdateHTLCs { node_id, updates } => {
+			assert!(updates.update_fail_htlcs.is_empty());
+			assert!(updates.update_fail_malformed_htlcs.is_empty());
+			assert!(updates.update_fee.is_none());
+			assert_eq!(updates.update_fulfill_htlcs.len(), 1);
+			nodes[1].node.handle_update_fulfill_htlc(&nodes[0].node.get_our_node_id(), &updates.update_fulfill_htlcs[0]);
+			expect_payment_sent!(nodes[1], payment_preimage_0);
+			assert_eq!(updates.update_add_htlcs.len(), 1);
+			nodes[1].node.handle_update_add_htlc(&nodes[0].node.get_our_node_id(), &updates.update_add_htlcs[0]);
+			updates.commitment_signed
+		},
+		_ => panic!("Unexpected event type!"),
+	};
+
+	nodes[1].node.handle_commitment_signed(&nodes[0].node.get_our_node_id(), &commitment_msg);
+	check_added_monitors!(nodes[1], 1);
+
+	let as_revoke_and_ack = get_event_msg!(nodes[0], MessageSendEvent::SendRevokeAndACK, nodes[1].node.get_our_node_id());
+	nodes[1].node.handle_revoke_and_ack(&nodes[0].node.get_our_node_id(), &as_revoke_and_ack);
+	expect_pending_htlcs_forwardable!(nodes[1]);
+	expect_payment_received!(nodes[1], payment_hash_1, 100000);
+	check_added_monitors!(nodes[1], 1);
+
+	commitment_signed_dance!(nodes[1], nodes[0], (), false, true, false);
+
+	expect_pending_htlcs_forwardable!(nodes[1]);
+	expect_payment_received!(nodes[1], payment_hash_2, 100000);
+
+	claim_payment(&nodes[0], &[&nodes[1]], payment_preimage_1, 100000);
+	claim_payment(&nodes[0], &[&nodes[1]], payment_preimage_2, 100000);
+}
+#[test]
+fn channel_holding_cell_serialize() {
+	do_channel_holding_cell_serialize(true, true);
+	do_channel_holding_cell_serialize(true, false);
+	do_channel_holding_cell_serialize(false, true); // last arg doesn't matter
 }

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2668,13 +2668,11 @@ impl<Signer: Sign> Channel<Signer> {
 	/// implicitly dropping) and the payment_hashes of HTLCs we tried to add but are dropping.
 	/// No further message handling calls may be made until a channel_reestablish dance has
 	/// completed.
-	pub fn remove_uncommitted_htlcs_and_mark_paused<L: Deref>(&mut self, logger: &L) -> Vec<(HTLCSource, PaymentHash)> where L::Target: Logger {
-		let mut outbound_drops = Vec::new();
-
+	pub fn remove_uncommitted_htlcs_and_mark_paused<L: Deref>(&mut self, logger: &L)  where L::Target: Logger {
 		assert_eq!(self.channel_state & ChannelState::ShutdownComplete as u32, 0);
 		if self.channel_state < ChannelState::FundingSent as u32 {
 			self.channel_state = ChannelState::ShutdownComplete as u32;
-			return outbound_drops;
+			return;
 		}
 		// Upon reconnect we have to start the closing_signed dance over, but shutdown messages
 		// will be retransmitted.
@@ -2717,23 +2715,8 @@ impl<Signer: Sign> Channel<Signer> {
 			}
 		}
 
-		self.holding_cell_htlc_updates.retain(|htlc_update| {
-			match htlc_update {
-				// Note that currently on channel reestablish we assert that there are
-				// no holding cell HTLC update_adds, so if in the future we stop
-				// dropping added HTLCs here and failing them backwards, then there will
-				// need to be corresponding changes made in the Channel's re-establish
-				// logic.
-				&HTLCUpdateAwaitingACK::AddHTLC { ref payment_hash, ref source, .. } => {
-					outbound_drops.push((source.clone(), payment_hash.clone()));
-					false
-				},
-				&HTLCUpdateAwaitingACK::ClaimHTLC {..} | &HTLCUpdateAwaitingACK::FailHTLC {..} => true,
-			}
-		});
 		self.channel_state |= ChannelState::PeerDisconnected as u32;
-		log_debug!(logger, "Peer disconnection resulted in {} remote-announced HTLC drops and {} waiting-to-locally-announced HTLC drops on channel {}", outbound_drops.len(), inbound_drop_count, log_bytes!(self.channel_id()));
-		outbound_drops
+		log_debug!(logger, "Peer disconnection resulted in {} waiting-to-locally-announced HTLC drops on channel {}", inbound_drop_count, log_bytes!(self.channel_id()));
 	}
 
 	/// Indicates that a ChannelMonitor update failed to be stored by the client and further
@@ -2908,7 +2891,7 @@ impl<Signer: Sign> Channel<Signer> {
 
 	/// May panic if some calls other than message-handling calls (which will all Err immediately)
 	/// have been called between remove_uncommitted_htlcs_and_mark_paused and this call.
-	pub fn channel_reestablish<L: Deref>(&mut self, msg: &msgs::ChannelReestablish, logger: &L) -> Result<(Option<msgs::FundingLocked>, Option<msgs::RevokeAndACK>, Option<msgs::CommitmentUpdate>, Option<ChannelMonitorUpdate>, RAACommitmentOrder, Option<msgs::Shutdown>), ChannelError> where L::Target: Logger {
+	pub fn channel_reestablish<L: Deref>(&mut self, msg: &msgs::ChannelReestablish, logger: &L) -> Result<(Option<msgs::FundingLocked>, Option<msgs::RevokeAndACK>, Option<msgs::CommitmentUpdate>, Option<ChannelMonitorUpdate>, RAACommitmentOrder, Vec<(HTLCSource, PaymentHash)>, Option<msgs::Shutdown>), ChannelError> where L::Target: Logger {
 		if self.channel_state & (ChannelState::PeerDisconnected as u32) == 0 {
 			// While BOLT 2 doesn't indicate explicitly we should error this channel here, it
 			// almost certainly indicates we are going to end up out-of-sync in some way, so we
@@ -2959,7 +2942,7 @@ impl<Signer: Sign> Channel<Signer> {
 					return Err(ChannelError::Close("Peer claimed they saw a revoke_and_ack but we haven't sent funding_locked yet".to_owned()));
 				}
 				// Short circuit the whole handler as there is nothing we can resend them
-				return Ok((None, None, None, None, RAACommitmentOrder::CommitmentFirst, shutdown_msg));
+				return Ok((None, None, None, None, RAACommitmentOrder::CommitmentFirst, Vec::new(), shutdown_msg));
 			}
 
 			// We have OurFundingLocked set!
@@ -2967,7 +2950,7 @@ impl<Signer: Sign> Channel<Signer> {
 			return Ok((Some(msgs::FundingLocked {
 				channel_id: self.channel_id(),
 				next_per_commitment_point,
-			}), None, None, None, RAACommitmentOrder::CommitmentFirst, shutdown_msg));
+			}), None, None, None, RAACommitmentOrder::CommitmentFirst, Vec::new(), shutdown_msg));
 		}
 
 		let required_revoke = if msg.next_remote_commitment_number + 1 == INITIAL_COMMITMENT_NUMBER - self.cur_holder_commitment_transaction_number {
@@ -3008,14 +2991,6 @@ impl<Signer: Sign> Channel<Signer> {
 			}
 
 			if (self.channel_state & (ChannelState::AwaitingRemoteRevoke as u32 | ChannelState::MonitorUpdateFailed as u32)) == 0 {
-				// Note that if in the future we no longer drop holding cell update_adds on peer
-				// disconnect, this logic will need to be updated.
-				for htlc_update in self.holding_cell_htlc_updates.iter() {
-					if let &HTLCUpdateAwaitingACK::AddHTLC { .. } = htlc_update {
-						debug_assert!(false, "There shouldn't be any add-HTLCs in the holding cell now because they should have been dropped on peer disconnect. Panic here because said HTLCs won't be handled correctly.");
-					}
-				}
-
 				// We're up-to-date and not waiting on a remote revoke (if we are our
 				// channel_reestablish should result in them sending a revoke_and_ack), but we may
 				// have received some updates while we were disconnected. Free the holding cell
@@ -3024,20 +2999,14 @@ impl<Signer: Sign> Channel<Signer> {
 					Err(ChannelError::Close(msg)) => return Err(ChannelError::Close(msg)),
 					Err(ChannelError::Ignore(_)) | Err(ChannelError::CloseDelayBroadcast(_)) => panic!("Got non-channel-failing result from free_holding_cell_htlcs"),
 					Ok((Some((commitment_update, monitor_update)), htlcs_to_fail)) => {
-						// If in the future we no longer drop holding cell update_adds on peer
-						// disconnect, we may be handed some HTLCs to fail backwards here.
-						assert!(htlcs_to_fail.is_empty());
-						return Ok((resend_funding_locked, required_revoke, Some(commitment_update), Some(monitor_update), self.resend_order.clone(), shutdown_msg));
+						return Ok((resend_funding_locked, required_revoke, Some(commitment_update), Some(monitor_update), self.resend_order.clone(), htlcs_to_fail, shutdown_msg));
 					},
 					Ok((None, htlcs_to_fail)) => {
-						// If in the future we no longer drop holding cell update_adds on peer
-						// disconnect, we may be handed some HTLCs to fail backwards here.
-						assert!(htlcs_to_fail.is_empty());
-						return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), shutdown_msg));
+						return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), htlcs_to_fail, shutdown_msg));
 					},
 				}
 			} else {
-				return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), shutdown_msg));
+				return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), Vec::new(), shutdown_msg));
 			}
 		} else if msg.next_local_commitment_number == next_counterparty_commitment_number - 1 {
 			if required_revoke.is_some() {
@@ -3048,10 +3017,10 @@ impl<Signer: Sign> Channel<Signer> {
 
 			if self.channel_state & (ChannelState::MonitorUpdateFailed as u32) != 0 {
 				self.monitor_pending_commitment_signed = true;
-				return Ok((resend_funding_locked, None, None, None, self.resend_order.clone(), shutdown_msg));
+				return Ok((resend_funding_locked, None, None, None, self.resend_order.clone(), Vec::new(), shutdown_msg));
 			}
 
-			return Ok((resend_funding_locked, required_revoke, Some(self.get_last_commitment_update(logger)), None, self.resend_order.clone(), shutdown_msg));
+			return Ok((resend_funding_locked, required_revoke, Some(self.get_last_commitment_update(logger)), None, self.resend_order.clone(), Vec::new(), shutdown_msg));
 		} else {
 			return Err(ChannelError::Close("Peer attempted to reestablish channel with a very old remote commitment transaction".to_owned()));
 		}
@@ -4289,7 +4258,7 @@ impl Readable for InboundHTLCRemovalReason {
 impl<Signer: Sign> Writeable for Channel<Signer> {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
 		// Note that we write out as if remove_uncommitted_htlcs_and_mark_paused had just been
-		// called but include holding cell updates (and obviously we don't modify self).
+		// called.
 
 		writer.write_all(&[SERIALIZATION_VERSION; 1])?;
 		writer.write_all(&[MIN_SERIALIZATION_VERSION; 1])?;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2975,7 +2975,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	}
 
 	fn internal_channel_reestablish(&self, counterparty_node_id: &PublicKey, msg: &msgs::ChannelReestablish) -> Result<(), MsgHandleErrInternal> {
-		let chan_restoration_res = {
+		let (htlcs_failed_forward, chan_restoration_res) = {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 
@@ -2988,7 +2988,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					// disconnect, so Channel's reestablish will never hand us any holding cell
 					// freed HTLCs to fail backwards. If in the future we no longer drop pending
 					// add-HTLCs on disconnect, we may be handed HTLCs to fail backwards here.
-					let (funding_locked, revoke_and_ack, commitment_update, monitor_update_opt, order, shutdown) =
+					let (funding_locked, revoke_and_ack, commitment_update, monitor_update_opt, order, htlcs_failed_forward, shutdown) =
 						try_chan_entry!(self, chan.get_mut().channel_reestablish(msg, &self.logger), channel_state, chan);
 					if let Some(msg) = shutdown {
 						channel_state.pending_msg_events.push(events::MessageSendEvent::SendShutdown {
@@ -2996,12 +2996,12 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							msg,
 						});
 					}
-					handle_chan_restoration_locked!(self, channel_state_lock, channel_state, chan, revoke_and_ack, commitment_update, order, monitor_update_opt, Vec::new(), false, funding_locked)
+					(htlcs_failed_forward, handle_chan_restoration_locked!(self, channel_state_lock, channel_state, chan, revoke_and_ack, commitment_update, order, monitor_update_opt, Vec::new(), false, funding_locked))
 				},
 				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
 			}
 		};
-		post_handle_chan_restoration!(self, chan_restoration_res, Vec::new(), Vec::new());
+		post_handle_chan_restoration!(self, chan_restoration_res, Vec::new(), htlcs_failed_forward);
 		Ok(())
 	}
 
@@ -3429,7 +3429,6 @@ impl<Signer: Sign, M: Deref + Sync + Send, T: Deref + Sync + Send, K: Deref + Sy
 	fn peer_disconnected(&self, counterparty_node_id: &PublicKey, no_connection_possible: bool) {
 		let _persistence_guard = PersistenceNotifierGuard::new(&self.total_consistency_lock, &self.persistence_notifier);
 		let mut failed_channels = Vec::new();
-		let mut failed_payments = Vec::new();
 		let mut no_channels_remain = true;
 		{
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
@@ -3458,16 +3457,8 @@ impl<Signer: Sign, M: Deref + Sync + Send, T: Deref + Sync + Send, K: Deref + Sy
 				log_debug!(self.logger, "Marking channels with {} disconnected and generating channel_updates", log_pubkey!(counterparty_node_id));
 				channel_state.by_id.retain(|_, chan| {
 					if chan.get_counterparty_node_id() == *counterparty_node_id {
-						// Note that currently on channel reestablish we assert that there are no
-						// holding cell add-HTLCs, so if in the future we stop removing uncommitted HTLCs
-						// on peer disconnect here, there will need to be corresponding changes in
-						// reestablish logic.
-						let failed_adds = chan.remove_uncommitted_htlcs_and_mark_paused(&self.logger);
+						chan.remove_uncommitted_htlcs_and_mark_paused(&self.logger);
 						chan.to_disabled_marked();
-						if !failed_adds.is_empty() {
-							let chan_update = self.get_channel_update(&chan).map(|u| u.encode_with_len()).unwrap(); // Cannot add/recv HTLCs before we have a short_id so unwrap is safe
-							failed_payments.push((chan_update, failed_adds));
-						}
 						if chan.is_shutdown() {
 							if let Some(short_id) = chan.get_short_channel_id() {
 								short_to_id.remove(&short_id);
@@ -3509,11 +3500,6 @@ impl<Signer: Sign, M: Deref + Sync + Send, T: Deref + Sync + Send, K: Deref + Sy
 
 		for failure in failed_channels.drain(..) {
 			self.finish_force_close_channel(failure);
-		}
-		for (chan_update, mut htlc_sources) in failed_payments {
-			for (htlc_source, payment_hash) in htlc_sources.drain(..) {
-				self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_source, &payment_hash, HTLCFailReason::Reason { failure_code: 0x1000 | 7, data: chan_update.clone() });
-			}
 		}
 	}
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2262,7 +2262,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	pub fn channel_monitor_updated(&self, funding_txo: &OutPoint, highest_applied_update_id: u64) {
 		let _persistence_guard = PersistenceNotifierGuard::new(&self.total_consistency_lock, &self.persistence_notifier);
 
-		let mut close_results = Vec::new();
 		let mut htlc_forwards = Vec::new();
 		let mut htlc_failures = Vec::new();
 		let mut pending_events = Vec::new();
@@ -2339,10 +2338,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), failure.0, &failure.1, failure.2);
 		}
 		self.forward_htlcs(&mut htlc_forwards[..]);
-
-		for res in close_results.drain(..) {
-			self.finish_force_close_channel(res);
-		}
 	}
 
 	fn internal_open_channel(&self, counterparty_node_id: &PublicKey, their_features: InitFeatures, msg: &msgs::OpenChannel) -> Result<(), MsgHandleErrInternal> {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -744,6 +744,83 @@ macro_rules! maybe_break_monitor_err {
 	}
 }
 
+macro_rules! handle_chan_restoration_locked {
+	($self: expr, $channel_lock: expr, $channel_state: expr, $channel_entry: expr,
+	 $raa: expr, $commitment_update: expr, $order: expr,
+	 $pending_forwards: expr, $pending_failures: expr, $broadcast_safe: expr, $funding_locked: expr) => { {
+		let mut htlc_forwards = Vec::new();
+		let mut htlc_failures = Vec::new();
+		let mut pending_events = Vec::new();
+
+		{
+			if !$pending_forwards.is_empty() {
+				htlc_forwards.push(($channel_entry.get().get_short_channel_id().expect("We can't have pending forwards before funding confirmation"),
+					$channel_entry.get().get_funding_txo().unwrap(), $pending_forwards));
+			}
+			htlc_failures.append(&mut $pending_failures);
+
+			macro_rules! handle_cs { () => {
+				if let Some(update) = $commitment_update {
+					$channel_state.pending_msg_events.push(events::MessageSendEvent::UpdateHTLCs {
+						node_id: $channel_entry.get().get_counterparty_node_id(),
+						updates: update,
+					});
+				}
+			} }
+			macro_rules! handle_raa { () => {
+				if let Some(revoke_and_ack) = $raa {
+					$channel_state.pending_msg_events.push(events::MessageSendEvent::SendRevokeAndACK {
+						node_id: $channel_entry.get().get_counterparty_node_id(),
+						msg: revoke_and_ack,
+					});
+				}
+			} }
+			match $order {
+				RAACommitmentOrder::CommitmentFirst => {
+					handle_cs!();
+					handle_raa!();
+				},
+				RAACommitmentOrder::RevokeAndACKFirst => {
+					handle_raa!();
+					handle_cs!();
+				},
+			}
+			if $broadcast_safe {
+				pending_events.push(events::Event::FundingBroadcastSafe {
+					funding_txo: $channel_entry.get().get_funding_txo().unwrap(),
+					user_channel_id: $channel_entry.get().get_user_id(),
+				});
+			}
+			if let Some(msg) = $funding_locked {
+				$channel_state.pending_msg_events.push(events::MessageSendEvent::SendFundingLocked {
+					node_id: $channel_entry.get().get_counterparty_node_id(),
+					msg,
+				});
+				if let Some(announcement_sigs) = $self.get_announcement_sigs($channel_entry.get()) {
+					$channel_state.pending_msg_events.push(events::MessageSendEvent::SendAnnouncementSignatures {
+						node_id: $channel_entry.get().get_counterparty_node_id(),
+						msg: announcement_sigs,
+					});
+				}
+				$channel_state.short_to_id.insert($channel_entry.get().get_short_channel_id().unwrap(), $channel_entry.get().channel_id());
+			}
+		}
+		(htlc_forwards, htlc_failures, pending_events)
+	} }
+}
+
+macro_rules! post_handle_chan_restoration {
+	($self: expr, $locked_res: expr) => { {
+		let (mut htlc_forwards, mut htlc_failures, mut pending_events) = $locked_res;
+		$self.pending_events.lock().unwrap().append(&mut pending_events);
+
+		for failure in htlc_failures.drain(..) {
+			$self.fail_htlc_backwards_internal($self.channel_state.lock().unwrap(), failure.0, &failure.1, failure.2);
+		}
+		$self.forward_htlcs(&mut htlc_forwards[..]);
+	} }
+}
+
 impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelManager<Signer, M, T, K, F, L>
 	where M::Target: chain::Watch<Signer>,
         T::Target: BroadcasterInterface,
@@ -2262,82 +2339,21 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	pub fn channel_monitor_updated(&self, funding_txo: &OutPoint, highest_applied_update_id: u64) {
 		let _persistence_guard = PersistenceNotifierGuard::new(&self.total_consistency_lock, &self.persistence_notifier);
 
-		let mut htlc_forwards = Vec::new();
-		let mut htlc_failures = Vec::new();
-		let mut pending_events = Vec::new();
-
-		{
+		let chan_restoration_res = {
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
-			let short_to_id = &mut channel_state.short_to_id;
-			let pending_msg_events = &mut channel_state.pending_msg_events;
-			let channel = match channel_state.by_id.get_mut(&funding_txo.to_channel_id()) {
-				Some(chan) => chan,
-				None => return,
+			let mut channel = match channel_state.by_id.entry(funding_txo.to_channel_id()) {
+				hash_map::Entry::Occupied(chan) => chan,
+				hash_map::Entry::Vacant(_) => return,
 			};
-			if !channel.is_awaiting_monitor_update() || channel.get_latest_monitor_update_id() != highest_applied_update_id {
+			if !channel.get().is_awaiting_monitor_update() || channel.get().get_latest_monitor_update_id() != highest_applied_update_id {
 				return;
 			}
 
-			let (raa, commitment_update, order, pending_forwards, mut pending_failures, needs_broadcast_safe, funding_locked) = channel.monitor_updating_restored(&self.logger);
-			if !pending_forwards.is_empty() {
-				htlc_forwards.push((channel.get_short_channel_id().expect("We can't have pending forwards before funding confirmation"), funding_txo.clone(), pending_forwards));
-			}
-			htlc_failures.append(&mut pending_failures);
-
-			macro_rules! handle_cs { () => {
-				if let Some(update) = commitment_update {
-					pending_msg_events.push(events::MessageSendEvent::UpdateHTLCs {
-						node_id: channel.get_counterparty_node_id(),
-						updates: update,
-					});
-				}
-			} }
-			macro_rules! handle_raa { () => {
-				if let Some(revoke_and_ack) = raa {
-					pending_msg_events.push(events::MessageSendEvent::SendRevokeAndACK {
-						node_id: channel.get_counterparty_node_id(),
-						msg: revoke_and_ack,
-					});
-				}
-			} }
-			match order {
-				RAACommitmentOrder::CommitmentFirst => {
-					handle_cs!();
-					handle_raa!();
-				},
-				RAACommitmentOrder::RevokeAndACKFirst => {
-					handle_raa!();
-					handle_cs!();
-				},
-			}
-			if needs_broadcast_safe {
-				pending_events.push(events::Event::FundingBroadcastSafe {
-					funding_txo: channel.get_funding_txo().unwrap(),
-					user_channel_id: channel.get_user_id(),
-				});
-			}
-			if let Some(msg) = funding_locked {
-				pending_msg_events.push(events::MessageSendEvent::SendFundingLocked {
-					node_id: channel.get_counterparty_node_id(),
-					msg,
-				});
-				if let Some(announcement_sigs) = self.get_announcement_sigs(channel) {
-					pending_msg_events.push(events::MessageSendEvent::SendAnnouncementSignatures {
-						node_id: channel.get_counterparty_node_id(),
-						msg: announcement_sigs,
-					});
-				}
-				short_to_id.insert(channel.get_short_channel_id().unwrap(), channel.channel_id());
-			}
-		}
-
-		self.pending_events.lock().unwrap().append(&mut pending_events);
-
-		for failure in htlc_failures.drain(..) {
-			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), failure.0, &failure.1, failure.2);
-		}
-		self.forward_htlcs(&mut htlc_forwards[..]);
+			let (raa, commitment_update, order, pending_forwards, mut pending_failures, needs_broadcast_safe, funding_locked) = channel.get_mut().monitor_updating_restored(&self.logger);
+			handle_chan_restoration_locked!(self, channel_lock, channel_state, channel, raa, commitment_update, order, pending_forwards, pending_failures, needs_broadcast_safe, funding_locked)
+		};
+		post_handle_chan_restoration!(self, chan_restoration_res);
 	}
 
 	fn internal_open_channel(&self, counterparty_node_id: &PublicKey, their_features: InitFeatures, msg: &msgs::OpenChannel) -> Result<(), MsgHandleErrInternal> {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -747,22 +747,21 @@ macro_rules! maybe_break_monitor_err {
 macro_rules! handle_chan_restoration_locked {
 	($self: expr, $channel_lock: expr, $channel_state: expr, $channel_entry: expr,
 	 $raa: expr, $commitment_update: expr, $order: expr,
-	 $pending_forwards: expr, $pending_failures: expr, $broadcast_safe: expr, $funding_locked: expr) => { {
-		let mut htlc_forwards = Vec::new();
-		let mut htlc_failures = Vec::new();
-		let mut pending_events = Vec::new();
+	 $pending_forwards: expr, $broadcast_safe: expr, $funding_locked: expr) => { {
+		let mut htlc_forwards = None;
+		let mut funding_broadcast_safe = None;
+		let counterparty_node_id = $channel_entry.get().get_counterparty_node_id();
 
 		{
 			if !$pending_forwards.is_empty() {
-				htlc_forwards.push(($channel_entry.get().get_short_channel_id().expect("We can't have pending forwards before funding confirmation"),
+				htlc_forwards = Some(($channel_entry.get().get_short_channel_id().expect("We can't have pending forwards before funding confirmation"),
 					$channel_entry.get().get_funding_txo().unwrap(), $pending_forwards));
 			}
-			htlc_failures.append(&mut $pending_failures);
 
 			macro_rules! handle_cs { () => {
 				if let Some(update) = $commitment_update {
 					$channel_state.pending_msg_events.push(events::MessageSendEvent::UpdateHTLCs {
-						node_id: $channel_entry.get().get_counterparty_node_id(),
+						node_id: counterparty_node_id,
 						updates: update,
 					});
 				}
@@ -770,7 +769,7 @@ macro_rules! handle_chan_restoration_locked {
 			macro_rules! handle_raa { () => {
 				if let Some(revoke_and_ack) = $raa {
 					$channel_state.pending_msg_events.push(events::MessageSendEvent::SendRevokeAndACK {
-						node_id: $channel_entry.get().get_counterparty_node_id(),
+						node_id: counterparty_node_id,
 						msg: revoke_and_ack,
 					});
 				}
@@ -786,38 +785,43 @@ macro_rules! handle_chan_restoration_locked {
 				},
 			}
 			if $broadcast_safe {
-				pending_events.push(events::Event::FundingBroadcastSafe {
+				funding_broadcast_safe = Some(events::Event::FundingBroadcastSafe {
 					funding_txo: $channel_entry.get().get_funding_txo().unwrap(),
 					user_channel_id: $channel_entry.get().get_user_id(),
 				});
 			}
 			if let Some(msg) = $funding_locked {
 				$channel_state.pending_msg_events.push(events::MessageSendEvent::SendFundingLocked {
-					node_id: $channel_entry.get().get_counterparty_node_id(),
+					node_id: counterparty_node_id,
 					msg,
 				});
 				if let Some(announcement_sigs) = $self.get_announcement_sigs($channel_entry.get()) {
 					$channel_state.pending_msg_events.push(events::MessageSendEvent::SendAnnouncementSignatures {
-						node_id: $channel_entry.get().get_counterparty_node_id(),
+						node_id: counterparty_node_id,
 						msg: announcement_sigs,
 					});
 				}
 				$channel_state.short_to_id.insert($channel_entry.get().get_short_channel_id().unwrap(), $channel_entry.get().channel_id());
 			}
 		}
-		(htlc_forwards, htlc_failures, pending_events)
+		(htlc_forwards, funding_broadcast_safe)
 	} }
 }
 
 macro_rules! post_handle_chan_restoration {
-	($self: expr, $locked_res: expr) => { {
-		let (mut htlc_forwards, mut htlc_failures, mut pending_events) = $locked_res;
-		$self.pending_events.lock().unwrap().append(&mut pending_events);
+	($self: expr, $locked_res: expr, $pending_failures: expr) => { {
+		let (htlc_forwards, funding_broadcast_safe) = $locked_res;
 
-		for failure in htlc_failures.drain(..) {
+		if let Some(ev) = funding_broadcast_safe {
+			$self.pending_events.lock().unwrap().push(ev);
+		}
+
+		for failure in $pending_failures.drain(..) {
 			$self.fail_htlc_backwards_internal($self.channel_state.lock().unwrap(), failure.0, &failure.1, failure.2);
 		}
-		$self.forward_htlcs(&mut htlc_forwards[..]);
+		if let Some(forwards) = htlc_forwards {
+			$self.forward_htlcs(&mut [forwards][..]);
+		}
 	} }
 }
 
@@ -2339,7 +2343,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	pub fn channel_monitor_updated(&self, funding_txo: &OutPoint, highest_applied_update_id: u64) {
 		let _persistence_guard = PersistenceNotifierGuard::new(&self.total_consistency_lock, &self.persistence_notifier);
 
-		let chan_restoration_res = {
+		let (mut pending_failures, chan_restoration_res) = {
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
 			let mut channel = match channel_state.by_id.entry(funding_txo.to_channel_id()) {
@@ -2350,10 +2354,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				return;
 			}
 
-			let (raa, commitment_update, order, pending_forwards, mut pending_failures, needs_broadcast_safe, funding_locked) = channel.get_mut().monitor_updating_restored(&self.logger);
-			handle_chan_restoration_locked!(self, channel_lock, channel_state, channel, raa, commitment_update, order, pending_forwards, pending_failures, needs_broadcast_safe, funding_locked)
+			let (raa, commitment_update, order, pending_forwards, pending_failures, needs_broadcast_safe, funding_locked) = channel.get_mut().monitor_updating_restored(&self.logger);
+			(pending_failures, handle_chan_restoration_locked!(self, channel_lock, channel_state, channel, raa, commitment_update, order, pending_forwards, needs_broadcast_safe, funding_locked))
 		};
-		post_handle_chan_restoration!(self, chan_restoration_res);
+		post_handle_chan_restoration!(self, chan_restoration_res, pending_failures);
 	}
 
 	fn internal_open_channel(&self, counterparty_node_id: &PublicKey, their_features: InitFeatures, msg: &msgs::OpenChannel) -> Result<(), MsgHandleErrInternal> {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1353,6 +1353,11 @@ macro_rules! handle_chan_reestablish_msgs {
 				None
 			};
 
+			if let Some(&MessageSendEvent::SendAnnouncementSignatures { ref node_id, msg: _ }) = msg_events.get(idx) {
+				idx += 1;
+				assert_eq!(*node_id, $dst_node.node.get_our_node_id());
+			}
+
 			let mut revoke_and_ack = None;
 			let mut commitment_update = None;
 			let order = if let Some(ev) = msg_events.get(idx) {


### PR DESCRIPTION
This is effectively a superset of #755 (with the same commit) and an alternate approach to #754, instead holding onto the holding cell HTLCs and supporting handling them correctly in response to a channel_reestablish message. This was more of a slap-together thing, and still needs testing, but seeking concept ACKs on the restructure and approach (also to moving towards addressing #661).