### PR TITLE
Rescan dependent transactions in ChainMonitor

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -267,3 +267,56 @@ impl<ChannelSigner: Sign, C: Deref, T: Deref, F: Deref, L: Deref, P: Deref> even
 		pending_events
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use ::{check_added_monitors, get_local_commitment_txn};
+	use ln::features::InitFeatures;
+	use ln::functional_test_utils::*;
+	use util::events::EventsProvider;
+	use util::events::MessageSendEventsProvider;
+	use util::test_utils::{OnRegisterOutput, TxOutReference};
+
+	/// Tests that in-block dependent transactions are processed by `block_connected` when not
+	/// included in `txdata` but returned by [`chain::Filter::register_output`]. For instance,
+	/// a (non-anchor) commitment transaction's HTLC output may be spent in the same block as the
+	/// commitment transaction itself. An Electrum client may filter the commitment transaction but
+	/// needs to return the HTLC transaction so it can be processed.
+	#[test]
+	fn connect_block_checks_dependent_transactions() {
+		let chanmon_cfgs = create_chanmon_cfgs(2);
+		let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+		let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+		let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+		let channel = create_announced_chan_between_nodes(
+			&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
+
+		// Send a payment, saving nodes[0]'s revoked commitment and HTLC-Timeout transactions.
+		let (commitment_tx, htlc_tx) = {
+			let payment_preimage = route_payment(&nodes[0], &vec!(&nodes[1])[..], 5_000_000).0;
+			let mut txn = get_local_commitment_txn!(nodes[0], channel.2);
+			claim_payment(&nodes[0], &vec!(&nodes[1])[..], payment_preimage, 5_000_000);
+
+			assert_eq!(txn.len(), 2);
+			(txn.remove(0), txn.remove(0))
+		};
+
+		// Set expectations on nodes[1]'s chain source to return dependent transactions.
+		let htlc_output = TxOutReference(commitment_tx.clone(), 0);
+		let to_local_output = TxOutReference(commitment_tx.clone(), 1);
+		let htlc_timeout_output = TxOutReference(htlc_tx.clone(), 0);
+		nodes[1].chain_source
+			.expect(OnRegisterOutput { with: htlc_output, returns: Some((1, htlc_tx)) })
+			.expect(OnRegisterOutput { with: to_local_output, returns: None })
+			.expect(OnRegisterOutput { with: htlc_timeout_output, returns: None });
+
+		// Notify nodes[1] that nodes[0]'s revoked commitment transaction was mined. The chain
+		// source should return the dependent HTLC transaction when the HTLC output is registered.
+		mine_transaction(&nodes[1], &commitment_tx);
+
+		// Clean up so uninteresting assertions don't fail.
+		check_added_monitors!(nodes[1], 1);
+		nodes[1].node.get_and_clear_pending_msg_events();
+		nodes[1].node.get_and_clear_pending_events();
+	}
+}

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -40,6 +40,7 @@ use ln::chan_utils::{CounterpartyCommitmentSecrets, HTLCOutputInCommitment, HTLC
 use ln::channelmanager::{HTLCSource, PaymentPreimage, PaymentHash};
 use ln::onchaintx::{OnchainTxHandler, InputDescriptors};
 use chain;
+use chain::WatchedOutput;
 use chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use chain::transaction::{OutPoint, TransactionData};
 use chain::keysinterface::{SpendableOutputDescriptor, StaticPaymentOutputDescriptor, DelayedPaymentOutputDescriptor, Sign, KeysInterface};
@@ -1174,7 +1175,11 @@ impl<Signer: Sign> ChannelMonitor<Signer> {
 		for (txid, outputs) in lock.get_outputs_to_watch().iter() {
 			for (index, script_pubkey) in outputs.iter() {
 				assert!(*index <= u16::max_value() as u32);
-				filter.register_output(&OutPoint { txid: *txid, index: *index as u16 }, script_pubkey);
+				filter.register_output(WatchedOutput {
+					block_hash: None,
+					outpoint: OutPoint { txid: *txid, index: *index as u16 },
+					script_pubkey: script_pubkey.clone(),
+				});
 			}
 		}
 	}

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -11,7 +11,7 @@
 
 use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::blockdata::script::Script;
-use bitcoin::blockdata::transaction::TxOut;
+use bitcoin::blockdata::transaction::{Transaction, TxOut};
 use bitcoin::hash_types::{BlockHash, Txid};
 
 use chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateErr, MonitorEvent};
@@ -131,7 +131,10 @@ pub trait Filter: Send + Sync {
 
 	/// Registers interest in spends of a transaction output identified by `outpoint` having
 	/// `script_pubkey` as the spending condition.
-	fn register_output(&self, outpoint: &OutPoint, script_pubkey: &Script);
+	///
+	/// Optionally, returns any transaction dependent on the output. This is useful for Electrum
+	/// clients to facilitate registering in-block descendants.
+	fn register_output(&self, outpoint: &OutPoint, script_pubkey: &Script) -> Option<(usize, Transaction)>;
 }
 
 impl<T: Listen> Listen for std::ops::Deref<Target = T> {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -341,7 +341,8 @@ macro_rules! get_feerate {
 	}
 }
 
-#[cfg(test)]
+/// Returns any local commitment transactions for the channel.
+#[macro_export]
 macro_rules! get_local_commitment_txn {
 	($node: expr, $channel_id: expr) => {
 		{

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -546,7 +546,8 @@ impl chain::Filter for TestChainSource {
 		self.watched_txn.lock().unwrap().insert((*txid, script_pubkey.clone()));
 	}
 
-	fn register_output(&self, outpoint: &OutPoint, script_pubkey: &Script) {
+	fn register_output(&self, outpoint: &OutPoint, script_pubkey: &Script) -> Option<(usize, Transaction)> {
 		self.watched_outputs.lock().unwrap().insert((*outpoint, script_pubkey.clone()));
+		None
 	}
 }

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -8,6 +8,7 @@
 // licenses.
 
 use chain;
+use chain::WatchedOutput;
 use chain::chaininterface;
 use chain::chaininterface::ConfirmationTarget;
 use chain::chainmonitor;
@@ -546,8 +547,8 @@ impl chain::Filter for TestChainSource {
 		self.watched_txn.lock().unwrap().insert((*txid, script_pubkey.clone()));
 	}
 
-	fn register_output(&self, outpoint: &OutPoint, script_pubkey: &Script) -> Option<(usize, Transaction)> {
-		self.watched_outputs.lock().unwrap().insert((*outpoint, script_pubkey.clone()));
+	fn register_output(&self, output: WatchedOutput) -> Option<(usize, Transaction)> {
+		self.watched_outputs.lock().unwrap().insert((output.outpoint, output.script_pubkey));
 		None
 	}
 }


### PR DESCRIPTION
Electrum clients primarily operate by subscribing to notifications of transactions by script pubkeys. Therefore, they will send filtered transaction data without including dependent transactions. Outputs for such dependent transactions must be explicitly registered with these clients.

This PR updates `chain::Filter::register_output` to return dependent transaction data as `Option<TransactionData>`, allowing `ChainMonitor` to register more outputs that are found within them.