### PR TITLE
Add a simple send-funds benchmark in channelmanager

### DIFF
--- a/lightning-persister/Cargo.toml
+++ b/lightning-persister/Cargo.toml
@@ -8,6 +8,9 @@ description = """
 Utilities to manage Rust-Lightning channel data persistence and retrieval.
 """
 
+[features]
+unstable = ["lightning/unstable"]
+
 [dependencies]
 bitcoin = "0.26"
 lightning = { version = "0.0.13", path = "../lightning" }

--- a/lightning-persister/src/lib.rs
+++ b/lightning-persister/src/lib.rs
@@ -3,6 +3,9 @@
 #![deny(broken_intra_doc_links)]
 #![deny(missing_docs)]
 
+#![cfg_attr(all(test, feature = "unstable"), feature(test))]
+#[cfg(all(test, feature = "unstable"))] extern crate test;
+
 mod util;
 
 extern crate lightning;
@@ -328,5 +331,17 @@ mod tests {
 
 		nodes[1].node.get_and_clear_pending_msg_events();
 		added_monitors.clear();
+	}
+}
+
+#[cfg(all(test, feature = "unstable"))]
+pub mod bench {
+	use test::Bencher;
+
+	#[bench]
+	fn bench_sends(bench: &mut Bencher) {
+		let persister_a = super::FilesystemPersister::new("bench_filesystem_persister_a".to_string());
+		let persister_b = super::FilesystemPersister::new("bench_filesystem_persister_b".to_string());
+		lightning::ln::channelmanager::bench::bench_two_sends(bench, persister_a, persister_b);
 	}
 }

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -28,8 +28,8 @@
 #![allow(bare_trait_objects)]
 #![allow(ellipsis_inclusive_range_patterns)]
 
-#![cfg_attr(all(test, feature = "unstable"), feature(test))]
-#[cfg(all(test, feature = "unstable"))] extern crate test;
+#![cfg_attr(all(any(test, feature = "_test_utils"), feature = "unstable"), feature(test))]
+#[cfg(all(any(test, feature = "_test_utils"), feature = "unstable"))] extern crate test;
 
 extern crate bitcoin;
 #[cfg(any(test, feature = "_test_utils"))] extern crate hex;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -434,6 +434,7 @@ pub struct ChannelManager<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, 
 	#[cfg(not(any(test, feature = "_test_utils")))]
 	channel_state: Mutex<ChannelHolder<Signer>>,
 	our_network_key: SecretKey,
+	our_network_pubkey: PublicKey,
 
 	/// Used to track the last value sent in a node_announcement "timestamp" field. We ensure this
 	/// value increases strictly since we don't assume access to a time source.
@@ -822,7 +823,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 			latest_block_height: AtomicUsize::new(params.latest_height),
 			last_block_hash: RwLock::new(params.latest_hash),
-			secp_ctx,
 
 			channel_state: Mutex::new(ChannelHolder{
 				by_id: HashMap::new(),
@@ -832,6 +832,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				pending_msg_events: Vec::new(),
 			}),
 			our_network_key: keys_manager.get_node_secret(),
+			our_network_pubkey: PublicKey::from_secret_key(&secp_ctx, &keys_manager.get_node_secret()),
+			secp_ctx,
 
 			last_node_announcement_serial: AtomicUsize::new(0),
 
@@ -2315,7 +2317,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 	/// Gets the node_id held by this ChannelManager
 	pub fn get_our_node_id(&self) -> PublicKey {
-		PublicKey::from_secret_key(&self.secp_ctx, &self.our_network_key)
+		self.our_network_pubkey.clone()
 	}
 
 	/// Restores a single, given channel to normal operation after a
@@ -4318,7 +4320,6 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 
 			latest_block_height: AtomicUsize::new(latest_block_height as usize),
 			last_block_hash: RwLock::new(last_block_hash),
-			secp_ctx,
 
 			channel_state: Mutex::new(ChannelHolder {
 				by_id,
@@ -4328,6 +4329,8 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 				pending_msg_events: Vec::new(),
 			}),
 			our_network_key: args.keys_manager.get_node_secret(),
+			our_network_pubkey: PublicKey::from_secret_key(&secp_ctx, &args.keys_manager.get_node_secret()),
+			secp_ctx,
 
 			last_node_announcement_serial: AtomicUsize::new(last_node_announcement_serial as usize),
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -313,6 +313,24 @@ macro_rules! get_event_msg {
 	}
 }
 
+/// Get a specific event from the pending events queue.
+#[macro_export]
+macro_rules! get_event {
+	($node: expr, $event_type: path) => {
+		{
+			let mut events = $node.node.get_and_clear_pending_events();
+			assert_eq!(events.len(), 1);
+			let ev = events.pop().unwrap();
+			match ev {
+				$event_type { .. } => {
+					ev
+				},
+				_ => panic!("Unexpected event"),
+			}
+		}
+	}
+}
+
 #[cfg(test)]
 macro_rules! get_htlc_update_msgs {
 	($node: expr, $node_id: expr) => {

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -866,7 +866,7 @@ macro_rules! expect_pending_htlcs_forwardable {
 	}}
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "unstable"))]
 macro_rules! expect_payment_received {
 	($node: expr, $expected_payment_hash: expr, $expected_recv_value: expr) => {
 		let events = $node.node.get_and_clear_pending_events();

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -18,6 +18,10 @@
 //! you want to learn things about the network topology (eg get a route for sending a payment),
 //! call into your NetGraphMsgHandler.
 
+#[cfg(any(test, feature = "_test_utils"))]
+#[macro_use]
+pub mod functional_test_utils;
+
 pub mod channelmanager;
 pub mod msgs;
 pub mod peer_handler;
@@ -38,9 +42,6 @@ mod wire;
 // without the node parameter being mut. This is incorrect, and thus newer rustcs will complain
 // about an unnecessary mut. Thus, we silence the unused_mut warning in two test modules below.
 
-#[cfg(any(test, feature = "_test_utils"))]
-#[macro_use]
-pub mod functional_test_utils;
 #[cfg(test)]
 #[allow(unused_mut)]
 mod functional_tests;

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -186,12 +186,12 @@ impl TestPersister {
 		*self.update_ret.lock().unwrap() = ret;
 	}
 }
-impl channelmonitor::Persist<EnforcingSigner> for TestPersister {
-	fn persist_new_channel(&self, _funding_txo: OutPoint, _data: &channelmonitor::ChannelMonitor<EnforcingSigner>) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
+impl<Signer: keysinterface::Sign> channelmonitor::Persist<Signer> for TestPersister {
+	fn persist_new_channel(&self, _funding_txo: OutPoint, _data: &channelmonitor::ChannelMonitor<Signer>) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
 		self.update_ret.lock().unwrap().clone()
 	}
 
-	fn update_persisted_channel(&self, _funding_txo: OutPoint, _update: &channelmonitor::ChannelMonitorUpdate, _data: &channelmonitor::ChannelMonitor<EnforcingSigner>) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
+	fn update_persisted_channel(&self, _funding_txo: OutPoint, _update: &channelmonitor::ChannelMonitorUpdate, _data: &channelmonitor::ChannelMonitor<Signer>) -> Result<(), channelmonitor::ChannelMonitorUpdateErr> {
 		self.update_ret.lock().unwrap().clone()
 	}
 }


### PR DESCRIPTION
I saw https://twitter.com/bottlepay/status/1376918214249218049 and was curious, so I benchmarked sends.

We're doing pretty good - on my local machine somewhere in the neighborhood of 5-6ms for two full back-and-forth sends, ignoring all IO latency.