### PR TITLE
Make cltv_expiry_delta configurable and reduce the min/default some

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,11 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 2%
+        threshold: 1%
         base: auto
         informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 100%
+        base: auto

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -25,7 +25,7 @@ use bitcoin::secp256k1;
 use ln::features::{ChannelFeatures, InitFeatures};
 use ln::msgs;
 use ln::msgs::{DecodeError, OptionalField, DataLossProtect};
-use ln::channelmanager::{PendingHTLCStatus, HTLCSource, HTLCFailReason, HTLCFailureMsg, PendingHTLCInfo, RAACommitmentOrder, PaymentPreimage, PaymentHash, BREAKDOWN_TIMEOUT, MAX_LOCAL_BREAKDOWN_TIMEOUT};
+use ln::channelmanager::{PendingHTLCStatus, HTLCSource, HTLCFailReason, HTLCFailureMsg, PendingHTLCInfo, RAACommitmentOrder, PaymentPreimage, PaymentHash, BREAKDOWN_TIMEOUT, MIN_CLTV_EXPIRY_DELTA, MAX_LOCAL_BREAKDOWN_TIMEOUT};
 use ln::chan_utils::{CounterpartyCommitmentSecrets, TxCreationKeys, HTLCOutputInCommitment, HTLC_SUCCESS_TX_WEIGHT, HTLC_TIMEOUT_TX_WEIGHT, make_funding_redeemscript, ChannelPublicKeys, CommitmentTransaction, HolderCommitmentTransaction, ChannelTransactionParameters, CounterpartyChannelTransactionParameters, MAX_HTLCS, get_commitment_transaction_number_obscure_factor};
 use ln::chan_utils;
 use chain::chaininterface::{FeeEstimator,ConfirmationTarget};
@@ -3357,6 +3357,10 @@ impl<Signer: Sign> Channel<Signer> {
 
 	pub fn get_fee_proportional_millionths(&self) -> u32 {
 		self.config.fee_proportional_millionths
+	}
+
+	pub fn get_cltv_expiry_delta(&self) -> u16 {
+		cmp::max(self.config.cltv_expiry_delta, MIN_CLTV_EXPIRY_DELTA)
 	}
 
 	#[cfg(test)]

--- a/lightning/src/util/config.rs
+++ b/lightning/src/util/config.rs
@@ -23,18 +23,21 @@ pub struct ChannelHandshakeConfig {
 	///
 	/// Default value: 6.
 	pub minimum_depth: u32,
-	/// Set to the amount of time we require our counterparty to wait to claim their money.
+	/// Set to the number of blocks we require our counterparty to wait to claim their money (ie
+	/// the number of blocks we have to punish our counterparty if they broadcast a revoked
+	/// transaction).
 	///
-	/// It's one of the main parameter of our security model. We (or one of our watchtowers) MUST
-	/// be online to check for peer having broadcast a revoked transaction to steal our funds
-	/// at least once every our_to_self_delay blocks.
+	/// This is one of the main parameters of our security model. We (or one of our watchtowers) MUST
+	/// be online to check for revoked transactions on-chain at least once every our_to_self_delay
+	/// blocks (minus some margin to allow us enough time to broadcast and confirm a transaction,
+	/// possibly with time in between to RBF the spending transaction).
 	///
 	/// Meanwhile, asking for a too high delay, we bother peer to freeze funds for nothing in
 	/// case of an honest unilateral channel close, which implicitly decrease the economic value of
 	/// our channel.
 	///
-	/// Default value: [`BREAKDOWN_TIMEOUT`] (currently 144), we enforce it as a minimum at channel
-	/// opening so you can tweak config to ask for more security, not less.
+	/// Default value: [`BREAKDOWN_TIMEOUT`], we enforce it as a minimum at channel opening so you
+	/// can tweak config to ask for more security, not less.
 	pub our_to_self_delay: u16,
 	/// Set to the smallest value HTLC we will accept to process.
 	///


### PR DESCRIPTION
This PR is just the top commit but is based on #848 because it uses the intra-doc-linking and this is what made me go write 848.

We allow users to configure the to_self_delay, which is analogous to
the cltv_expiry_delta in terms of its security context, so we should
allow users to specify both.

We similarly bound it on the lower end, but reduce that bound
somewhat now that it is configurable.