### PR TITLE
Electrum interface for ChannelMonitor

### DIFF
--- a/background-processor/src/lib.rs
+++ b/background-processor/src/lib.rs
@@ -131,7 +131,7 @@ mod tests {
 	use lightning::chain::keysinterface::{Sign, InMemorySigner, KeysInterface, KeysManager};
 	use lightning::chain::transaction::OutPoint;
 	use lightning::get_event_msg;
-	use lightning::ln::channelmanager::{ChainParameters, ChannelManager, SimpleArcChannelManager};
+	use lightning::ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, SimpleArcChannelManager};
 	use lightning::ln::features::InitFeatures;
 	use lightning::ln::msgs::ChannelMessageHandler;
 	use lightning::ln::peer_handler::{PeerManager, MessageHandler, SocketDescriptor};
@@ -192,14 +192,12 @@ mod tests {
 			let persister = Arc::new(FilesystemPersister::new(format!("{}_persister_{}", persist_dir, i)));
 			let seed = [i as u8; 32];
 			let network = Network::Testnet;
-			let genesis_block = genesis_block(network);
-			let now = Duration::from_secs(genesis_block.header.time as u64);
+			let now = Duration::from_secs(genesis_block(network).header.time as u64);
 			let keys_manager = Arc::new(KeysManager::new(&seed, now.as_secs(), now.subsec_nanos()));
 			let chain_monitor = Arc::new(chainmonitor::ChainMonitor::new(Some(chain_source.clone()), tx_broadcaster.clone(), logger.clone(), fee_estimator.clone(), persister.clone()));
 			let params = ChainParameters {
 				network,
-				latest_hash: genesis_block.block_hash(),
-				latest_height: 0,
+				best_block: BestBlock::from_genesis(network),
 			};
 			let manager = Arc::new(ChannelManager::new(fee_estimator.clone(), chain_monitor.clone(), tx_broadcaster, logger.clone(), keys_manager.clone(), UserConfig::default(), params));
 			let msg_handler = MessageHandler { chan_handler: Arc::new(test_utils::TestChannelMessageHandler::new()), route_handler: Arc::new(test_utils::TestRoutingMessageHandler::new() )};

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -36,7 +36,7 @@ use lightning::chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr, 
 use lightning::chain::transaction::OutPoint;
 use lightning::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget, FeeEstimator};
 use lightning::chain::keysinterface::{KeysInterface, InMemorySigner};
-use lightning::ln::channelmanager::{ChainParameters, ChannelManager, PaymentHash, PaymentPreimage, PaymentSecret, PaymentSendFailure, ChannelManagerReadArgs};
+use lightning::ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, PaymentHash, PaymentPreimage, PaymentSecret, PaymentSendFailure, ChannelManagerReadArgs};
 use lightning::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, DecodeError, ErrorAction, UpdateAddHTLC, Init};
 use lightning::util::enforcing_trait_impls::{EnforcingSigner, INITIAL_REVOKED_COMMITMENT_NUMBER};
@@ -322,8 +322,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 			let network = Network::Bitcoin;
 			let params = ChainParameters {
 				network,
-				latest_hash: genesis_block(network).block_hash(),
-				latest_height: 0,
+				best_block: BestBlock::from_genesis(network),
 			};
 			(ChannelManager::new(fee_est.clone(), monitor.clone(), broadcast.clone(), Arc::clone(&logger), keys_manager.clone(), config, params),
 			monitor, keys_manager)

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -32,7 +32,7 @@ use lightning::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget,
 use lightning::chain::chainmonitor;
 use lightning::chain::transaction::OutPoint;
 use lightning::chain::keysinterface::{InMemorySigner, KeysInterface};
-use lightning::ln::channelmanager::{ChainParameters, ChannelManager, PaymentHash, PaymentPreimage, PaymentSecret};
+use lightning::ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::ln::peer_handler::{MessageHandler,PeerManager,SocketDescriptor};
 use lightning::ln::msgs::DecodeError;
 use lightning::routing::router::get_route;
@@ -355,15 +355,13 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 	config.channel_options.announced_channel = get_slice!(1)[0] != 0;
 	config.peer_channel_config_limits.min_dust_limit_satoshis = 0;
 	let network = Network::Bitcoin;
-	let genesis_hash = genesis_block(network).block_hash();
 	let params = ChainParameters {
 		network,
-		latest_hash: genesis_hash,
-		latest_height: 0,
+		best_block: BestBlock::from_genesis(network),
 	};
 	let channelmanager = Arc::new(ChannelManager::new(fee_est.clone(), monitor.clone(), broadcast.clone(), Arc::clone(&logger), keys_manager.clone(), config, params));
 	let our_id = PublicKey::from_secret_key(&Secp256k1::signing_only(), &keys_manager.get_node_secret());
-	let net_graph_msg_handler = Arc::new(NetGraphMsgHandler::new(genesis_hash, None, Arc::clone(&logger)));
+	let net_graph_msg_handler = Arc::new(NetGraphMsgHandler::new(genesis_block(network).block_hash(), None, Arc::clone(&logger)));
 
 	let peers = RefCell::new([false; 256]);
 	let mut loss_detector = MoneyLossDetector::new(&peers, channelmanager.clone(), monitor.clone(), PeerManager::new(MessageHandler {

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -146,15 +146,15 @@ where C::Target: chain::Filter,
 			// transactions from within the block that previously had not been included in txdata.
 			if let Some(ref chain_source) = self.chain_source {
 				let block_hash = header.block_hash();
-				for (txid, outputs) in txn_outputs.drain(..) {
-					for (idx, output) in outputs.iter() {
+				for (txid, mut outputs) in txn_outputs.drain(..) {
+					for (idx, output) in outputs.drain(..) {
 						// Register any new outputs with the chain source for filtering and recurse
 						// if it indicates that there are dependent transactions within the block
 						// that had not been previously included in txdata.
 						let output = WatchedOutput {
 							block_hash: Some(block_hash),
-							outpoint: OutPoint { txid, index: *idx as u16 },
-							script_pubkey: output.script_pubkey.clone(),
+							outpoint: OutPoint { txid, index: idx as u16 },
+							script_pubkey: output.script_pubkey,
 						};
 						if let Some(tx) = chain_source.register_output(output) {
 							dependent_txdata.push(tx);

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -25,13 +25,12 @@
 
 use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::hash_types::Txid;
-use bitcoin::blockdata::transaction::TxOut;
 
 use chain;
 use chain::{Filter, WatchedOutput};
 use chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use chain::channelmonitor;
-use chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateErr, MonitorEvent, Persist};
+use chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate, ChannelMonitorUpdateErr, MonitorEvent, Persist, TransactionOutputs};
 use chain::transaction::{OutPoint, TransactionData};
 use chain::keysinterface::Sign;
 use util::logger::Logger;
@@ -135,7 +134,7 @@ where C::Target: chain::Filter,
 
 	fn process_chain_data<FN>(&self, header: &BlockHeader, txdata: &TransactionData, process: FN)
 	where
-		FN: Fn(&ChannelMonitor<ChannelSigner>, &TransactionData) -> Vec<(Txid, Vec<(u32, TxOut)>)>
+		FN: Fn(&ChannelMonitor<ChannelSigner>, &TransactionData) -> Vec<TransactionOutputs>
 	{
 		let mut dependent_txdata = Vec::new();
 		let monitors = self.monitors.read().unwrap();

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -1385,6 +1385,19 @@ impl<Signer: Sign> ChannelMonitor<Signer> {
 		self.inner.lock().unwrap().update_best_block(
 			header, height, broadcaster, fee_estimator, logger)
 	}
+
+	/// Returns the set of txids that should be monitored for re-organization out of the chain.
+	pub fn get_relevant_txids(&self) -> Vec<Txid> {
+		let inner = self.inner.lock().unwrap();
+		let mut txids: Vec<Txid> = inner.onchain_events_waiting_threshold_conf
+			.iter()
+			.map(|entry| entry.txid)
+			.chain(inner.onchain_tx_handler.get_relevant_txids().into_iter())
+			.collect();
+		txids.sort_unstable();
+		txids.dedup();
+		txids
+	}
 }
 
 impl<Signer: Sign> ChannelMonitorImpl<Signer> {

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -352,9 +352,6 @@ struct PeerState {
 	latest_features: InitFeatures,
 }
 
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-const ERR: () = "You need at least 32 bit pointers (well, usize, but we'll assume they're the same) for ChannelManager::latest_block_height";
-
 /// SimpleArcChannelManager is useful when you need a ChannelManager with a static lifetime, e.g.
 /// when you're using lightning-net-tokio (since tokio::spawn requires parameters with static
 /// lifetimes). Other times you can afford a reference, which is more efficient, in which case
@@ -424,10 +421,9 @@ pub struct ChannelManager<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, 
 	tx_broadcaster: T,
 
 	#[cfg(test)]
-	pub(super) latest_block_height: AtomicUsize,
+	pub(super) best_block: RwLock<BestBlock>,
 	#[cfg(not(test))]
-	latest_block_height: AtomicUsize,
-	last_block_hash: RwLock<BlockHash>,
+	best_block: RwLock<BestBlock>,
 	secp_ctx: Secp256k1<secp256k1::All>,
 
 	#[cfg(any(test, feature = "_test_utils"))]
@@ -475,13 +471,37 @@ pub struct ChainParameters {
 	/// The network for determining the `chain_hash` in Lightning messages.
 	pub network: Network,
 
-	/// The hash of the latest block successfully connected.
-	pub latest_hash: BlockHash,
-
-	/// The height of the latest block successfully connected.
+	/// The hash and height of the latest block successfully connected.
 	///
 	/// Used to track on-chain channel funding outputs and send payments with reliable timelocks.
-	pub latest_height: usize,
+	pub best_block: BestBlock,
+}
+
+/// The best known block as identified by its hash and height.
+pub struct BestBlock {
+	block_hash: BlockHash,
+	height: u32,
+}
+
+impl BestBlock {
+	/// Returns the best block from the genesis of the given network.
+	pub fn from_genesis(network: Network) -> Self {
+		BestBlock {
+			block_hash: genesis_block(network).header.block_hash(),
+			height: 0,
+		}
+	}
+
+	/// Returns the best block as identified by the given block hash and height.
+	pub fn new(block_hash: BlockHash, height: u32) -> Self {
+		BestBlock { block_hash, height }
+	}
+
+	/// Returns the best block hash.
+	pub fn block_hash(&self) -> BlockHash { self.block_hash }
+
+	/// Returns the best block height.
+	pub fn height(&self) -> u32 { self.height }
 }
 
 /// Whenever we release the `ChannelManager`'s `total_consistency_lock`, from read mode, it is
@@ -822,8 +842,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			chain_monitor,
 			tx_broadcaster,
 
-			latest_block_height: AtomicUsize::new(params.latest_height),
-			last_block_hash: RwLock::new(params.latest_hash),
+			best_block: RwLock::new(params.best_block),
 
 			channel_state: Mutex::new(ChannelHolder{
 				by_id: HashMap::new(),
@@ -1176,7 +1195,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				// HTLC_FAIL_BACK_BUFFER blocks to go.
 				// Also, ensure that, in the case of an unknown payment hash, our payment logic has enough time to fail the HTLC backward
 				// before our onchain logic triggers a channel closure (see HTLC_FAIL_BACK_BUFFER rational).
-				if (msg.cltv_expiry as u64) <= self.latest_block_height.load(Ordering::Acquire) as u64 + HTLC_FAIL_BACK_BUFFER as u64 + 1 {
+				if (msg.cltv_expiry as u64) <= self.best_block.read().unwrap().height() as u64 + HTLC_FAIL_BACK_BUFFER as u64 + 1 {
 					return_err!("The final CLTV expiry is too soon to handle", 17, &[0;0]);
 				}
 				// final_incorrect_htlc_amount
@@ -1299,7 +1318,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if (msg.cltv_expiry as u64) < (*outgoing_cltv_value) as u64 + chan.get_cltv_expiry_delta() as u64 { // incorrect_cltv_expiry
 						break Some(("Forwarding node has tampered with the intended HTLC values or origin node has an obsolete cltv_expiry_delta", 0x1000 | 13, Some(self.get_channel_update(chan).unwrap())));
 					}
-					let cur_height = self.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+					let cur_height = self.best_block.read().unwrap().height() + 1;
 					// Theoretically, channel counterparty shouldn't send us a HTLC expiring now, but we want to be robust wrt to counterparty
 					// packet sanitization (see HTLC_FAIL_BACK_BUFFER rational)
 					if msg.cltv_expiry <= cur_height + HTLC_FAIL_BACK_BUFFER as u32 { // expiry_too_soon
@@ -1516,7 +1535,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			return Err(PaymentSendFailure::PathParameterError(path_errs));
 		}
 
-		let cur_height = self.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+		let cur_height = self.best_block.read().unwrap().height() + 1;
 		let mut results = Vec::new();
 		for path in route.paths.iter() {
 			results.push(self.send_payment_along_path(&path, &payment_hash, payment_secret, total_value, cur_height));
@@ -1910,10 +1929,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 										for htlc in htlcs.iter() {
 											let mut htlc_msat_height_data = byte_utils::be64_to_array(htlc.value).to_vec();
 											htlc_msat_height_data.extend_from_slice(
-												&byte_utils::be32_to_array(
-													self.latest_block_height.load(Ordering::Acquire)
-														as u32,
-												),
+												&byte_utils::be32_to_array(self.best_block.read().unwrap().height()),
 											);
 											failed_forwards.push((HTLCSource::PreviousHopData(HTLCPreviousHopData {
 													short_channel_id: htlc.prev_hop.short_channel_id,
@@ -2033,8 +2049,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				if channel_state.is_none() { channel_state = Some(self.channel_state.lock().unwrap()); }
 				let mut htlc_msat_height_data = byte_utils::be64_to_array(htlc.value).to_vec();
 				htlc_msat_height_data.extend_from_slice(&byte_utils::be32_to_array(
-					self.latest_block_height.load(Ordering::Acquire) as u32,
-				));
+						self.best_block.read().unwrap().height()));
 				self.fail_htlc_backwards_internal(channel_state.take().unwrap(),
 						HTLCSource::PreviousHopData(htlc.prev_hop), payment_hash,
 						HTLCFailReason::Reason { failure_code: 0x4000 | 15, data: htlc_msat_height_data });
@@ -2248,8 +2263,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				if (is_mpp && !valid_mpp) || (!is_mpp && (htlc.value < expected_amount || htlc.value > expected_amount * 2)) {
 					let mut htlc_msat_height_data = byte_utils::be64_to_array(htlc.value).to_vec();
 					htlc_msat_height_data.extend_from_slice(&byte_utils::be32_to_array(
-						self.latest_block_height.load(Ordering::Acquire) as u32,
-					));
+							self.best_block.read().unwrap().height()));
 					self.fail_htlc_backwards_internal(channel_state.take().unwrap(),
 									 HTLCSource::PreviousHopData(htlc.prev_hop), &payment_hash,
 									 HTLCFailReason::Reason { failure_code: 0x4000|15, data: htlc_msat_height_data });
@@ -2534,7 +2548,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 	fn internal_funding_created(&self, counterparty_node_id: &PublicKey, msg: &msgs::FundingCreated) -> Result<(), MsgHandleErrInternal> {
 		let ((funding_msg, monitor), mut chan) = {
-			let last_block_hash = *self.last_block_hash.read().unwrap();
+			let last_block_hash = self.best_block.read().unwrap().block_hash();
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
 			match channel_state.by_id.entry(msg.temporary_channel_id.clone()) {
@@ -2591,7 +2605,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 	fn internal_funding_signed(&self, counterparty_node_id: &PublicKey, msg: &msgs::FundingSigned) -> Result<(), MsgHandleErrInternal> {
 		let funding_tx = {
-			let last_block_hash = *self.last_block_hash.read().unwrap();
+			let last_block_hash = self.best_block.read().unwrap().block_hash();
 			let mut channel_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_lock;
 			match channel_state.by_id.entry(msg.channel_id) {
@@ -3339,24 +3353,30 @@ where
 	L::Target: Logger,
 {
 	fn block_connected(&self, block: &Block, height: u32) {
-		assert_eq!(*self.last_block_hash.read().unwrap(), block.header.prev_blockhash,
-			"Blocks must be connected in chain-order - the connected header must build on the last connected header");
-		assert_eq!(self.latest_block_height.load(Ordering::Acquire) as u64, height as u64 - 1,
-			"Blocks must be connected in chain-order - the connected block height must be one greater than the previous height");
+		{
+			let best_block = self.best_block.read().unwrap();
+			assert_eq!(best_block.block_hash(), block.header.prev_blockhash,
+				"Blocks must be connected in chain-order - the connected header must build on the last connected header");
+			assert_eq!(best_block.height(), height - 1,
+				"Blocks must be connected in chain-order - the connected block height must be one greater than the previous height");
+		}
+
 		let txdata: Vec<_> = block.txdata.iter().enumerate().collect();
 		self.transactions_confirmed(&block.header, height, &txdata);
 		self.update_best_block(&block.header, height);
 	}
 
 	fn block_disconnected(&self, header: &BlockHeader, height: u32) {
-		assert_eq!(*self.last_block_hash.read().unwrap(), header.block_hash(),
-			"Blocks must be disconnected in chain-order - the disconnected header must be the last connected header");
-
 		let _persistence_guard = PersistenceNotifierGuard::new(&self.total_consistency_lock, &self.persistence_notifier);
-		let new_height = self.latest_block_height.fetch_sub(1, Ordering::AcqRel) as u32 - 1;
-		assert_eq!(new_height, height - 1,
-			"Blocks must be disconnected in chain-order - the disconnected block must have the correct height");
-		*self.last_block_hash.write().unwrap() = header.prev_blockhash;
+		let new_height = height - 1;
+		{
+			let mut best_block = self.best_block.write().unwrap();
+			assert_eq!(best_block.block_hash(), header.block_hash(),
+				"Blocks must be disconnected in chain-order - the disconnected header must be the last connected header");
+			assert_eq!(best_block.height(), height,
+				"Blocks must be disconnected in chain-order - the disconnected block must have the correct height");
+			*best_block = BestBlock::new(header.prev_blockhash, new_height)
+		}
 
 		self.do_chain_event(Some(new_height), |channel| channel.update_best_block(new_height, header.time));
 	}
@@ -3513,8 +3533,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 		let _persistence_guard = PersistenceNotifierGuard::new(&self.total_consistency_lock, &self.persistence_notifier);
 
-		self.latest_block_height.store(height as usize, Ordering::Release);
-		*self.last_block_hash.write().unwrap() = block_hash;
+		*self.best_block.write().unwrap() = BestBlock::new(block_hash, height);
 
 		self.do_chain_event(Some(height), |channel| channel.update_best_block(height, header.time));
 
@@ -4147,8 +4166,11 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable f
 		writer.write_all(&[MIN_SERIALIZATION_VERSION; 1])?;
 
 		self.genesis_hash.write(writer)?;
-		(self.latest_block_height.load(Ordering::Acquire) as u32).write(writer)?;
-		self.last_block_hash.read().unwrap().write(writer)?;
+		{
+			let best_block = self.best_block.read().unwrap();
+			best_block.height().write(writer)?;
+			best_block.block_hash().write(writer)?;
+		}
 
 		let channel_state = self.channel_state.lock().unwrap();
 		let mut unfunded_channels = 0;
@@ -4340,8 +4362,8 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 		}
 
 		let genesis_hash: BlockHash = Readable::read(reader)?;
-		let latest_block_height: u32 = Readable::read(reader)?;
-		let last_block_hash: BlockHash = Readable::read(reader)?;
+		let best_block_height: u32 = Readable::read(reader)?;
+		let best_block_hash: BlockHash = Readable::read(reader)?;
 
 		let mut failed_htlcs = Vec::new();
 
@@ -4449,8 +4471,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 			chain_monitor: args.chain_monitor,
 			tx_broadcaster: args.tx_broadcaster,
 
-			latest_block_height: AtomicUsize::new(latest_block_height as usize),
-			last_block_hash: RwLock::new(last_block_hash),
+			best_block: RwLock::new(BestBlock::new(best_block_hash, best_block_height)),
 
 			channel_state: Mutex::new(ChannelHolder {
 				by_id,
@@ -4484,7 +4505,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 		//TODO: Broadcast channel update for closed channels, but only after we've made a
 		//connection or two.
 
-		Ok((last_block_hash.clone(), channel_manager))
+		Ok((best_block_hash.clone(), channel_manager))
 	}
 }
 
@@ -4545,7 +4566,7 @@ pub mod bench {
 	use chain::chainmonitor::ChainMonitor;
 	use chain::channelmonitor::Persist;
 	use chain::keysinterface::{KeysManager, InMemorySigner};
-	use ln::channelmanager::{ChainParameters, ChannelManager, PaymentHash, PaymentPreimage};
+	use ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, PaymentHash, PaymentPreimage};
 	use ln::features::InitFeatures;
 	use ln::functional_test_utils::*;
 	use ln::msgs::ChannelMessageHandler;
@@ -4597,8 +4618,7 @@ pub mod bench {
 		let keys_manager_a = KeysManager::new(&seed_a, 42, 42);
 		let node_a = ChannelManager::new(&fee_estimator, &chain_monitor_a, &tx_broadcaster, &logger_a, &keys_manager_a, config.clone(), ChainParameters {
 			network,
-			latest_hash: genesis_hash,
-			latest_height: 0,
+			best_block: BestBlock::from_genesis(network),
 		});
 		let node_a_holder = NodeHolder { node: &node_a };
 
@@ -4608,8 +4628,7 @@ pub mod bench {
 		let keys_manager_b = KeysManager::new(&seed_b, 42, 42);
 		let node_b = ChannelManager::new(&fee_estimator, &chain_monitor_b, &tx_broadcaster, &logger_b, &keys_manager_b, config.clone(), ChainParameters {
 			network,
-			latest_hash: genesis_hash,
-			latest_height: 0,
+			best_block: BestBlock::from_genesis(network),
 		});
 		let node_b_holder = NodeHolder { node: &node_b };
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -130,10 +130,10 @@ fn do_connect_block<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, block: &Block, s
 		match *node.connect_style.borrow() {
 			ConnectStyle::BestBlockFirst|ConnectStyle::BestBlockFirstSkippingBlocks => {
 				node.node.update_best_block(&block.header, height);
-				node.node.transactions_confirmed(&block.header, height, &block.txdata.iter().enumerate().collect::<Vec<_>>());
+				node.node.transactions_confirmed(&block.header, height, &txdata);
 			},
 			ConnectStyle::TransactionsFirst|ConnectStyle::TransactionsFirstSkippingBlocks => {
-				node.node.transactions_confirmed(&block.header, height, &block.txdata.iter().enumerate().collect::<Vec<_>>());
+				node.node.transactions_confirmed(&block.header, height, &txdata);
 				node.node.update_best_block(&block.header, height);
 			},
 			ConnectStyle::FullBlockViaListen => {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -13,7 +13,7 @@
 use chain::{Listen, Watch};
 use chain::channelmonitor::ChannelMonitor;
 use chain::transaction::OutPoint;
-use ln::channelmanager::{ChainParameters, ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
+use ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
 use routing::router::{Route, get_route};
 use routing::network_graph::{NetGraphMsgHandler, NetworkGraph};
 use ln::features::InitFeatures;
@@ -1279,8 +1279,7 @@ pub fn create_node_chanmgrs<'a, 'b>(node_count: usize, cfgs: &'a Vec<NodeCfg<'b>
 		let network = Network::Testnet;
 		let params = ChainParameters {
 			network,
-			latest_hash: genesis_block(network).header.block_hash(),
-			latest_height: 0,
+			best_block: BestBlock::from_genesis(network),
 		};
 		let node = ChannelManager::new(cfgs[i].fee_estimator, &cfgs[i].chain_monitor, cfgs[i].tx_broadcaster, cfgs[i].logger, cfgs[i].keys_manager, if node_config[i].is_some() { node_config[i].clone().unwrap() } else { default_config }, params);
 		chanmgrs.push(node);

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -51,7 +51,6 @@ use regex;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::default::Default;
 use std::sync::Mutex;
-use std::sync::atomic::Ordering;
 
 use ln::functional_test_utils::*;
 use ln::chan_utils::CommitmentTransaction;
@@ -1585,7 +1584,7 @@ fn test_fee_spike_violation_fails_htlc() {
 	let secp_ctx = Secp256k1::new();
 	let session_priv = SecretKey::from_slice(&[42; 32]).expect("RNG is bad!");
 
-	let cur_height = nodes[1].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+	let cur_height = nodes[1].node.best_block.read().unwrap().height() + 1;
 
 	let onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route.paths[0], &session_priv).unwrap();
 	let (onion_payloads, htlc_msat, htlc_cltv) = onion_utils::build_onion_payloads(&route.paths[0], 3460001, &None, cur_height).unwrap();
@@ -1756,7 +1755,7 @@ fn test_chan_reserve_violation_inbound_htlc_outbound_channel() {
 	// Need to manually create the update_add_htlc message to go around the channel reserve check in send_htlc()
 	let secp_ctx = Secp256k1::new();
 	let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
-	let cur_height = nodes[1].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+	let cur_height = nodes[1].node.best_block.read().unwrap().height() + 1;
 	let onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route.paths[0], &session_priv).unwrap();
 	let (onion_payloads, htlc_msat, htlc_cltv) = onion_utils::build_onion_payloads(&route.paths[0], 1000, &None, cur_height).unwrap();
 	let onion_packet = onion_utils::construct_onion_packet(onion_payloads, onion_keys, [0; 32], &payment_hash);
@@ -1879,7 +1878,7 @@ fn test_chan_reserve_violation_inbound_htlc_inbound_chan() {
 	// Need to manually create the update_add_htlc message to go around the channel reserve check in send_htlc()
 	let secp_ctx = Secp256k1::new();
 	let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
-	let cur_height = nodes[0].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+	let cur_height = nodes[0].node.best_block.read().unwrap().height() + 1;
 	let onion_keys = onion_utils::construct_onion_keys(&secp_ctx, &route_2.paths[0], &session_priv).unwrap();
 	let (onion_payloads, htlc_msat, htlc_cltv) = onion_utils::build_onion_payloads(&route_2.paths[0], recv_value_2, &None, cur_height).unwrap();
 	let onion_packet = onion_utils::construct_onion_packet(onion_payloads, onion_keys, [0; 32], &our_payment_hash_1);
@@ -3400,7 +3399,7 @@ fn fail_backward_pending_htlc_upon_channel_failure() {
 
 		let secp_ctx = Secp256k1::new();
 		let session_priv = SecretKey::from_slice(&[42; 32]).unwrap();
-		let current_height = nodes[1].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+		let current_height = nodes[1].node.best_block.read().unwrap().height() + 1;
 		let net_graph_msg_handler = &nodes[1].net_graph_msg_handler;
 		let route = get_route(&nodes[1].node.get_our_node_id(), &net_graph_msg_handler.network_graph.read().unwrap(), &nodes[0].node.get_our_node_id(), None, None, &Vec::new(), 50_000, TEST_FINAL_CLTV, &logger).unwrap();
 		let (onion_payloads, _amount_msat, cltv_expiry) = onion_utils::build_onion_payloads(&route.paths[0], 50_000, &None, current_height).unwrap();
@@ -6504,7 +6503,7 @@ fn test_update_add_htlc_bolt2_receiver_check_max_htlc_limit() {
 	let net_graph_msg_handler = &nodes[0].net_graph_msg_handler;
 	let route = get_route(&nodes[0].node.get_our_node_id(), &net_graph_msg_handler.network_graph.read().unwrap(), &nodes[1].node.get_our_node_id(), None, None, &[], 3999999, TEST_FINAL_CLTV, &logger).unwrap();
 
-	let cur_height = nodes[0].node.latest_block_height.load(Ordering::Acquire) as u32 + 1;
+	let cur_height = nodes[0].node.best_block.read().unwrap().height() + 1;
 	let onion_keys = onion_utils::construct_onion_keys(&Secp256k1::signing_only(), &route.paths[0], &session_priv).unwrap();
 	let (onion_payloads, _htlc_msat, htlc_cltv) = onion_utils::build_onion_payloads(&route.paths[0], 3999999, &None, cur_height).unwrap();
 	let onion_packet = onion_utils::construct_onion_packet(onion_payloads, onion_keys, [0; 32], &our_payment_hash);

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -54,7 +54,7 @@ impl OnchainEventEntry {
 	}
 
 	fn has_reached_confirmation_threshold(&self, height: u32) -> bool {
-		self.confirmation_threshold() == height
+		height >= self.confirmation_threshold()
 	}
 }
 

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -945,6 +945,16 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 		}
 	}
 
+	pub(crate) fn get_relevant_txids(&self) -> Vec<Txid> {
+		let mut txids: Vec<Txid> = self.onchain_events_waiting_threshold_conf
+			.iter()
+			.map(|entry| entry.txid)
+			.collect();
+		txids.sort_unstable();
+		txids.dedup();
+		txids
+	}
+
 	pub(crate) fn provide_latest_holder_tx(&mut self, tx: HolderCommitmentTransaction) {
 		self.prev_holder_commitment = Some(replace(&mut self.holder_commitment, tx));
 		self.holder_htlc_sigs = None;

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -869,6 +869,30 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 		}
 	}
 
+	pub(crate) fn transaction_unconfirmed<B: Deref, F: Deref, L: Deref>(
+		&mut self,
+		txid: &Txid,
+		broadcaster: B,
+		fee_estimator: F,
+		logger: L,
+	) where
+		B::Target: BroadcasterInterface,
+		F::Target: FeeEstimator,
+		L::Target: Logger,
+	{
+		let mut height = None;
+		for entry in self.onchain_events_waiting_threshold_conf.iter() {
+			if entry.txid == *txid {
+				height = Some(entry.height);
+				break;
+			}
+		}
+
+		if let Some(height) = height {
+			self.block_disconnected(height, broadcaster, fee_estimator, logger);
+		}
+	}
+
 	pub(crate) fn block_disconnected<B: Deref, F: Deref, L: Deref>(&mut self, height: u32, broadcaster: B, fee_estimator: F, logger: L)
 		where B::Target: BroadcasterInterface,
 		      F::Target: FeeEstimator,

--- a/lightning/src/ln/onchaintx.rs
+++ b/lightning/src/ln/onchaintx.rs
@@ -848,8 +848,8 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 
 		// Check if any pending claim request must be rescheduled
 		for (first_claim_txid, ref claim_data) in self.pending_claim_requests.iter() {
-			if let Some(h) = claim_data.height_timer {
-				if h == height {
+			if let Some(height_timer) = claim_data.height_timer {
+				if height >= height_timer {
 					bump_candidates.insert(*first_claim_txid, (*claim_data).clone());
 				}
 			}
@@ -878,7 +878,7 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 		let onchain_events_waiting_threshold_conf =
 			self.onchain_events_waiting_threshold_conf.drain(..).collect::<Vec<_>>();
 		for entry in onchain_events_waiting_threshold_conf {
-			if entry.height == height {
+			if entry.height >= height {
 				//- our claim tx on a commitment tx output
 				//- resurect outpoint back in its claimable set and regenerate tx
 				match entry.event {
@@ -912,7 +912,7 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 		// right now if one of the outpoint get disconnected, just erase whole pending claim request.
 		let mut remove_request = Vec::new();
 		self.claimable_outpoints.retain(|_, ref v|
-			if v.1 == height {
+			if v.1 >= height {
 			remove_request.push(v.0.clone());
 			false
 			} else { true });


### PR DESCRIPTION
Define an Electrum-friendly interface for `ChannelMonitor` where transaction are confirmed and unconfirmed independently from updating the latest block.