### PR TITLE
Add rpc sync method

### DIFF
--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -11,6 +11,9 @@ Utilities to fetch the chain data from a block source and feed them into Rust Li
 [features]
 rest-client = [ "serde", "serde_json", "chunked_transfer" ]
 rpc-client = [ "serde", "serde_json", "chunked_transfer" ]
+generic-rpc-client = [ "tokio" ]
+generic-rest-client = [ "tokio" ]
+tokio-runtime = [ "tokio" ]
 
 [dependencies]
 bitcoin = "0.26"

--- a/lightning-block-sync/Cargo.toml
+++ b/lightning-block-sync/Cargo.toml
@@ -15,7 +15,7 @@ rpc-client = [ "serde", "serde_json", "chunked_transfer" ]
 [dependencies]
 bitcoin = "0.26"
 lightning = { version = "0.0.12", path = "../lightning" }
-tokio = { version = "1.0", features = [ "io-util", "net" ], optional = true }
+tokio = { version = "1.0", features = [ "io-util", "net", "rt-multi-thread" ], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 chunked_transfer = { version = "1.4", optional = true }

--- a/lightning-block-sync/src/convert.rs
+++ b/lightning-block-sync/src/convert.rs
@@ -156,6 +156,15 @@ impl TryInto<(BlockHash, Option<u32>)> for JsonResponse {
 	}
 }
 
+/// Returns the raw serde_json::Value.
+impl TryInto<serde_json::Value> for JsonResponse {
+	type Error = std::io::Error;
+
+	fn try_into(self) -> std::io::Result<serde_json::Value> {
+		Ok(self.0)
+	}
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
 	use super::*;

--- a/lightning-block-sync/src/rest.rs
+++ b/lightning-block-sync/src/rest.rs
@@ -8,6 +8,9 @@ use bitcoin::hashes::hex::ToHex;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 
+#[cfg(feature = "generic-rest-client")]
+use tokio::runtime::Runtime;
+
 /// A simple REST client for requesting resources using HTTP `GET`.
 pub struct RestClient {
 	endpoint: HttpEndpoint,
@@ -21,6 +24,13 @@ impl RestClient {
 	pub fn new(endpoint: HttpEndpoint) -> std::io::Result<Self> {
 		let client = HttpClient::connect(&endpoint)?;
 		Ok(Self { endpoint, client })
+	}
+
+	#[cfg(feature = "generic-rest-client")]
+	/// Requests a resource synchronously with the response encoded in JSON format.
+	pub fn request(&mut self, resource_path: &str) -> std::io::Result<serde_json::Value> {
+		let runtime = Runtime::new().expect("Unable to create a runtime");
+		runtime.block_on(self.request_resource::<serde_json::Value>(resource_path))
 	}
 
 	/// Requests a resource encoded in `F` format and interpreted as type `T`.

--- a/lightning-block-sync/src/rpc.rs
+++ b/lightning-block-sync/src/rpc.rs
@@ -10,7 +10,7 @@ use serde_json;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicUsize, Ordering};
-// #[cfg(feature = "tokio")]
+#[cfg(feature = "generic-rpc-client")]
 use tokio::runtime::Runtime;
 
 /// A simple RPC client for calling methods using HTTP `POST`.
@@ -36,6 +36,7 @@ impl RpcClient {
 	}
 
 	/// Calls a method synchronously with the response encoded in JSON format.
+	#[cfg(feature = "generic-rpc-client")]
 	pub fn call_method(&mut self, method: &str, params: &[serde_json::Value]) ->
 		std::io::Result<serde_json::Value>
 	{

--- a/lightning-block-sync/src/rpc.rs
+++ b/lightning-block-sync/src/rpc.rs
@@ -10,6 +10,8 @@ use serde_json;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::sync::atomic::{AtomicUsize, Ordering};
+// #[cfg(feature = "tokio")]
+use tokio::runtime::Runtime;
 
 /// A simple RPC client for calling methods using HTTP `POST`.
 pub struct RpcClient {
@@ -31,6 +33,14 @@ impl RpcClient {
 			client,
 			id: AtomicUsize::new(0),
 		})
+	}
+
+	/// Calls a method synchronously with the response encoded in JSON format.
+	pub fn call_method(&mut self, method: &str, params: &[serde_json::Value]) ->
+		std::io::Result<serde_json::Value>
+	{
+		let runtime = Runtime::new().expect("Unable to create a runtime");
+		runtime.block_on(self.call_method_async::<serde_json::Value>(method, params))
 	}
 
 	/// Calls a method with the response encoded in JSON format and interpreted as type `T`.


### PR DESCRIPTION
Adds a synchronous `call_method` to the RPC client.

Not in the greatest shape atm.