### PR TITLE
Specify honggfuzz version in ci-fuzz

### DIFF
--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -12,6 +12,7 @@ rm *_target.rs
 [ "$(git diff)" != "" ] && exit 1
 popd
 
+cargo update
 cargo install --color always --force honggfuzz
 sed -i 's/lto = true//' Cargo.toml
 HFUZZ_BUILD_ARGS="--features honggfuzz_fuzz" cargo --color always hfuzz build


### PR DESCRIPTION
I've been consistently running into some version of `honggfuzz dependency (0.5.45) and build command (0.5.49) versions do not match`. This seems to fix it.