### PR TITLE
Clean up and more liberally free holding cell HTLCs (without re-entrancy)

### DIFF
--- a/fuzz/ci-fuzz.sh
+++ b/fuzz/ci-fuzz.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 pushd src/msg_targets
 rm msg_*.rs

--- a/fuzz/src/bin/chanmon_consistency_target.rs
+++ b/fuzz/src/bin/chanmon_consistency_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/chanmon_deser_target.rs
+++ b/fuzz/src/bin/chanmon_deser_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/full_stack_target.rs
+++ b/fuzz/src/bin/full_stack_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_accept_channel_target.rs
+++ b/fuzz/src/bin/msg_accept_channel_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_announcement_signatures_target.rs
+++ b/fuzz/src/bin/msg_announcement_signatures_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_channel_announcement_target.rs
+++ b/fuzz/src/bin/msg_channel_announcement_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_channel_reestablish_target.rs
+++ b/fuzz/src/bin/msg_channel_reestablish_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_channel_update_target.rs
+++ b/fuzz/src/bin/msg_channel_update_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_closing_signed_target.rs
+++ b/fuzz/src/bin/msg_closing_signed_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_commitment_signed_target.rs
+++ b/fuzz/src/bin/msg_commitment_signed_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
+++ b/fuzz/src/bin/msg_decoded_onion_error_packet_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_error_message_target.rs
+++ b/fuzz/src/bin/msg_error_message_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_funding_created_target.rs
+++ b/fuzz/src/bin/msg_funding_created_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_funding_locked_target.rs
+++ b/fuzz/src/bin/msg_funding_locked_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_funding_signed_target.rs
+++ b/fuzz/src/bin/msg_funding_signed_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
+++ b/fuzz/src/bin/msg_gossip_timestamp_filter_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_init_target.rs
+++ b/fuzz/src/bin/msg_init_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_node_announcement_target.rs
+++ b/fuzz/src/bin/msg_node_announcement_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_onion_hop_data_target.rs
+++ b/fuzz/src/bin/msg_onion_hop_data_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_open_channel_target.rs
+++ b/fuzz/src/bin/msg_open_channel_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_ping_target.rs
+++ b/fuzz/src/bin/msg_ping_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_pong_target.rs
+++ b/fuzz/src/bin/msg_pong_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_query_channel_range_target.rs
+++ b/fuzz/src/bin/msg_query_channel_range_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_query_short_channel_ids_target.rs
+++ b/fuzz/src/bin/msg_query_short_channel_ids_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_reply_channel_range_target.rs
+++ b/fuzz/src/bin/msg_reply_channel_range_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
+++ b/fuzz/src/bin/msg_reply_short_channel_ids_end_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_revoke_and_ack_target.rs
+++ b/fuzz/src/bin/msg_revoke_and_ack_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_shutdown_target.rs
+++ b/fuzz/src/bin/msg_shutdown_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_add_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_add_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fail_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fail_malformed_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fee_target.rs
+++ b/fuzz/src/bin/msg_update_fee_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
+++ b/fuzz/src/bin/msg_update_fulfill_htlc_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/peer_crypt_target.rs
+++ b/fuzz/src/bin/peer_crypt_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/router_target.rs
+++ b/fuzz/src/bin/router_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/target_template.txt
+++ b/fuzz/src/bin/target_template.txt
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/bin/zbase32_target.rs
+++ b/fuzz/src/bin/zbase32_target.rs
@@ -93,10 +93,18 @@ fn run_test_cases() {
 			}
 		}
 	}
+	let mut failed_outputs = Vec::new();
 	for (test, thread) in threads.drain(..) {
 		if let Some(output) = thread.join().unwrap() {
-			println!("Output of {}:\n{}", test, output);
-			panic!();
+			println!("\nOutput of {}:\n{}\n", test, output);
+			failed_outputs.push(test);
 		}
+	}
+	if !failed_outputs.is_empty() {
+		println!("Test cases which failed: ");
+		for case in failed_outputs {
+			println!("{}", case);
+		}
+		panic!();
 	}
 }

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -800,6 +800,10 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 					chan_a_disconnected = true;
 					drain_msg_events_on_disconnect!(0);
 				}
+				if monitor_a.should_update_manager.load(atomic::Ordering::Relaxed) {
+					node_a_ser.0.clear();
+					nodes[0].write(&mut node_a_ser).unwrap();
+				}
 				let (new_node_a, new_monitor_a) = reload_node!(node_a_ser, 0, monitor_a, keys_manager_a);
 				nodes[0] = new_node_a;
 				monitor_a = new_monitor_a;
@@ -826,6 +830,10 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 					nodes[1].peer_disconnected(&nodes[2].get_our_node_id(), false);
 					chan_b_disconnected = true;
 					drain_msg_events_on_disconnect!(2);
+				}
+				if monitor_c.should_update_manager.load(atomic::Ordering::Relaxed) {
+					node_c_ser.0.clear();
+					nodes[2].write(&mut node_c_ser).unwrap();
 				}
 				let (new_node_c, new_monitor_c) = reload_node!(node_c_ser, 2, monitor_c, keys_manager_c);
 				nodes[2] = new_node_c;

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -40,7 +40,7 @@ use lightning::chain::keysinterface::{KeysInterface, InMemorySigner};
 use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, PaymentSendFailure, ChannelManagerReadArgs};
 use lightning::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
-use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, DecodeError, ErrorAction, UpdateAddHTLC, Init};
+use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, DecodeError, UpdateAddHTLC, Init};
 use lightning::util::enforcing_trait_impls::{EnforcingSigner, INITIAL_REVOKED_COMMITMENT_NUMBER};
 use lightning::util::errors::APIError;
 use lightning::util::events;
@@ -624,7 +624,6 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
-							events::MessageSendEvent::HandleError { action: ErrorAction::IgnoreError, .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
 					}
@@ -637,7 +636,6 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
-							events::MessageSendEvent::HandleError { action: ErrorAction::IgnoreError, .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
 					}
@@ -649,17 +647,16 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 				for event in events.drain(..) {
 					let push = match event {
 						events::MessageSendEvent::UpdateHTLCs { ref node_id, .. } => {
-							if *node_id != drop_node_id { true } else { false }
+							if *node_id != drop_node_id { true } else { panic!("peer_disconnected should drop msgs bound for the disconnected peer"); }
 						},
 						events::MessageSendEvent::SendRevokeAndACK { ref node_id, .. } => {
-							if *node_id != drop_node_id { true } else { false }
+							if *node_id != drop_node_id { true } else { panic!("peer_disconnected should drop msgs bound for the disconnected peer"); }
 						},
 						events::MessageSendEvent::SendChannelReestablish { ref node_id, .. } => {
-							if *node_id != drop_node_id { true } else { false }
+							if *node_id != drop_node_id { true } else { panic!("peer_disconnected should drop msgs bound for the disconnected peer"); }
 						},
 						events::MessageSendEvent::SendFundingLocked { .. } => false,
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => false,
-						events::MessageSendEvent::HandleError { action: ErrorAction::IgnoreError, .. } => false,
 						_ => panic!("Unhandled message event"),
 					};
 					if push { msg_sink.push(event); }

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -603,6 +603,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 						events::MessageSendEvent::SendFundingLocked { .. } => {
 							// Can be generated as a reestablish response
 						},
+						events::MessageSendEvent::SendAnnouncementSignatures { .. } => {
+							// Can be generated as a reestablish response
+						},
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {
 							// Can be generated due to a payment forward being rejected due to a
 							// channel having previously failed a monitor update
@@ -623,6 +626,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendRevokeAndACK { .. } => {},
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
+							events::MessageSendEvent::SendAnnouncementSignatures { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
@@ -635,6 +639,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							events::MessageSendEvent::SendRevokeAndACK { .. } => {},
 							events::MessageSendEvent::SendChannelReestablish { .. } => {},
 							events::MessageSendEvent::SendFundingLocked { .. } => {},
+							events::MessageSendEvent::SendAnnouncementSignatures { .. } => {},
 							events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => {},
 							_ => panic!("Unhandled message event"),
 						}
@@ -656,6 +661,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							if *node_id != drop_node_id { true } else { panic!("peer_disconnected should drop msgs bound for the disconnected peer"); }
 						},
 						events::MessageSendEvent::SendFundingLocked { .. } => false,
+						events::MessageSendEvent::SendAnnouncementSignatures { .. } => false,
 						events::MessageSendEvent::PaymentFailureNetworkUpdate { .. } => false,
 						_ => panic!("Unhandled message event"),
 					};

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -2695,19 +2695,16 @@ impl<Signer: Sign> Channel<Signer> {
 		}
 	}
 
-	/// Removes any uncommitted HTLCs, to be used on peer disconnection, including any pending
-	/// HTLCs that we intended to add but haven't as we were waiting on a remote revoke.
-	/// Returns the set of PendingHTLCStatuses from remote uncommitted HTLCs (which we're
-	/// implicitly dropping) and the payment_hashes of HTLCs we tried to add but are dropping.
+	/// Removes any uncommitted inbound HTLCs and resets the state of uncommitted outbound HTLC
+	/// updates, to be used on peer disconnection. After this, update_*_htlc messages need to be
+	/// resent.
 	/// No further message handling calls may be made until a channel_reestablish dance has
 	/// completed.
-	pub fn remove_uncommitted_htlcs_and_mark_paused<L: Deref>(&mut self, logger: &L) -> Vec<(HTLCSource, PaymentHash)> where L::Target: Logger {
-		let mut outbound_drops = Vec::new();
-
+	pub fn remove_uncommitted_htlcs_and_mark_paused<L: Deref>(&mut self, logger: &L)  where L::Target: Logger {
 		assert_eq!(self.channel_state & ChannelState::ShutdownComplete as u32, 0);
 		if self.channel_state < ChannelState::FundingSent as u32 {
 			self.channel_state = ChannelState::ShutdownComplete as u32;
-			return outbound_drops;
+			return;
 		}
 		// Upon reconnect we have to start the closing_signed dance over, but shutdown messages
 		// will be retransmitted.
@@ -2750,23 +2747,8 @@ impl<Signer: Sign> Channel<Signer> {
 			}
 		}
 
-		self.holding_cell_htlc_updates.retain(|htlc_update| {
-			match htlc_update {
-				// Note that currently on channel reestablish we assert that there are
-				// no holding cell HTLC update_adds, so if in the future we stop
-				// dropping added HTLCs here and failing them backwards, then there will
-				// need to be corresponding changes made in the Channel's re-establish
-				// logic.
-				&HTLCUpdateAwaitingACK::AddHTLC { ref payment_hash, ref source, .. } => {
-					outbound_drops.push((source.clone(), payment_hash.clone()));
-					false
-				},
-				&HTLCUpdateAwaitingACK::ClaimHTLC {..} | &HTLCUpdateAwaitingACK::FailHTLC {..} => true,
-			}
-		});
 		self.channel_state |= ChannelState::PeerDisconnected as u32;
-		log_debug!(logger, "Peer disconnection resulted in {} remote-announced HTLC drops and {} waiting-to-locally-announced HTLC drops on channel {}", outbound_drops.len(), inbound_drop_count, log_bytes!(self.channel_id()));
-		outbound_drops
+		log_debug!(logger, "Peer disconnection resulted in {} remote-announced HTLC drops on channel {}", inbound_drop_count, log_bytes!(self.channel_id()));
 	}
 
 	/// Indicates that a ChannelMonitor update failed to be stored by the client and further
@@ -2925,7 +2907,7 @@ impl<Signer: Sign> Channel<Signer> {
 
 	/// May panic if some calls other than message-handling calls (which will all Err immediately)
 	/// have been called between remove_uncommitted_htlcs_and_mark_paused and this call.
-	pub fn channel_reestablish<L: Deref>(&mut self, msg: &msgs::ChannelReestablish, logger: &L) -> Result<(Option<msgs::FundingLocked>, Option<msgs::RevokeAndACK>, Option<msgs::CommitmentUpdate>, Option<ChannelMonitorUpdate>, RAACommitmentOrder, Option<msgs::Shutdown>), ChannelError> where L::Target: Logger {
+	pub fn channel_reestablish<L: Deref>(&mut self, msg: &msgs::ChannelReestablish, logger: &L) -> Result<(Option<msgs::FundingLocked>, Option<msgs::RevokeAndACK>, Option<msgs::CommitmentUpdate>, Option<ChannelMonitorUpdate>, RAACommitmentOrder, Vec<(HTLCSource, PaymentHash)>, Option<msgs::Shutdown>), ChannelError> where L::Target: Logger {
 		if self.channel_state & (ChannelState::PeerDisconnected as u32) == 0 {
 			// While BOLT 2 doesn't indicate explicitly we should error this channel here, it
 			// almost certainly indicates we are going to end up out-of-sync in some way, so we
@@ -2976,7 +2958,7 @@ impl<Signer: Sign> Channel<Signer> {
 					return Err(ChannelError::Close("Peer claimed they saw a revoke_and_ack but we haven't sent funding_locked yet".to_owned()));
 				}
 				// Short circuit the whole handler as there is nothing we can resend them
-				return Ok((None, None, None, None, RAACommitmentOrder::CommitmentFirst, shutdown_msg));
+				return Ok((None, None, None, None, RAACommitmentOrder::CommitmentFirst, Vec::new(), shutdown_msg));
 			}
 
 			// We have OurFundingLocked set!
@@ -2984,7 +2966,7 @@ impl<Signer: Sign> Channel<Signer> {
 			return Ok((Some(msgs::FundingLocked {
 				channel_id: self.channel_id(),
 				next_per_commitment_point,
-			}), None, None, None, RAACommitmentOrder::CommitmentFirst, shutdown_msg));
+			}), None, None, None, RAACommitmentOrder::CommitmentFirst, Vec::new(), shutdown_msg));
 		}
 
 		let required_revoke = if msg.next_remote_commitment_number + 1 == INITIAL_COMMITMENT_NUMBER - self.cur_holder_commitment_transaction_number {
@@ -3025,14 +3007,6 @@ impl<Signer: Sign> Channel<Signer> {
 			}
 
 			if (self.channel_state & (ChannelState::AwaitingRemoteRevoke as u32 | ChannelState::MonitorUpdateFailed as u32)) == 0 {
-				// Note that if in the future we no longer drop holding cell update_adds on peer
-				// disconnect, this logic will need to be updated.
-				for htlc_update in self.holding_cell_htlc_updates.iter() {
-					if let &HTLCUpdateAwaitingACK::AddHTLC { .. } = htlc_update {
-						debug_assert!(false, "There shouldn't be any add-HTLCs in the holding cell now because they should have been dropped on peer disconnect. Panic here because said HTLCs won't be handled correctly.");
-					}
-				}
-
 				// We're up-to-date and not waiting on a remote revoke (if we are our
 				// channel_reestablish should result in them sending a revoke_and_ack), but we may
 				// have received some updates while we were disconnected. Free the holding cell
@@ -3041,20 +3015,14 @@ impl<Signer: Sign> Channel<Signer> {
 					Err(ChannelError::Close(msg)) => return Err(ChannelError::Close(msg)),
 					Err(ChannelError::Ignore(_)) | Err(ChannelError::CloseDelayBroadcast(_)) => panic!("Got non-channel-failing result from free_holding_cell_htlcs"),
 					Ok((Some((commitment_update, monitor_update)), htlcs_to_fail)) => {
-						// If in the future we no longer drop holding cell update_adds on peer
-						// disconnect, we may be handed some HTLCs to fail backwards here.
-						assert!(htlcs_to_fail.is_empty());
-						return Ok((resend_funding_locked, required_revoke, Some(commitment_update), Some(monitor_update), self.resend_order.clone(), shutdown_msg));
+						return Ok((resend_funding_locked, required_revoke, Some(commitment_update), Some(monitor_update), self.resend_order.clone(), htlcs_to_fail, shutdown_msg));
 					},
 					Ok((None, htlcs_to_fail)) => {
-						// If in the future we no longer drop holding cell update_adds on peer
-						// disconnect, we may be handed some HTLCs to fail backwards here.
-						assert!(htlcs_to_fail.is_empty());
-						return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), shutdown_msg));
+						return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), htlcs_to_fail, shutdown_msg));
 					},
 				}
 			} else {
-				return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), shutdown_msg));
+				return Ok((resend_funding_locked, required_revoke, None, None, self.resend_order.clone(), Vec::new(), shutdown_msg));
 			}
 		} else if msg.next_local_commitment_number == next_counterparty_commitment_number - 1 {
 			if required_revoke.is_some() {
@@ -3065,10 +3033,10 @@ impl<Signer: Sign> Channel<Signer> {
 
 			if self.channel_state & (ChannelState::MonitorUpdateFailed as u32) != 0 {
 				self.monitor_pending_commitment_signed = true;
-				return Ok((resend_funding_locked, None, None, None, self.resend_order.clone(), shutdown_msg));
+				return Ok((resend_funding_locked, None, None, None, self.resend_order.clone(), Vec::new(), shutdown_msg));
 			}
 
-			return Ok((resend_funding_locked, required_revoke, Some(self.get_last_commitment_update(logger)), None, self.resend_order.clone(), shutdown_msg));
+			return Ok((resend_funding_locked, required_revoke, Some(self.get_last_commitment_update(logger)), None, self.resend_order.clone(), Vec::new(), shutdown_msg));
 		} else {
 			return Err(ChannelError::Close("Peer attempted to reestablish channel with a very old remote commitment transaction".to_owned()));
 		}
@@ -4404,7 +4372,7 @@ impl Readable for ChannelUpdateStatus {
 impl<Signer: Sign> Writeable for Channel<Signer> {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
 		// Note that we write out as if remove_uncommitted_htlcs_and_mark_paused had just been
-		// called but include holding cell updates (and obviously we don't modify self).
+		// called.
 
 		writer.write_all(&[SERIALIZATION_VERSION; 1])?;
 		writer.write_all(&[MIN_SERIALIZATION_VERSION; 1])?;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2593,7 +2593,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	pub fn channel_monitor_updated(&self, funding_txo: &OutPoint, highest_applied_update_id: u64) {
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(&self.total_consistency_lock, &self.persistence_notifier);
 
-		let mut close_results = Vec::new();
 		let mut htlc_forwards = Vec::new();
 		let mut htlc_failures = Vec::new();
 		let mut pending_events = Vec::new();
@@ -2668,10 +2667,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), failure.0, &failure.1, failure.2);
 		}
 		self.forward_htlcs(&mut htlc_forwards[..]);
-
-		for res in close_results.drain(..) {
-			self.finish_force_close_channel(res);
-		}
 	}
 
 	fn internal_open_channel(&self, counterparty_node_id: &PublicKey, their_features: InitFeatures, msg: &msgs::OpenChannel) -> Result<(), MsgHandleErrInternal> {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2069,7 +2069,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 								},
 								HTLCForwardInfo::FailHTLC { htlc_id, err_packet } => {
 									log_trace!(self.logger, "Failing HTLC back to channel with short id {} after delay", short_chan_id);
-									match chan.get_mut().get_update_fail_htlc(htlc_id, err_packet) {
+									match chan.get_mut().get_update_fail_htlc(htlc_id, err_packet, &self.logger) {
 										Err(e) => {
 											if let ChannelError::Ignore(msg) = e {
 												log_trace!(self.logger, "Failed to fail backwards to short_id {}: {}", short_chan_id, msg);

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1515,6 +1515,11 @@ macro_rules! handle_chan_reestablish_msgs {
 				None
 			};
 
+			if let Some(&MessageSendEvent::SendAnnouncementSignatures { ref node_id, msg: _ }) = msg_events.get(idx) {
+				idx += 1;
+				assert_eq!(*node_id, $dst_node.node.get_our_node_id());
+			}
+
 			let mut revoke_and_ack = None;
 			let mut commitment_update = None;
 			let order = if let Some(ev) = msg_events.get(idx) {


### PR DESCRIPTION
This is #756 reworked a decent chunk. In #756 the reentrancy story around `channel_monitor_updated` scared me significantly, but for some reason I apparently never bothered to really think deeply about the options. Here we move the holding cell free to `get_and_clear_pending_msg_events`, which is a *super* obvious location for it - it should be called right after `channel_monitor_updated` in most cases, but shouldn't have the same reentrancy issues because it already can generate a monitor update. It requires some macro rework, but its not too bad.