### PR TITLE
Bump lightning-net-tokio crate version.

### DIFF
--- a/lightning-net-tokio/Cargo.toml
+++ b/lightning-net-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-net-tokio"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Matt Corallo"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
Forgot to do this one. Already uploaded all the other crates to crates.io, though, so just gonna do this locally to match and upload.