### PR TITLE
Fix two new compiler warnings in fuzz

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -234,7 +234,7 @@ fn check_api_err(api_err: APIError) {
 				_ if err.starts_with("Cannot send value that would put our balance under counterparty-announced channel reserve value") => {},
 				_ if err.starts_with("Cannot send value that would overdraw remaining funds.") => {},
 				_ if err.starts_with("Cannot send value that would not leave enough to pay for fees.") => {},
-				_ => panic!(err),
+				_ => panic!("{}", err),
 			}
 		},
 		APIError::MonitorUpdateFailed => {

--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -130,7 +130,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 					msgs::DecodeError::InvalidValue => return,
 					msgs::DecodeError::BadLengthDescriptor => return,
 					msgs::DecodeError::ShortRead => panic!("We picked the length..."),
-					msgs::DecodeError::Io(e) => panic!(format!("{:?}", e)),
+					msgs::DecodeError::Io(e) => panic!("{:?}", e),
 				}
 			}
 		}}


### PR DESCRIPTION
This fixes two trivial compiler warnings in fuzz that point to
broken usage of explicit `panic!()`s.