### PR TITLE
Make `util::logger::macro_logger` pub(crate) not pub.

### DIFF
--- a/lightning/src/util/mod.rs
+++ b/lightning/src/util/mod.rs
@@ -28,7 +28,7 @@ pub(crate) mod ser_macros;
 
 /// Logging macro utilities.
 #[macro_use]
-pub mod macro_logger;
+pub(crate) mod macro_logger;
 
 // These have to come after macro_logger to build
 pub mod logger;


### PR DESCRIPTION
There is no reason for it to be pub, its a largely-internal
implementation detail of how we format our own objects for logging.