### PR TITLE
Expose RpcClient and RestClient interfaces as pub

### DIFF
--- a/lightning-block-sync/src/http.rs
+++ b/lightning-block-sync/src/http.rs
@@ -399,10 +399,10 @@ enum HttpMessageLength {
 }
 
 /// An HTTP response body in binary format.
-pub(crate) struct BinaryResponse(pub(crate) Vec<u8>);
+pub struct BinaryResponse(pub Vec<u8>);
 
 /// An HTTP response body in JSON format.
-pub(crate) struct JsonResponse(pub(crate) serde_json::Value);
+pub struct JsonResponse(pub serde_json::Value);
 
 /// Interprets bytes from an HTTP response body as binary data.
 impl TryFrom<Vec<u8>> for BinaryResponse {

--- a/lightning-block-sync/src/rest.rs
+++ b/lightning-block-sync/src/rest.rs
@@ -24,7 +24,7 @@ impl RestClient {
 	}
 
 	/// Requests a resource encoded in `F` format and interpreted as type `T`.
-	async fn request_resource<F, T>(&mut self, resource_path: &str) -> std::io::Result<T>
+	pub async fn request_resource<F, T>(&mut self, resource_path: &str) -> std::io::Result<T>
 	where F: TryFrom<Vec<u8>, Error = std::io::Error> + TryInto<T, Error = std::io::Error> {
 		let host = format!("{}:{}", self.endpoint.host(), self.endpoint.port());
 		let uri = format!("{}/{}", self.endpoint.path().trim_end_matches("/"), resource_path);

--- a/lightning-block-sync/src/rpc.rs
+++ b/lightning-block-sync/src/rpc.rs
@@ -34,7 +34,7 @@ impl RpcClient {
 	}
 
 	/// Calls a method with the response encoded in JSON format and interpreted as type `T`.
-	async fn call_method<T>(&mut self, method: &str, params: &[serde_json::Value]) -> std::io::Result<T>
+	pub async fn call_method<T>(&mut self, method: &str, params: &[serde_json::Value]) -> std::io::Result<T>
 	where JsonResponse: TryFrom<Vec<u8>, Error = std::io::Error> + TryInto<T, Error = std::io::Error> {
 		let host = format!("{}:{}", self.endpoint.host(), self.endpoint.port());
 		let uri = self.endpoint.path();


### PR DESCRIPTION
Useful for use outside of the BlockSource context, e.g., when implementing fee estimation or transaction broadcasting.