### PR TITLE
Process monitor update events in block_[dis]connected asynchronously

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4180,6 +4180,10 @@ impl<Signer: Sign> Channel<Signer> {
 	/// Also returns the list of payment_hashes for channels which we can safely fail backwards
 	/// immediately (others we will have to allow to time out).
 	pub fn force_shutdown(&mut self, should_broadcast: bool) -> (Option<(OutPoint, ChannelMonitorUpdate)>, Vec<(HTLCSource, PaymentHash)>) {
+		// Note that we MUST only generate a monitor update that indicates force-closure - we're
+		// called during initialization prior to the chain_monitor in the encompassing ChannelManager
+		// being fully configured in some cases. Thus, its likely any monitor events we generate will
+		// be delayed in being processed! See the docs for `ChannelManagerReadArgs` for more.
 		assert!(self.channel_state != ChannelState::ShutdownComplete as u32);
 
 		// We go ahead and "free" any holding cell HTLCs or HTLCs we haven't yet committed to and

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4179,7 +4179,7 @@ impl<Signer: Sign> Channel<Signer> {
 	/// those explicitly stated to be allowed after shutdown completes, eg some simple getters).
 	/// Also returns the list of payment_hashes for channels which we can safely fail backwards
 	/// immediately (others we will have to allow to time out).
-	pub fn force_shutdown(&mut self, should_broadcast: bool) -> (Option<OutPoint>, ChannelMonitorUpdate, Vec<(HTLCSource, PaymentHash)>) {
+	pub fn force_shutdown(&mut self, should_broadcast: bool) -> (Option<(OutPoint, ChannelMonitorUpdate)>, Vec<(HTLCSource, PaymentHash)>) {
 		assert!(self.channel_state != ChannelState::ShutdownComplete as u32);
 
 		// We go ahead and "free" any holding cell HTLCs or HTLCs we haven't yet committed to and
@@ -4193,7 +4193,7 @@ impl<Signer: Sign> Channel<Signer> {
 				_ => {}
 			}
 		}
-		let funding_txo = if let Some(funding_txo) = self.get_funding_txo() {
+		let monitor_update = if let Some(funding_txo) = self.get_funding_txo() {
 			// If we haven't yet exchanged funding signatures (ie channel_state < FundingSent),
 			// returning a channel monitor update here would imply a channel monitor update before
 			// we even registered the channel monitor to begin with, which is invalid.
@@ -4202,17 +4202,17 @@ impl<Signer: Sign> Channel<Signer> {
 			// monitor update to the user, even if we return one).
 			// See test_duplicate_chan_id and test_pre_lockin_no_chan_closed_update for more.
 			if self.channel_state & (ChannelState::FundingSent as u32 | ChannelState::ChannelFunded as u32 | ChannelState::ShutdownComplete as u32) != 0 {
-				Some(funding_txo.clone())
+				self.latest_monitor_update_id += 1;
+				Some((funding_txo, ChannelMonitorUpdate {
+					update_id: self.latest_monitor_update_id,
+					updates: vec![ChannelMonitorUpdateStep::ChannelForceClosed { should_broadcast }],
+				}))
 			} else { None }
 		} else { None };
 
 		self.channel_state = ChannelState::ShutdownComplete as u32;
 		self.update_time_counter += 1;
-		self.latest_monitor_update_id += 1;
-		(funding_txo, ChannelMonitorUpdate {
-			update_id: self.latest_monitor_update_id,
-			updates: vec![ChannelMonitorUpdateStep::ChannelForceClosed { should_broadcast }],
-		}, dropped_outbound_htlcs)
+		(monitor_update, dropped_outbound_htlcs)
 	}
 }
 

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4009,8 +4009,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable f
 ///    ChannelManager)>::read(reader, args).
 ///    This may result in closing some Channels if the ChannelMonitor is newer than the stored
 ///    ChannelManager state to ensure no loss of funds. Thus, transactions may be broadcasted.
-/// 3) Register all relevant ChannelMonitor outpoints with your chain watch mechanism using
-///    ChannelMonitor::get_outputs_to_watch() and ChannelMonitor::get_funding_txo().
+/// 3) If you are not fetching full blocks, register all relevant ChannelMonitor outpoints the same
+///    way you would handle a `chain::Filter` call using ChannelMonitor::get_outputs_to_watch() and
+///    ChannelMonitor::get_funding_txo().
 /// 4) Reconnect blocks on your ChannelMonitors.
 /// 5) Disconnect/connect blocks on the ChannelManager.
 /// 6) Move the ChannelMonitors into your local chain::Watch.

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3934,6 +3934,13 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable f
 /// 4) Reconnect blocks on your ChannelMonitors.
 /// 5) Move the ChannelMonitors into your local chain::Watch.
 /// 6) Disconnect/connect blocks on the ChannelManager.
+///
+/// Note that because some channels may be closed during deserialization, it is critical that you
+/// always deserialize only the latest version of a ChannelManager and ChannelMonitors available to
+/// you. If you deserialize an old ChannelManager (during which force-closure transactions may be
+/// broadcast), and then later deserialize a newer version of the same ChannelManager (which will
+/// not force-close the same channels but consider them live), you may end up revoking a state for
+/// which you've already broadcasted the transaction.
 pub struct ChannelManagerReadArgs<'a, Signer: 'a + Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 	where M::Target: chain::Watch<Signer>,
         T::Target: BroadcasterInterface,

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -83,11 +83,13 @@ pub fn connect_block<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, block: &Block, 
 	let txdata: Vec<_> = block.txdata.iter().enumerate().collect();
 	node.chain_monitor.chain_monitor.block_connected(&block.header, &txdata, height);
 	node.node.block_connected(&block.header, &txdata, height);
+	node.node.test_process_background_events();
 }
 
 pub fn disconnect_block<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, header: &BlockHeader, height: u32) {
 	node.chain_monitor.chain_monitor.block_disconnected(header, height);
 	node.node.block_disconnected(header);
+	node.node.test_process_background_events();
 }
 
 pub struct TestChanMonCfg {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -8422,48 +8422,48 @@ fn test_pre_lockin_no_chan_closed_update() {
 #[test]
 fn test_htlc_no_detection() {
 	// This test is a mutation to underscore the detection logic bug we had
-        // before #653. HTLC value routed is above the remaining balance, thus
-        // inverting HTLC and `to_remote` output. HTLC will come second and
-        // it wouldn't be seen by pre-#653 detection as we were enumerate()'ing
-        // on a watched outputs vector (Vec<TxOut>) thus implicitly relying on
-        // outputs order detection for correct spending children filtring.
+	// before #653. HTLC value routed is above the remaining balance, thus
+	// inverting HTLC and `to_remote` output. HTLC will come second and
+	// it wouldn't be seen by pre-#653 detection as we were enumerate()'ing
+	// on a watched outputs vector (Vec<TxOut>) thus implicitly relying on
+	// outputs order detection for correct spending children filtring.
 
-        let chanmon_cfgs = create_chanmon_cfgs(2);
-        let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
-        let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
-        let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
-        // Create some initial channels
-        let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 10001, InitFeatures::known(), InitFeatures::known());
+	// Create some initial channels
+	let chan_1 = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 100000, 10001, InitFeatures::known(), InitFeatures::known());
 
-        send_payment(&nodes[0], &vec!(&nodes[1])[..], 1_000_000, 1_000_000);
-        let (_, our_payment_hash) = route_payment(&nodes[0], &vec!(&nodes[1])[..], 2_000_000);
-        let local_txn = get_local_commitment_txn!(nodes[0], chan_1.2);
-        assert_eq!(local_txn[0].input.len(), 1);
-        assert_eq!(local_txn[0].output.len(), 3);
-        check_spends!(local_txn[0], chan_1.3);
+	send_payment(&nodes[0], &vec!(&nodes[1])[..], 1_000_000, 1_000_000);
+	let (_, our_payment_hash) = route_payment(&nodes[0], &vec!(&nodes[1])[..], 2_000_000);
+	let local_txn = get_local_commitment_txn!(nodes[0], chan_1.2);
+	assert_eq!(local_txn[0].input.len(), 1);
+	assert_eq!(local_txn[0].output.len(), 3);
+	check_spends!(local_txn[0], chan_1.3);
 
-        // Timeout HTLC on A's chain and so it can generate a HTLC-Timeout tx
-        let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-        connect_block(&nodes[0], &Block { header, txdata: vec![local_txn[0].clone()] }, 200);
+	// Timeout HTLC on A's chain and so it can generate a HTLC-Timeout tx
+	let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	connect_block(&nodes[0], &Block { header, txdata: vec![local_txn[0].clone()] }, 200);
 	// We deliberately connect the local tx twice as this should provoke a failure calling
 	// this test before #653 fix.
-        connect_block(&nodes[0], &Block { header, txdata: vec![local_txn[0].clone()] }, 200);
-        check_closed_broadcast!(nodes[0], false);
-        check_added_monitors!(nodes[0], 1);
+	connect_block(&nodes[0], &Block { header, txdata: vec![local_txn[0].clone()] }, 200);
+	check_closed_broadcast!(nodes[0], false);
+	check_added_monitors!(nodes[0], 1);
 
-        let htlc_timeout = {
-                let node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
-                assert_eq!(node_txn[0].input.len(), 1);
-                assert_eq!(node_txn[0].input[0].witness.last().unwrap().len(), OFFERED_HTLC_SCRIPT_WEIGHT);
-                check_spends!(node_txn[0], local_txn[0]);
-                node_txn[0].clone()
-        };
+	let htlc_timeout = {
+		let node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn[0].input.len(), 1);
+		assert_eq!(node_txn[0].input[0].witness.last().unwrap().len(), OFFERED_HTLC_SCRIPT_WEIGHT);
+		check_spends!(node_txn[0], local_txn[0]);
+		node_txn[0].clone()
+	};
 
-        let header_201 = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-        connect_block(&nodes[0], &Block { header: header_201, txdata: vec![htlc_timeout.clone()] }, 201);
-        connect_blocks(&nodes[0], ANTI_REORG_DELAY - 1, 201, true, header_201.block_hash());
-        expect_payment_failed!(nodes[0], our_payment_hash, true);
+	let header_201 = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	connect_block(&nodes[0], &Block { header: header_201, txdata: vec![htlc_timeout.clone()] }, 201);
+	connect_blocks(&nodes[0], ANTI_REORG_DELAY - 1, 201, true, header_201.block_hash());
+	expect_payment_failed!(nodes[0], our_payment_hash, true);
 }
 
 fn do_test_onchain_htlc_settlement_after_close(broadcast_alice: bool, go_onchain_before_fulfill: bool) {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -51,7 +51,6 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::default::Default;
 use std::sync::Mutex;
 use std::sync::atomic::Ordering;
-use std::mem;
 
 use ln::functional_test_utils::*;
 use ln::chan_utils::CommitmentTransaction;
@@ -3531,37 +3530,6 @@ fn test_force_close_fail_back() {
 	assert_eq!(node_txn[0].input[0].witness.len(), 5); // Must be an HTLC-Success
 
 	check_spends!(node_txn[0], tx);
-}
-
-#[test]
-fn test_unconf_chan() {
-	// After creating a chan between nodes, we disconnect all blocks previously seen to force a channel close on nodes[0] side
-	let chanmon_cfgs = create_chanmon_cfgs(2);
-	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
-	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
-	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
-	create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
-
-	let channel_state = nodes[0].node.channel_state.lock().unwrap();
-	assert_eq!(channel_state.by_id.len(), 1);
-	assert_eq!(channel_state.short_to_id.len(), 1);
-	mem::drop(channel_state);
-
-	let mut headers = Vec::new();
-	let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	headers.push(header.clone());
-	for _i in 2..100 {
-		header = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-		headers.push(header.clone());
-	}
-	while !headers.is_empty() {
-		nodes[0].node.block_disconnected(&headers.pop().unwrap());
-	}
-	check_closed_broadcast!(nodes[0], false);
-	check_added_monitors!(nodes[0], 1);
-	let channel_state = nodes[0].node.channel_state.lock().unwrap();
-	assert_eq!(channel_state.by_id.len(), 0);
-	assert_eq!(channel_state.short_to_id.len(), 0);
 }
 
 #[test]
@@ -8057,103 +8025,6 @@ fn test_bump_penalty_txn_on_remote_commitment() {
 
 	nodes[1].node.get_and_clear_pending_events();
 	nodes[1].node.get_and_clear_pending_msg_events();
-}
-
-#[test]
-fn test_set_outpoints_partial_claiming() {
-	// - remote party claim tx, new bump tx
-	// - disconnect remote claiming tx, new bump
-	// - disconnect tx, see no tx anymore
-	let chanmon_cfgs = create_chanmon_cfgs(2);
-	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
-	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
-	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
-
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 59000000, InitFeatures::known(), InitFeatures::known());
-	let payment_preimage_1 = route_payment(&nodes[1], &vec!(&nodes[0])[..], 3_000_000).0;
-	let payment_preimage_2 = route_payment(&nodes[1], &vec!(&nodes[0])[..], 3_000_000).0;
-
-	// Remote commitment txn with 4 outputs: to_local, to_remote, 2 outgoing HTLC
-	let remote_txn = get_local_commitment_txn!(nodes[1], chan.2);
-	assert_eq!(remote_txn.len(), 3);
-	assert_eq!(remote_txn[0].output.len(), 4);
-	assert_eq!(remote_txn[0].input.len(), 1);
-	assert_eq!(remote_txn[0].input[0].previous_output.txid, chan.3.txid());
-	check_spends!(remote_txn[1], remote_txn[0]);
-	check_spends!(remote_txn[2], remote_txn[0]);
-
-	// Connect blocks on node A to advance height towards TEST_FINAL_CLTV
-	let prev_header_100 = connect_blocks(&nodes[1], 100, 0, false, Default::default());
-	// Provide node A with both preimage
-	nodes[0].node.claim_funds(payment_preimage_1, &None, 3_000_000);
-	nodes[0].node.claim_funds(payment_preimage_2, &None, 3_000_000);
-	check_added_monitors!(nodes[0], 2);
-	nodes[0].node.get_and_clear_pending_events();
-	nodes[0].node.get_and_clear_pending_msg_events();
-
-	// Connect blocks on node A commitment transaction
-	let header = BlockHeader { version: 0x20000000, prev_blockhash: prev_header_100, merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	connect_block(&nodes[0], &Block { header, txdata: vec![remote_txn[0].clone()] }, 101);
-	check_closed_broadcast!(nodes[0], false);
-	check_added_monitors!(nodes[0], 1);
-	// Verify node A broadcast tx claiming both HTLCs
-	{
-		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
-		// ChannelMonitor: claim tx, ChannelManager: local commitment tx + HTLC-Success*2
-		assert_eq!(node_txn.len(), 4);
-		check_spends!(node_txn[0], remote_txn[0]);
-		check_spends!(node_txn[1], chan.3);
-		check_spends!(node_txn[2], node_txn[1]);
-		check_spends!(node_txn[3], node_txn[1]);
-		assert_eq!(node_txn[0].input.len(), 2);
-		node_txn.clear();
-	}
-
-	// Connect blocks on node B
-	connect_blocks(&nodes[1], 135, 0, false, Default::default());
-	check_closed_broadcast!(nodes[1], false);
-	check_added_monitors!(nodes[1], 1);
-	// Verify node B broadcast 2 HTLC-timeout txn
-	let partial_claim_tx = {
-		let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
-		assert_eq!(node_txn.len(), 3);
-		check_spends!(node_txn[1], node_txn[0]);
-		check_spends!(node_txn[2], node_txn[0]);
-		assert_eq!(node_txn[1].input.len(), 1);
-		assert_eq!(node_txn[2].input.len(), 1);
-		node_txn[1].clone()
-	};
-
-	// Broadcast partial claim on node A, should regenerate a claiming tx with HTLC dropped
-	let header = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	connect_block(&nodes[0], &Block { header, txdata: vec![partial_claim_tx.clone()] }, 102);
-	{
-		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
-		assert_eq!(node_txn.len(), 1);
-		check_spends!(node_txn[0], remote_txn[0]);
-		assert_eq!(node_txn[0].input.len(), 1); //dropped HTLC
-		node_txn.clear();
-	}
-	nodes[0].node.get_and_clear_pending_msg_events();
-
-	// Disconnect last block on node A, should regenerate a claiming tx with HTLC dropped
-	disconnect_block(&nodes[0], &header, 102);
-	{
-		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
-		assert_eq!(node_txn.len(), 1);
-		check_spends!(node_txn[0], remote_txn[0]);
-		assert_eq!(node_txn[0].input.len(), 2); //resurrected HTLC
-		node_txn.clear();
-	}
-
-	//// Disconnect one more block and then reconnect multiple no transaction should be generated
-	disconnect_block(&nodes[0], &header, 101);
-	connect_blocks(&nodes[1], 15, 101, false, prev_header_100);
-	{
-		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
-		assert_eq!(node_txn.len(), 0);
-		node_txn.clear();
-	}
 }
 
 #[test]

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -207,6 +207,7 @@ fn test_unconf_chan() {
 		nodes[0].node.block_disconnected(&headers.pop().unwrap());
 	}
 	check_closed_broadcast!(nodes[0], false);
+	nodes[0].node.test_process_background_events(); // Required to free the pending background monitor update
 	check_added_monitors!(nodes[0], 1);
 	let channel_state = nodes[0].node.channel_state.lock().unwrap();
 	assert_eq!(channel_state.by_id.len(), 0);

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -280,6 +280,8 @@ fn do_test_unconf_chan(reload_node: bool, reorg_after_reload: bool) {
 		}
 	}
 
+	// With expect_channel_force_closed set the TestChainMonitor will enforce that the next update
+	// is a ChannelForcClosed on the right channel with should_broadcast set.
 	*nodes[0].chain_monitor.expect_channel_force_closed.lock().unwrap() = Some((chan_id, true));
 	nodes[0].node.test_process_background_events(); // Required to free the pending background monitor update
 	check_added_monitors!(nodes[0], 1);

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -17,6 +17,7 @@ use util::events::{Event, EventsProvider, MessageSendEvent, MessageSendEventsPro
 use bitcoin::blockdata::block::{Block, BlockHeader};
 
 use std::default::Default;
+use std::mem;
 
 use ln::functional_test_utils::*;
 
@@ -179,4 +180,132 @@ fn test_onchain_htlc_claim_reorg_remote_commitment() {
 #[test]
 fn test_onchain_htlc_timeout_delay_remote_commitment() {
 	do_test_onchain_htlc_reorg(false, false);
+}
+
+#[test]
+fn test_unconf_chan() {
+	// After creating a chan between nodes, we disconnect all blocks previously seen to force a channel close on nodes[0] side
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+	create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
+
+	let channel_state = nodes[0].node.channel_state.lock().unwrap();
+	assert_eq!(channel_state.by_id.len(), 1);
+	assert_eq!(channel_state.short_to_id.len(), 1);
+	mem::drop(channel_state);
+
+	let mut headers = Vec::new();
+	let mut header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	headers.push(header.clone());
+	for _i in 2..100 {
+		header = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+		headers.push(header.clone());
+	}
+	while !headers.is_empty() {
+		nodes[0].node.block_disconnected(&headers.pop().unwrap());
+	}
+	check_closed_broadcast!(nodes[0], false);
+	check_added_monitors!(nodes[0], 1);
+	let channel_state = nodes[0].node.channel_state.lock().unwrap();
+	assert_eq!(channel_state.by_id.len(), 0);
+	assert_eq!(channel_state.short_to_id.len(), 0);
+}
+
+#[test]
+fn test_set_outpoints_partial_claiming() {
+	// - remote party claim tx, new bump tx
+	// - disconnect remote claiming tx, new bump
+	// - disconnect tx, see no tx anymore
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 59000000, InitFeatures::known(), InitFeatures::known());
+	let payment_preimage_1 = route_payment(&nodes[1], &vec!(&nodes[0])[..], 3_000_000).0;
+	let payment_preimage_2 = route_payment(&nodes[1], &vec!(&nodes[0])[..], 3_000_000).0;
+
+	// Remote commitment txn with 4 outputs: to_local, to_remote, 2 outgoing HTLC
+	let remote_txn = get_local_commitment_txn!(nodes[1], chan.2);
+	assert_eq!(remote_txn.len(), 3);
+	assert_eq!(remote_txn[0].output.len(), 4);
+	assert_eq!(remote_txn[0].input.len(), 1);
+	assert_eq!(remote_txn[0].input[0].previous_output.txid, chan.3.txid());
+	check_spends!(remote_txn[1], remote_txn[0]);
+	check_spends!(remote_txn[2], remote_txn[0]);
+
+	// Connect blocks on node A to advance height towards TEST_FINAL_CLTV
+	let prev_header_100 = connect_blocks(&nodes[1], 100, 0, false, Default::default());
+	// Provide node A with both preimage
+	nodes[0].node.claim_funds(payment_preimage_1, &None, 3_000_000);
+	nodes[0].node.claim_funds(payment_preimage_2, &None, 3_000_000);
+	check_added_monitors!(nodes[0], 2);
+	nodes[0].node.get_and_clear_pending_events();
+	nodes[0].node.get_and_clear_pending_msg_events();
+
+	// Connect blocks on node A commitment transaction
+	let header = BlockHeader { version: 0x20000000, prev_blockhash: prev_header_100, merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	connect_block(&nodes[0], &Block { header, txdata: vec![remote_txn[0].clone()] }, 101);
+	check_closed_broadcast!(nodes[0], false);
+	check_added_monitors!(nodes[0], 1);
+	// Verify node A broadcast tx claiming both HTLCs
+	{
+		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		// ChannelMonitor: claim tx, ChannelManager: local commitment tx + HTLC-Success*2
+		assert_eq!(node_txn.len(), 4);
+		check_spends!(node_txn[0], remote_txn[0]);
+		check_spends!(node_txn[1], chan.3);
+		check_spends!(node_txn[2], node_txn[1]);
+		check_spends!(node_txn[3], node_txn[1]);
+		assert_eq!(node_txn[0].input.len(), 2);
+		node_txn.clear();
+	}
+
+	// Connect blocks on node B
+	connect_blocks(&nodes[1], 135, 0, false, Default::default());
+	check_closed_broadcast!(nodes[1], false);
+	check_added_monitors!(nodes[1], 1);
+	// Verify node B broadcast 2 HTLC-timeout txn
+	let partial_claim_tx = {
+		let node_txn = nodes[1].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 3);
+		check_spends!(node_txn[1], node_txn[0]);
+		check_spends!(node_txn[2], node_txn[0]);
+		assert_eq!(node_txn[1].input.len(), 1);
+		assert_eq!(node_txn[2].input.len(), 1);
+		node_txn[1].clone()
+	};
+
+	// Broadcast partial claim on node A, should regenerate a claiming tx with HTLC dropped
+	let header = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
+	connect_block(&nodes[0], &Block { header, txdata: vec![partial_claim_tx.clone()] }, 102);
+	{
+		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 1);
+		check_spends!(node_txn[0], remote_txn[0]);
+		assert_eq!(node_txn[0].input.len(), 1); //dropped HTLC
+		node_txn.clear();
+	}
+	nodes[0].node.get_and_clear_pending_msg_events();
+
+	// Disconnect last block on node A, should regenerate a claiming tx with HTLC dropped
+	disconnect_block(&nodes[0], &header, 102);
+	{
+		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 1);
+		check_spends!(node_txn[0], remote_txn[0]);
+		assert_eq!(node_txn[0].input.len(), 2); //resurrected HTLC
+		node_txn.clear();
+	}
+
+	//// Disconnect one more block and then reconnect multiple no transaction should be generated
+	disconnect_block(&nodes[0], &header, 101);
+	connect_blocks(&nodes[1], 15, 101, false, prev_header_100);
+	{
+		let mut node_txn = nodes[0].tx_broadcaster.txn_broadcasted.lock().unwrap();
+		assert_eq!(node_txn.len(), 0);
+		node_txn.clear();
+	}
 }

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -82,9 +82,12 @@ pub struct TestChainMonitor<'a> {
 	pub chain_monitor: chainmonitor::ChainMonitor<EnforcingSigner, &'a TestChainSource, &'a chaininterface::BroadcasterInterface, &'a TestFeeEstimator, &'a TestLogger, &'a channelmonitor::Persist<EnforcingSigner>>,
 	pub keys_manager: &'a TestKeysInterface,
 	pub update_ret: Mutex<Option<Result<(), channelmonitor::ChannelMonitorUpdateErr>>>,
-	// If this is set to Some(), after the next return, we'll always return this until update_ret
-	// is changed:
+	/// If this is set to Some(), after the next return, we'll always return this until update_ret
+	/// is changed:
 	pub next_update_ret: Mutex<Option<Result<(), channelmonitor::ChannelMonitorUpdateErr>>>,
+	/// If this is set to Some(), the next update_channel call (not watch_channel) must be a
+	/// ChannelForceClosed event for the given channel_id with should_broadcast set to the given
+	/// boolean.
 	pub expect_channel_force_closed: Mutex<Option<([u8; 32], bool)>>,
 }
 impl<'a> TestChainMonitor<'a> {


### PR DESCRIPTION
The instructions for `ChannelManagerReadArgs` indicate that you need
to connect blocks on a newly-deserialized `ChannelManager` in a
separate pass from the newly-deserialized `ChannelMontiors` as the
`ChannelManager` assumes the ability to update the monitors during
block [dis]connected events, saying that users need to:
```
4) Reconnect blocks on your ChannelMonitors
5) Move the ChannelMonitors into your local chain::Watch.
6) Disconnect/connect blocks on the ChannelManager.
```

This is fine for `ChannelManager`'s purpose, but is very awkward
for users. Notably, our new `lightning-block-sync` implemented
on-load reconnection in the most obvious (and performant) way -
connecting the blocks all at once, violating the
`ChannelManagerReadArgs` API.

Luckily, the events in question really don't need to be processed
with the same urgency as most channel monitor updates. The only two
monitor updates which can occur in block_[dis]connected is either
a) in block_connected, we identify a now-confirmed commitment
   transaction, closing one of our channels, or
b) in block_disconnected, the funding transaction is reorganized
   out of the chain, making our channel no longer funded.
In the case of (a), sending a monitor update which broadcasts a
conflicting holder commitment transaction is far from
time-critical, though we should still ensure we do it. In the case
of (b), we should try to broadcast our holder commitment transaction
when we can, but within a few minutes is fine on the scale of
block mining anyway.

Note that in both cases cannot simply move the logic to
ChannelMonitor::block[dis]_connected, as this could result in us
broadcasting a commitment transaction from ChannelMonitor, then
revoking the now-broadcasted state, and only then receiving the
block_[dis]connected event in the ChannelManager.

Thus, we move both events into an internal invent queue and process
them in timer_chan_freshness_every_min().


Plus a few random commits I had lying around that are nice to include. I need to fix one bug in deserialization and add a test for it, but otherwise this should be good.
