### PR TITLE
Track full-path htlc-minimum-msat while routing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,11 @@ jobs:
             echo "Bad hash"
             exit 1
           fi
+      - name: Test with Network Graph on Rust ${{ matrix.toolchain }}
+        run: |
+          cd lightning
+          RUSTFLAGS="--cfg=require_route_graph_test" cargo test
+          cd ..
       - name: Run benchmarks on Rust ${{ matrix.toolchain }}
         run: |
           cd lightning

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -979,11 +979,6 @@ pub fn get_route<L: Deref>(our_node_id: &PublicKey, network: &NetworkGraph, paye
 					let mut spent_on_hop_msat = value_contribution_msat;
 					let next_hops_fee_msat = payment_hop.next_hops_fee_msat;
 					spent_on_hop_msat += next_hops_fee_msat;
-					if *channel_liquidity_available_msat < spent_on_hop_msat {
-						// This should not happen because we do recompute fees right before,
-						// trying to avoid cases when a hop is not usable due to the fee situation.
-						break 'path_construction;
-					}
 					if spent_on_hop_msat == *channel_liquidity_available_msat {
 						// If this path used all of this channel's available liquidity, we know
 						// this path will not be selected again in the next loop iteration.


### PR DESCRIPTION
To review new changes to #646, I wrote an extension of the router fuzzer to test each route against the graph available. This found one non-regression which is fixed here, as well as the fuzzer extension and a fix to make the router fuzz target deterministic.

It needs a) a test, b) a long discussion in `get_route` about how our algorithm ultimately differs from Dijkstra's/A*, why that's ok, and some edge cases where other algorithms may be more optimal.