### PR TITLE
Add flag to indicate when a payment was rejected by the first hop

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2006,6 +2006,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						events::Event::PaymentFailed {
 							payment_hash,
 							rejected_by_dest: false,
+							rejected_by_first_hop: false,
 #[cfg(test)]
 							error_code: None,
 #[cfg(test)]
@@ -2039,9 +2040,9 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				match &onion_error {
 					&HTLCFailReason::LightningError { ref err } => {
 #[cfg(test)]
-						let (channel_update, payment_retryable, onion_error_code, onion_error_data) = onion_utils::process_onion_failure(&self.secp_ctx, &self.logger, &source, err.data.clone());
+						let (channel_update, payment_retryable, rejected_by_first_hop, onion_error_code, onion_error_data) = onion_utils::process_onion_failure(&self.secp_ctx, &self.logger, &source, err.data.clone());
 #[cfg(not(test))]
-						let (channel_update, payment_retryable, _, _) = onion_utils::process_onion_failure(&self.secp_ctx, &self.logger, &source, err.data.clone());
+						let (channel_update, payment_retryable, rejected_by_first_hop, _, _) = onion_utils::process_onion_failure(&self.secp_ctx, &self.logger, &source, err.data.clone());
 						// TODO: If we decided to blame ourselves (or one of our channels) in
 						// process_onion_failure we should close that channel as it implies our
 						// next-hop is needlessly blaming us!
@@ -2056,6 +2057,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							events::Event::PaymentFailed {
 								payment_hash: payment_hash.clone(),
 								rejected_by_dest: !payment_retryable,
+								rejected_by_first_hop,
 #[cfg(test)]
 								error_code: onion_error_code,
 #[cfg(test)]
@@ -2080,6 +2082,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							events::Event::PaymentFailed {
 								payment_hash: payment_hash.clone(),
 								rejected_by_dest: path.len() == 1,
+								rejected_by_first_hop: true,
 #[cfg(test)]
 								error_code: Some(*failure_code),
 #[cfg(test)]

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -882,7 +882,7 @@ macro_rules! expect_payment_failed {
 		let events = $node.node.get_and_clear_pending_events();
 		assert_eq!(events.len(), 1);
 		match events[0] {
-			Event::PaymentFailed { ref payment_hash, rejected_by_dest, ref error_code, ref error_data } => {
+			Event::PaymentFailed { ref payment_hash, rejected_by_dest, rejected_by_first_hop: _, ref error_code, ref error_data } => {
 				assert_eq!(*payment_hash, $expected_payment_hash, "unexpected payment_hash");
 				assert_eq!(rejected_by_dest, $rejected_by_dest, "unexpected rejected_by_dest value");
 				assert!(error_code.is_some(), "expected error_code.is_some() = true");

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5952,8 +5952,9 @@ fn test_fail_holding_cell_htlc_upon_free() {
 	let events = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 1);
 	match &events[0] {
-		&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest, ref error_code, ref error_data } => {
+		&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest, ref rejected_by_first_hop, ref error_code, ref error_data } => {
 			assert_eq!(our_payment_hash.clone(), *payment_hash);
+			assert_eq!(*rejected_by_first_hop, false);
 			assert_eq!(*rejected_by_dest, false);
 			assert_eq!(*error_code, None);
 			assert_eq!(*error_data, None);
@@ -6032,8 +6033,9 @@ fn test_free_and_fail_holding_cell_htlcs() {
 	let events = nodes[0].node.get_and_clear_pending_events();
 	assert_eq!(events.len(), 1);
 	match &events[0] {
-		&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest, ref error_code, ref error_data } => {
+		&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest, ref rejected_by_first_hop, ref error_code, ref error_data } => {
 			assert_eq!(payment_hash_2.clone(), *payment_hash);
+			assert_eq!(*rejected_by_first_hop, false);
 			assert_eq!(*rejected_by_dest, false);
 			assert_eq!(*error_code, None);
 			assert_eq!(*error_data, None);

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -109,14 +109,14 @@ pub enum Event {
 		/// retry the payment via a different route.
 		///
 		/// Note that if the destination node returned garbage which we were unable to
-		/// understanding, this will *not* be set, indicating that retrying the payment over
+		/// understand, this will *not* be set, indicating that retrying the payment over
 		/// another path is unlikely to solve the issue.
 		rejected_by_dest: bool,
 		/// Indicates the payment was rejected by the first hop in the route. This may be useful to
 		/// detect when an otherwise-trusted peer rejected a payment.
 		///
-		/// Note that this is not set if we reject the payment ourselves (eg because our connection
-		/// to the next-hop peer was closed).
+		/// Note that this is not set if we reject the payment ourselves (e.g. because our
+		/// connection to the next-hop peer was closed).
 		rejected_by_first_hop: bool,
 #[cfg(test)]
 		error_code: Option<u16>,


### PR DESCRIPTION
This was requested by a user wishing to brute-force the expected
feerate as a stopgap to trampoline, allowing them to have the
first hop node return a route with missing first-hop feerate info.