### PR TITLE
Handle query_channel_range gossip queries

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -37,6 +37,7 @@ use util::ser::{Readable, ReadableArgs, Writeable, Writer, VecWriter};
 use util::logger::Logger;
 use util::errors::APIError;
 use util::config::{UserConfig,ChannelConfig};
+use util::scid_utils::scid_from_parts;
 
 use std;
 use std::default::Default;
@@ -3556,14 +3557,11 @@ impl<Signer: Sign> Channel<Signer> {
 								}
 							}
 						}
-						if height > 0xff_ff_ff || (index_in_block) > 0xff_ff_ff {
-							panic!("Block was bogus - either height 16 million or had > 16 million transactions");
-						}
-						assert!(txo_idx <= 0xffff); // txo_idx is a (u16 as usize), so this is just listed here for completeness
 						self.funding_tx_confirmations = 1;
-						self.short_channel_id = Some(((height as u64)         << (5*8)) |
-						                             ((index_in_block as u64) << (2*8)) |
-						                             ((txo_idx as u64)        << (0*8)));
+						self.short_channel_id = match scid_from_parts(height as u64, index_in_block as u64, txo_idx as u64) {
+							Ok(scid) => Some(scid),
+							Err(_) => panic!("Block was bogus - either height was > 16 million, had > 16 million transactions, or had > 65k outputs"),
+						}
 					}
 				}
 			}

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3499,6 +3499,7 @@ impl<Signer: Sign, M: Deref + Sync + Send, T: Deref + Sync + Send, K: Deref + Sy
 					&events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => true,
 					&events::MessageSendEvent::SendChannelRangeQuery { .. } => false,
 					&events::MessageSendEvent::SendShortIdsQuery { .. } => false,
+					&events::MessageSendEvent::SendReplyChannelRange { .. } => false,
 				}
 			});
 		}

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -1690,7 +1690,7 @@ impl QueryChannelRange {
 	pub fn end_blocknum(&self) -> u32 {
 		match self.first_blocknum.checked_add(self.number_of_blocks) {
 			Some(block) => block,
-			None => 0xffffffff,
+			None => u32::max_value(),
 		}
 	}
 }

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1281,6 +1281,17 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref> PeerManager<D
 						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg)));
 						self.do_attempt_write_data(&mut descriptor, peer);
 					}
+					MessageSendEvent::SendReplyChannelRange { ref node_id, ref msg } => {
+						log_trace!(self.logger, "Handling SendReplyChannelRange event in peer_handler for node {} with num_scids={} first_blocknum={} number_of_blocks={}, sync_complete={}",
+							log_pubkey!(node_id),
+							msg.short_channel_ids.len(),
+							msg.first_blocknum,
+							msg.number_of_blocks,
+							msg.sync_complete);
+						let (mut descriptor, peer) = get_peer_for_forwarding!(node_id, {});
+						peer.pending_outbound_buffer.push_back(peer.channel_encryptor.encrypt_message(&encode_msg!(msg)));
+						self.do_attempt_write_data(&mut descriptor, peer);
+					}
 				}
 			}
 

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -30,7 +30,7 @@ use ln::msgs;
 use util::ser::{Writeable, Readable, Writer};
 use util::logger::Logger;
 use util::events::{MessageSendEvent, MessageSendEventsProvider};
-use util::scid_utils::{block_from_scid, scid_from_parts};
+use util::scid_utils::{block_from_scid, scid_from_parts, MAX_SCID_BLOCK};
 
 use std::{cmp, fmt};
 use std::sync::{RwLock, RwLockReadGuard};
@@ -329,11 +329,11 @@ impl<C: Deref + Sync + Send, L: Deref + Sync + Send> RoutingMessageHandler for N
 
 		let network_graph = self.network_graph.read().unwrap();
 
-		let start_scid = scid_from_parts(msg.first_blocknum, 0, 0);
+		let start_scid = scid_from_parts(msg.first_blocknum as u64, 0, 0);
 
 		// We receive valid queries with end_blocknum that would overflow SCID conversion.
 		// Manually cap the ending block to avoid this overflow.
-		let exclusive_end_scid = scid_from_parts(cmp::min(msg.end_blocknum(), 0xffffff), 0, 0);
+		let exclusive_end_scid = scid_from_parts(cmp::min(msg.end_blocknum() as u64, MAX_SCID_BLOCK), 0, 0);
 
 		// Per spec, we must reply to a query. Send an empty message when things are invalid.
 		if msg.chain_hash != network_graph.genesis_hash || start_scid.is_err() || exclusive_end_scid.is_err() {

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -369,9 +369,8 @@ impl<C: Deref + Sync + Send, L: Deref + Sync + Send> RoutingMessageHandler for N
 		drop(network_graph);
 
 		let mut pending_events = self.pending_events.lock().unwrap();
-		let mut batch_index = 0;
 		let batch_count = batches.len();
-		for batch in batches.into_iter() {
+		for (batch_index, batch) in batches.into_iter().enumerate() {
 			// Per spec, the initial first_blocknum needs to be <= the query's first_blocknum.
 			// Use the query's values since we don't use pre-processed reply ranges.
 			let first_blocknum = if batch_index == 0 {
@@ -409,8 +408,6 @@ impl<C: Deref + Sync + Send, L: Deref + Sync + Send> RoutingMessageHandler for N
 					short_channel_ids: batch,
 				}
 			});
-
-			batch_index += 1;
 		}
 
 		Ok(())

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -30,6 +30,7 @@ use ln::msgs;
 use util::ser::{Writeable, Readable, Writer};
 use util::logger::Logger;
 use util::events::{MessageSendEvent, MessageSendEventsProvider};
+use util::scid_utils::{block_from_scid, scid_from_parts};
 
 use std::{cmp, fmt};
 use std::sync::{RwLock, RwLockReadGuard};
@@ -70,6 +71,11 @@ pub struct NetGraphMsgHandler<C: Deref, L: Deref> where C::Target: chain::Access
 	full_syncs_requested: AtomicUsize,
 	pending_events: Mutex<Vec<MessageSendEvent>>,
 	logger: L,
+
+	/// Maximum number of short_channel_ids that will be encoded in one gossip reply message.
+	/// Default is 8000 which ensures a reply fits within the 65k payload limit and is
+	/// consistent with other implementations.
+	max_reply_scids: usize,
 }
 
 impl<C: Deref, L: Deref> NetGraphMsgHandler<C, L> where C::Target: chain::Access, L::Target: Logger {
@@ -86,6 +92,7 @@ impl<C: Deref, L: Deref> NetGraphMsgHandler<C, L> where C::Target: chain::Access
 			chain_access,
 			pending_events: Mutex::new(vec![]),
 			logger,
+			max_reply_scids: 8000,
 		}
 	}
 
@@ -99,6 +106,7 @@ impl<C: Deref, L: Deref> NetGraphMsgHandler<C, L> where C::Target: chain::Access
 			chain_access,
 			pending_events: Mutex::new(vec![]),
 			logger,
+			max_reply_scids: 8000,
 		}
 	}
 
@@ -312,12 +320,100 @@ impl<C: Deref + Sync + Send, L: Deref + Sync + Send> RoutingMessageHandler for N
 		Ok(())
 	}
 
-	fn handle_query_channel_range(&self, _their_node_id: &PublicKey, _msg: QueryChannelRange) -> Result<(), LightningError> {
-		// TODO
-		Err(LightningError {
-			err: String::from("Not implemented"),
-			action: ErrorAction::IgnoreError,
-		})
+	/// Processes a query from a peer by finding channels whose funding UTXOs
+	/// are in the specified block range. Due to message size limits, large range
+	/// queries may result in several reply messages. This implementation enqueues
+	/// all reply messages into pending events.
+	fn handle_query_channel_range(&self, their_node_id: &PublicKey, msg: QueryChannelRange) -> Result<(), LightningError> {
+		log_debug!(self.logger, "Handling query_channel_range peer={}, first_blocknum={}, number_of_blocks={}", log_pubkey!(their_node_id), msg.first_blocknum, msg.number_of_blocks);
+
+		let network_graph = self.network_graph.read().unwrap();
+
+		let start_scid = scid_from_parts(msg.first_blocknum, 0, 0);
+
+		// We receive valid queries with end_blocknum that would overflow SCID conversion.
+		// Manually cap the ending block to avoid this overflow.
+		let exclusive_end_scid = scid_from_parts(cmp::min(msg.end_blocknum(), 0xffffff), 0, 0);
+
+		// Per spec, we must reply to a query. Send an empty message when things are invalid.
+		if msg.chain_hash != network_graph.genesis_hash || start_scid.is_err() || exclusive_end_scid.is_err() {
+			let mut pending_events = self.pending_events.lock().unwrap();
+			pending_events.push(MessageSendEvent::SendReplyChannelRange {
+				node_id: their_node_id.clone(),
+				msg: ReplyChannelRange {
+					chain_hash: msg.chain_hash.clone(),
+					first_blocknum: msg.first_blocknum,
+					number_of_blocks: msg.number_of_blocks,
+					sync_complete: true,
+					short_channel_ids: vec![],
+				}
+			});
+			return Ok(());
+		}
+
+		// Creates channel batches. We are not checking if the channel is routable
+		// (has at least one update). A peer may still want to know the channel
+		// exists even if its not yet routable.
+		let mut batches: Vec<Vec<u64>> = vec![Vec::with_capacity(self.max_reply_scids)];
+		for (_, ref chan) in network_graph.get_channels().range(start_scid.unwrap()..exclusive_end_scid.unwrap()) {
+			if let Some(chan_announcement) = &chan.announcement_message {
+				// Construct a new batch if last one is full
+				if batches.last().unwrap().len() == batches.last().unwrap().capacity() {
+					batches.push(Vec::with_capacity(self.max_reply_scids));
+				}
+
+				let batch = batches.last_mut().unwrap();
+				batch.push(chan_announcement.contents.short_channel_id);
+			}
+		}
+		drop(network_graph);
+
+		let mut pending_events = self.pending_events.lock().unwrap();
+		let mut batch_index = 0;
+		let batch_count = batches.len();
+		for batch in batches.into_iter() {
+			// Per spec, the initial first_blocknum needs to be <= the query's first_blocknum.
+			// Use the query's values since we don't use pre-processed reply ranges.
+			let first_blocknum = if batch_index == 0 {
+				msg.first_blocknum
+			}
+			// Subsequent replies must be >= the last sent first_blocknum. Use the first block
+			// in the new batch.
+			else {
+				block_from_scid(batch.first().unwrap())
+			};
+
+			// Per spec, the last end_block needs to be >= the query's end_block. Last
+			// reply calculates difference between the query's end_blocknum and the start of the reply.
+			// Overflow safe since end_blocknum=msg.first_block_num+msg.number_of_blocks and first_blocknum
+			// will be either msg.first_blocknum or a higher block height.
+			let number_of_blocks = if batch_index == batch_count-1 {
+				msg.end_blocknum() - first_blocknum
+			}
+			// Prior replies should use the number of blocks that fit into the reply. Overflow
+			// safe since first_blocknum is always <= last SCID's block.
+			else {
+				block_from_scid(batch.last().unwrap()) - first_blocknum + 1
+			};
+
+			// Only true for the last message in a sequence
+			let sync_complete = batch_index == batch_count - 1;
+
+			pending_events.push(MessageSendEvent::SendReplyChannelRange {
+				node_id: their_node_id.clone(),
+				msg: ReplyChannelRange {
+					chain_hash: msg.chain_hash.clone(),
+					first_blocknum,
+					number_of_blocks,
+					sync_complete,
+					short_channel_ids: batch,
+				}
+			});
+
+			batch_index += 1;
+		}
+
+		Ok(())
 	}
 
 	fn handle_query_short_channel_ids(&self, _their_node_id: &PublicKey, _msg: QueryShortChannelIds) -> Result<(), LightningError> {
@@ -2088,18 +2184,351 @@ mod tests {
 
 	#[test]
 	fn handling_query_channel_range() {
-		let (secp_ctx, net_graph_msg_handler) = create_net_graph_msg_handler();
-		let node_privkey = &SecretKey::from_slice(&[41; 32]).unwrap();
-		let node_id = PublicKey::from_secret_key(&secp_ctx, node_privkey);
+		let (secp_ctx, mut net_graph_msg_handler) = create_net_graph_msg_handler();
 
 		let chain_hash = genesis_block(Network::Testnet).header.block_hash();
+		let node_1_privkey = &SecretKey::from_slice(&[42; 32]).unwrap();
+		let node_2_privkey = &SecretKey::from_slice(&[41; 32]).unwrap();
+		let node_1_btckey = &SecretKey::from_slice(&[40; 32]).unwrap();
+		let node_2_btckey = &SecretKey::from_slice(&[39; 32]).unwrap();
+		let node_id_1 = PublicKey::from_secret_key(&secp_ctx, node_1_privkey);
+		let node_id_2 = PublicKey::from_secret_key(&secp_ctx, node_2_privkey);
+		let bitcoin_key_1 = PublicKey::from_secret_key(&secp_ctx, node_1_btckey);
+		let bitcoin_key_2 = PublicKey::from_secret_key(&secp_ctx, node_2_btckey);
 
-		let result = net_graph_msg_handler.handle_query_channel_range(&node_id, QueryChannelRange {
-			chain_hash,
-			first_blocknum: 0,
-			number_of_blocks: 0xffff_ffff,
-		});
-		assert!(result.is_err());
+		let scids: Vec<u64> = vec![
+			0x000000_000000_0000, // 0x0x0
+			0x000001_000000_0000, // 1x0x0
+			0x000002_000000_0000, // 2x0x0
+			0x000002_000001_0000, // 2x1x0
+			0x000100_000000_0000, // 256x0x0
+			0x000101_000000_0000, // 257x0x0
+			0xfffffe_ffffff_ffff, // max
+			0xffffff_ffffff_ffff, // never
+		];
+
+		for scid in scids {
+			let unsigned_announcement = UnsignedChannelAnnouncement {
+				features: ChannelFeatures::known(),
+				chain_hash: chain_hash.clone(),
+				short_channel_id: scid,
+				node_id_1,
+				node_id_2,
+				bitcoin_key_1,
+				bitcoin_key_2,
+				excess_data: Vec::new(),
+			};
+
+			let msghash = hash_to_message!(&Sha256dHash::hash(&unsigned_announcement.encode()[..])[..]);
+			let valid_announcement = ChannelAnnouncement {
+				node_signature_1: secp_ctx.sign(&msghash, node_1_privkey),
+				node_signature_2: secp_ctx.sign(&msghash, node_2_privkey),
+				bitcoin_signature_1: secp_ctx.sign(&msghash, node_1_btckey),
+				bitcoin_signature_2: secp_ctx.sign(&msghash, node_2_btckey),
+				contents: unsigned_announcement.clone(),
+			};
+			match net_graph_msg_handler.handle_channel_announcement(&valid_announcement) {
+				Ok(_) => (),
+				_ => panic!()
+			};
+		}
+
+		// Empty reply when number_of_blocks=0
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0,
+				number_of_blocks: 0,
+			},
+			vec![ReplyChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0,
+				number_of_blocks: 0,
+				sync_complete: true,
+				short_channel_ids: vec![]
+			}]
+		);
+
+		// Empty when wrong chain
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: genesis_block(Network::Bitcoin).header.block_hash(),
+				first_blocknum: 0,
+				number_of_blocks: 0xffff_ffff,
+			},
+			vec![ReplyChannelRange {
+				chain_hash: genesis_block(Network::Bitcoin).header.block_hash(),
+				first_blocknum: 0,
+				number_of_blocks: 0xffff_ffff,
+				sync_complete: true,
+				short_channel_ids: vec![],
+			}]
+		);
+
+		// Empty reply when first_blocknum > 0xffffff
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0x01000000,
+				number_of_blocks: 0xffffffff,
+			},
+			vec![ReplyChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0x01000000,
+				number_of_blocks: 0xffffffff,
+				sync_complete: true,
+				short_channel_ids: vec![]
+			}]
+		);
+
+		// Empty reply when max valid SCID block num.
+		// Unlike prior test this is a valid but no results are found
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0xffffff,
+				number_of_blocks: 1,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 0xffffff,
+					number_of_blocks: 1,
+					sync_complete: true,
+					short_channel_ids: vec![]
+				},
+			]
+		);
+
+		// No results in valid query range
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0x00100000,
+				number_of_blocks: 1000,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 0x00100000,
+					number_of_blocks: 1000,
+					sync_complete: true,
+					short_channel_ids: vec![],
+				}
+			]
+		);
+
+		// Single reply - all blocks
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0,
+				number_of_blocks: 0xffffffff,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 0,
+					number_of_blocks: 0xffffffff,
+					sync_complete: true,
+					short_channel_ids: vec![
+						0x000000_000000_0000, // 0x0x0
+						0x000001_000000_0000, // 1x0x0
+						0x000002_000000_0000, // 2x0x0
+						0x000002_000001_0000, // 2x1x0
+						0x000100_000000_0000, // 256x0x0
+						0x000101_000000_0000, // 257x0x0
+						0xfffffe_ffffff_ffff, // max
+					]
+				}
+			]
+		);
+
+		// Single reply - overflow of first_blocknum + number_of_blocks
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 1,
+				number_of_blocks: 0xffffffff,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 1,
+					number_of_blocks: 0xfffffffe,
+					sync_complete: true,
+					short_channel_ids: vec![
+						0x000001_000000_0000, // 1x0x0
+						0x000002_000000_0000, // 2x0x0
+						0x000002_000001_0000, // 2x1x0
+						0x000100_000000_0000, // 256x0x0
+						0x000101_000000_0000, // 257x0x0
+						0xfffffe_ffffff_ffff, // max
+					]
+				}
+			]
+		);
+
+		// Single reply - query larger than found results
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 100,
+				number_of_blocks: 1000,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 100,
+					number_of_blocks: 1000,
+					sync_complete: true,
+					short_channel_ids: vec![
+						0x000100_000000_0000, // 256x0x0
+						0x000101_000000_0000, // 257x0x0
+					]
+				}
+			]
+		);
+
+		// Tests below here will chunk replies
+		net_graph_msg_handler.max_reply_scids = 1;
+
+		// Multipart - new block per messages
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 0,
+				number_of_blocks: 2,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 0,
+					number_of_blocks: 1,
+					sync_complete: false,
+					short_channel_ids: vec![
+						0x000000_000000_0000, // 0x0x0
+					]
+				},
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 1,
+					number_of_blocks: 1,
+					sync_complete: true,
+					short_channel_ids: vec![
+						0x000001_000000_0000, // 1x0x0
+					]
+				},
+			]
+		);
+
+		// Multiplart - resumption of same block
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 2,
+				number_of_blocks: 1,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 2,
+					number_of_blocks: 1,
+					sync_complete: false,
+					short_channel_ids: vec![
+						0x000002_000000_0000, // 2x0x0
+					]
+				},
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 2,
+					number_of_blocks: 1,
+					sync_complete: true,
+					short_channel_ids: vec![
+						0x000002_000001_0000, // 2x1x0
+					]
+				}
+			]
+		);
+
+		// Multipart - query larger than found results, similar to single reply
+		test_handling_query_channel_range(
+			&net_graph_msg_handler,
+			&node_id_2,
+			QueryChannelRange {
+				chain_hash: chain_hash.clone(),
+				first_blocknum: 100,
+				number_of_blocks: 1000,
+			},
+			vec![
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 100,	// <=  query first_blocknum
+					number_of_blocks: 157,
+					sync_complete: false,
+					short_channel_ids: vec![
+						0x000100_000000_0000, // 256x0x0
+					]
+				},
+				ReplyChannelRange {
+					chain_hash: chain_hash.clone(),
+					first_blocknum: 257,
+					number_of_blocks: 843, // >= query first_blocknum+number_of_blocks
+					sync_complete: true,
+					short_channel_ids: vec![
+						0x000101_000000_0000, // 257x0x0
+					]
+				}
+			]
+		);
+	}
+
+	fn test_handling_query_channel_range(
+		net_graph_msg_handler: &NetGraphMsgHandler<Arc<test_utils::TestChainSource>, Arc<test_utils::TestLogger>>,
+		test_node_id: &PublicKey,
+		msg: QueryChannelRange,
+		expected_replies: Vec<ReplyChannelRange>
+	) {
+		let result = net_graph_msg_handler.handle_query_channel_range(test_node_id, msg);
+		assert!(result.is_ok());
+
+		let events = net_graph_msg_handler.get_and_clear_pending_msg_events();
+		assert_eq!(events.len(), expected_replies.len());
+
+		for i in 0..events.len() {
+			let expected_reply = &expected_replies[i];
+			match &events[i] {
+				MessageSendEvent::SendReplyChannelRange { node_id, msg } => {
+					assert_eq!(node_id, test_node_id);
+					assert_eq!(msg.chain_hash, expected_reply.chain_hash);
+					assert_eq!(msg.first_blocknum, expected_reply.first_blocknum);
+					assert_eq!(msg.number_of_blocks, expected_reply.number_of_blocks);
+					assert_eq!(msg.sync_complete, expected_reply.sync_complete);
+					assert_eq!(msg.short_channel_ids, expected_reply.short_channel_ids);
+				},
+				_ => panic!("expected MessageSendEvent::SendReplyChannelRange"),
+			}
+		}
 	}
 
 	#[test]

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -362,7 +362,7 @@ pub enum MessageSendEvent {
 		/// The query_short_channel_ids which should be sent.
 		msg: msgs::QueryShortChannelIds,
 	},
-	/// Sends a reply to a channel range query. This may be one of several events
+	/// Sends a reply to a channel range query. This may be one of several SendReplyChannelRange events
 	/// emitted during processing of the query.
 	SendReplyChannelRange {
 		/// The node_id of this message recipient

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -362,6 +362,14 @@ pub enum MessageSendEvent {
 		/// The query_short_channel_ids which should be sent.
 		msg: msgs::QueryShortChannelIds,
 	},
+	/// Sends a reply to a channel range query. This may be one of several events
+	/// emitted during processing of the query.
+	SendReplyChannelRange {
+		/// The node_id of this message recipient
+		node_id: PublicKey,
+		/// The reply_channel_range which should be sent.
+		msg: msgs::ReplyChannelRange,
+	}
 }
 
 /// A trait indicating an object may generate message send events

--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod chacha20;
 pub(crate) mod poly1305;
 pub(crate) mod chacha20poly1305rfc;
 pub(crate) mod transaction_utils;
+pub(crate) mod scid_utils;
 
 #[macro_use]
 pub(crate) mod ser_macros;

--- a/lightning/src/util/scid_utils.rs
+++ b/lightning/src/util/scid_utils.rs
@@ -1,0 +1,60 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+/// A `short_channel_id` construction error
+#[derive(Debug, PartialEq)]
+pub enum ShortChannelIdError {
+	BlockOverflow,
+	TxIndexOverflow,
+}
+
+/// Extracts the block height (most significant 3-bytes) from the `short_channel_id`
+#[allow(dead_code)]
+pub fn block_from_scid(short_channel_id: &u64) -> u32 {
+	return (short_channel_id >> 40) as u32;
+}
+
+/// Constructs a `short_channel_id` using the components pieces. Results in an error
+/// if the block height or tx index overflow the 3-bytes for each component.
+#[allow(dead_code)]
+pub fn scid_from_parts(block: u32, tx_index: u32, vout_index: u16) -> Result<u64, ShortChannelIdError> {
+	if block > 0x00ffffff {
+		return Err(ShortChannelIdError::BlockOverflow);
+	}
+
+	if	tx_index > 0x00ffffff {
+		return Err(ShortChannelIdError::TxIndexOverflow);
+	}
+
+	Ok(((block as u64) << 40) | ((tx_index as u64) << 16) | (vout_index as u64))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_block_from_scid() {
+		assert_eq!(block_from_scid(&0x000000_000000_0000), 0);
+		assert_eq!(block_from_scid(&0x000001_000000_0000), 1);
+		assert_eq!(block_from_scid(&0x000001_ffffff_ffff), 1);
+		assert_eq!(block_from_scid(&0x800000_ffffff_ffff), 0x800000);
+		assert_eq!(block_from_scid(&0xffffff_ffffff_ffff), 0xffffff);
+	}
+
+	#[test]
+	fn test_scid_from_parts() {
+		assert_eq!(scid_from_parts(0x00000000, 0x00000000, 0x0000).unwrap(), 0x000000_000000_0000);
+		assert_eq!(scid_from_parts(0x00000001, 0x00000002, 0x0003).unwrap(), 0x000001_000002_0003);
+		assert_eq!(scid_from_parts(0x00111111, 0x00222222, 0x3333).unwrap(), 0x111111_222222_3333);
+		assert_eq!(scid_from_parts(0x00ffffff, 0x00ffffff, 0xffff).unwrap(), 0xffffff_ffffff_ffff);
+		assert_eq!(scid_from_parts(0x01ffffff, 0x00000000, 0x0000).err().unwrap(), ShortChannelIdError::BlockOverflow);
+		assert_eq!(scid_from_parts(0x00000000, 0x01ffffff, 0x0000).err().unwrap(), ShortChannelIdError::TxIndexOverflow);
+	}
+}

--- a/lightning/src/util/scid_utils.rs
+++ b/lightning/src/util/scid_utils.rs
@@ -7,32 +7,47 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+/// Maximum block height that can be used in a `short_channel_id`. This
+/// value is based on the 3-bytes available for block height.
+pub const MAX_SCID_BLOCK: u64 = 0x00ffffff;
+
+/// Maximum transaction index that can be used in a `short_channel_id`.
+/// This value is based on the 3-bytes available for tx index.
+pub const MAX_SCID_TX_INDEX: u64 = 0x00ffffff;
+
+/// Maximum vout index that can be used in a `short_channel_id`. This
+/// value is based on the 2-bytes available for the vout index.
+pub const MAX_SCID_VOUT_INDEX: u64 = 0xffff;
+
 /// A `short_channel_id` construction error
 #[derive(Debug, PartialEq)]
 pub enum ShortChannelIdError {
 	BlockOverflow,
 	TxIndexOverflow,
+	VoutIndexOverflow,
 }
 
 /// Extracts the block height (most significant 3-bytes) from the `short_channel_id`
-#[allow(dead_code)]
 pub fn block_from_scid(short_channel_id: &u64) -> u32 {
 	return (short_channel_id >> 40) as u32;
 }
 
 /// Constructs a `short_channel_id` using the components pieces. Results in an error
-/// if the block height or tx index overflow the 3-bytes for each component.
-#[allow(dead_code)]
-pub fn scid_from_parts(block: u32, tx_index: u32, vout_index: u16) -> Result<u64, ShortChannelIdError> {
-	if block > 0x00ffffff {
+/// if the block height, tx index, or vout index overflow the maximum sizes.
+pub fn scid_from_parts(block: u64, tx_index: u64, vout_index: u64) -> Result<u64, ShortChannelIdError> {
+	if block > MAX_SCID_BLOCK {
 		return Err(ShortChannelIdError::BlockOverflow);
 	}
 
-	if	tx_index > 0x00ffffff {
+	if tx_index > MAX_SCID_TX_INDEX {
 		return Err(ShortChannelIdError::TxIndexOverflow);
 	}
 
-	Ok(((block as u64) << 40) | ((tx_index as u64) << 16) | (vout_index as u64))
+	if vout_index > MAX_SCID_VOUT_INDEX {
+		return Err(ShortChannelIdError::VoutIndexOverflow);
+	}
+
+	Ok((block << 40) | (tx_index << 16) | vout_index)
 }
 
 #[cfg(test)]
@@ -56,5 +71,6 @@ mod tests {
 		assert_eq!(scid_from_parts(0x00ffffff, 0x00ffffff, 0xffff).unwrap(), 0xffffff_ffffff_ffff);
 		assert_eq!(scid_from_parts(0x01ffffff, 0x00000000, 0x0000).err().unwrap(), ShortChannelIdError::BlockOverflow);
 		assert_eq!(scid_from_parts(0x00000000, 0x01ffffff, 0x0000).err().unwrap(), ShortChannelIdError::TxIndexOverflow);
+		assert_eq!(scid_from_parts(0x00000000, 0x00000000, 0x010000).err().unwrap(), ShortChannelIdError::VoutIndexOverflow);
 	}
 }


### PR DESCRIPTION
Finally back in the saddle on this. This PR implements the `NetGraphMsgHandler` method for processing inbound `query_channel_range` messages. I'm working on another PR to handle `query_short_channel_ids` as well.

Notes:

- This implementation enqueues each reply message as an event. Right now, at most this will only generate a few events per query due to the graph size. In the future it could generate a large number of events if the graph is large. I'm considering switching to a polling model like the `init_sync` code in  `do_attempt_write_data` to be more aware of the write buffer. Wanted opinions before I go down that path though.
- Sequencing metadata in replies (`first_blocknum`, `number_of_blocks`) is still necessary to be spec compliant even though its ugly. I added notes on overflow safety. I'm happy to make that more explicit if that's preferable. 