### PR TITLE
Define chain::Confirm trait for use by Electrum clients

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -30,6 +30,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hash_types::{BlockHash, WPubkeyHash};
 
 use lightning::chain;
+use lightning::chain::Confirm;
 use lightning::chain::chainmonitor;
 use lightning::chain::channelmonitor;
 use lightning::chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr, MonitorEvent};
@@ -428,11 +429,11 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 			let chain_hash = genesis_block(Network::Bitcoin).block_hash();
 			let mut header = BlockHeader { version: 0x20000000, prev_blockhash: chain_hash, merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 			let txdata: Vec<_> = channel_txn.iter().enumerate().map(|(i, tx)| (i + 1, tx)).collect();
-			$node.transactions_confirmed(&header, 1, &txdata);
+			$node.transactions_confirmed(&header, &txdata, 1);
 			for _ in 2..100 {
 				header = BlockHeader { version: 0x20000000, prev_blockhash: header.block_hash(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
 			}
-			$node.update_best_block(&header, 99);
+			$node.best_block_updated(&header, 99);
 		} }
 	}
 

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -209,7 +209,8 @@ impl<'a> MoneyLossDetector<'a> {
 		self.height += 1;
 		self.manager.transactions_confirmed(&header, &txdata, self.height as u32);
 		self.manager.best_block_updated(&header, self.height as u32);
-		(*self.monitor).block_connected(&header, &txdata, self.height as u32);
+		(*self.monitor).transactions_confirmed(&header, &txdata, self.height as u32);
+		(*self.monitor).best_block_updated(&header, self.height as u32);
 		if self.header_hashes.len() > self.height {
 			self.header_hashes[self.height] = (header.block_hash(), self.blocks_connected);
 		} else {

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -27,7 +27,7 @@ use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hash_types::{Txid, BlockHash, WPubkeyHash};
 
 use lightning::chain;
-use lightning::chain::Listen;
+use lightning::chain::{Confirm, Listen};
 use lightning::chain::chaininterface::{BroadcasterInterface, ConfirmationTarget, FeeEstimator};
 use lightning::chain::chainmonitor;
 use lightning::chain::transaction::OutPoint;
@@ -207,8 +207,8 @@ impl<'a> MoneyLossDetector<'a> {
 		self.blocks_connected += 1;
 		let header = BlockHeader { version: 0x20000000, prev_blockhash: self.header_hashes[self.height].0, merkle_root: Default::default(), time: self.blocks_connected, bits: 42, nonce: 42 };
 		self.height += 1;
-		self.manager.transactions_confirmed(&header, self.height as u32, &txdata);
-		self.manager.update_best_block(&header, self.height as u32);
+		self.manager.transactions_confirmed(&header, &txdata, self.height as u32);
+		self.manager.best_block_updated(&header, self.height as u32);
 		(*self.monitor).block_connected(&header, &txdata, self.height as u32);
 		if self.header_hashes.len() > self.height {
 			self.header_hashes[self.height] = (header.block_hash(), self.blocks_connected);

--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -94,11 +94,11 @@ where C::Target: chain::Filter,
 	/// [`ChannelMonitor::transactions_confirmed`].
 	///
 	/// Used instead of [`block_connected`] by clients that are notified of transactions rather than
-	/// blocks. May be called before or after [`update_best_block`] for transactions in the
-	/// corresponding block. See [`update_best_block`] for further calling expectations.
+	/// blocks. May be called before or after [`best_block_updated`] for transactions in the
+	/// corresponding block. See [`best_block_updated`] for further calling expectations.
 	///
 	/// [`block_connected`]: Self::block_connected
-	/// [`update_best_block`]: Self::update_best_block
+	/// [`best_block_updated`]: Self::best_block_updated
 	pub fn transactions_confirmed(&self, header: &BlockHeader, txdata: &TransactionData, height: u32) {
 		self.process_chain_data(header, txdata, |monitor, txdata| {
 			monitor.transactions_confirmed(
@@ -108,7 +108,7 @@ where C::Target: chain::Filter,
 
 	/// Dispatches to per-channel monitors, which are responsible for updating their on-chain view
 	/// of a channel and reacting accordingly based on the new chain tip. For details, see
-	/// [`ChannelMonitor::update_best_block`].
+	/// [`ChannelMonitor::best_block_updated`].
 	///
 	/// Used instead of [`block_connected`] by clients that are notified of transactions rather than
 	/// blocks. May be called before or after [`transactions_confirmed`] for the corresponding
@@ -122,12 +122,12 @@ where C::Target: chain::Filter,
 	/// [`block_connected`]: Self::block_connected
 	/// [`transactions_confirmed`]: Self::transactions_confirmed
 	/// [`transaction_unconfirmed`]: Self::transaction_unconfirmed
-	pub fn update_best_block(&self, header: &BlockHeader, height: u32) {
+	pub fn best_block_updated(&self, header: &BlockHeader, height: u32) {
 		self.process_chain_data(header, &[], |monitor, txdata| {
 			// While in practice there shouldn't be any recursive calls when given empty txdata,
 			// it's still possible if a chain::Filter implementation returns a transaction.
 			debug_assert!(txdata.is_empty());
-			monitor.update_best_block(
+			monitor.best_block_updated(
 				header, height, &*self.broadcaster, &*self.fee_estimator, &*self.logger)
 		});
 	}
@@ -187,11 +187,11 @@ where C::Target: chain::Filter,
 	/// [`ChannelMonitor::transaction_unconfirmed`] for details.
 	///
 	/// Used instead of [`block_disconnected`] by clients that are notified of transactions rather
-	/// than blocks. May be called before or after [`update_best_block`] for transactions in the
-	/// corresponding block. See [`update_best_block`] for further calling expectations. 
+	/// than blocks. May be called before or after [`best_block_updated`] for transactions in the
+	/// corresponding block. See [`best_block_updated`] for further calling expectations.
 	///
 	/// [`block_disconnected`]: Self::block_disconnected
-	/// [`update_best_block`]: Self::update_best_block
+	/// [`best_block_updated`]: Self::best_block_updated
 	pub fn transaction_unconfirmed(&self, txid: &Txid) {
 		let monitors = self.monitors.read().unwrap();
 		for monitor in monitors.values() {

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -12,11 +12,12 @@
 //! There are a bunch of these as their handling is relatively error-prone so they are split out
 //! here. See also the chanmon_fail_consistency fuzz test.
 
-use bitcoin::blockdata::block::BlockHeader;
+use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::hash_types::BlockHash;
 use bitcoin::network::constants::Network;
 use chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdateErr};
 use chain::transaction::OutPoint;
+use chain::Listen;
 use chain::Watch;
 use ln::channelmanager::{RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
 use ln::features::InitFeatures;
@@ -114,7 +115,7 @@ fn test_monitor_and_persister_update_fail() {
 		chain_mon
 	};
 	let header = BlockHeader { version: 0x20000000, prev_blockhash: Default::default(), merkle_root: Default::default(), time: 42, bits: 42, nonce: 42 };
-	chain_mon.chain_monitor.block_connected(&header, &[], 200);
+	chain_mon.chain_monitor.block_connected(&Block { header, txdata: vec![] }, 200);
 
 	// Set the persister's return value to be a TemporaryFailure.
 	persister.set_update_ret(Err(ChannelMonitorUpdateErr::TemporaryFailure));

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -140,8 +140,8 @@ fn do_connect_block<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, block: &Block, s
 				node.node.best_block_updated(&block.header, height);
 			},
 			ConnectStyle::FullBlockViaListen => {
-				node.chain_monitor.chain_monitor.block_connected(&block.header, &txdata, height);
-				Listen::block_connected(node.node, &block, height);
+				node.chain_monitor.chain_monitor.block_connected(&block, height);
+				node.node.block_connected(&block, height);
 			}
 		}
 	}

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -10,7 +10,7 @@
 //! A bunch of useful utilities for building networks of nodes and exchanging messages between
 //! nodes for functional tests.
 
-use chain::{Listen, Watch};
+use chain::{Confirm, Listen, Watch};
 use chain::channelmonitor::ChannelMonitor;
 use chain::transaction::OutPoint;
 use ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, ChannelManagerReadArgs, RAACommitmentOrder, PaymentPreimage, PaymentHash, PaymentSecret, PaymentSendFailure};
@@ -79,17 +79,17 @@ pub fn confirm_transaction_at<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, tx: &T
 /// The possible ways we may notify a ChannelManager of a new block
 #[derive(Clone, Copy, PartialEq)]
 pub enum ConnectStyle {
-	/// Calls update_best_block first, detecting transactions in the block only after receiving the
+	/// Calls best_block_updated first, detecting transactions in the block only after receiving the
 	/// header and height information.
 	BestBlockFirst,
 	/// The same as BestBlockFirst, however when we have multiple blocks to connect, we only
-	/// make a single update_best_block call.
+	/// make a single best_block_updated call.
 	BestBlockFirstSkippingBlocks,
 	/// Calls transactions_confirmed first, detecting transactions in the block before updating the
 	/// header and height information.
 	TransactionsFirst,
 	/// The same as TransactionsFirst, however when we have multiple blocks to connect, we only
-	/// make a single update_best_block call.
+	/// make a single best_block_updated call.
 	TransactionsFirstSkippingBlocks,
 	/// Provides the full block via the chain::Listen interface. In the current code this is
 	/// equivalent to TransactionsFirst with some additional assertions.
@@ -128,16 +128,16 @@ fn do_connect_block<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, block: &Block, s
 		let txdata: Vec<_> = block.txdata.iter().enumerate().collect();
 		match *node.connect_style.borrow() {
 			ConnectStyle::BestBlockFirst|ConnectStyle::BestBlockFirstSkippingBlocks => {
-				node.chain_monitor.chain_monitor.update_best_block(&block.header, height);
+				node.chain_monitor.chain_monitor.best_block_updated(&block.header, height);
 				node.chain_monitor.chain_monitor.transactions_confirmed(&block.header, &txdata, height);
-				node.node.update_best_block(&block.header, height);
-				node.node.transactions_confirmed(&block.header, height, &txdata);
+				node.node.best_block_updated(&block.header, height);
+				node.node.transactions_confirmed(&block.header, &txdata, height);
 			},
 			ConnectStyle::TransactionsFirst|ConnectStyle::TransactionsFirstSkippingBlocks => {
 				node.chain_monitor.chain_monitor.transactions_confirmed(&block.header, &txdata, height);
-				node.chain_monitor.chain_monitor.update_best_block(&block.header, height);
-				node.node.transactions_confirmed(&block.header, height, &txdata);
-				node.node.update_best_block(&block.header, height);
+				node.chain_monitor.chain_monitor.best_block_updated(&block.header, height);
+				node.node.transactions_confirmed(&block.header, &txdata, height);
+				node.node.best_block_updated(&block.header, height);
 			},
 			ConnectStyle::FullBlockViaListen => {
 				node.chain_monitor.chain_monitor.block_connected(&block.header, &txdata, height);
@@ -162,13 +162,13 @@ pub fn disconnect_blocks<'a, 'b, 'c, 'd>(node: &'a Node<'b, 'c, 'd>, count: u32)
 			},
 			ConnectStyle::BestBlockFirstSkippingBlocks|ConnectStyle::TransactionsFirstSkippingBlocks => {
 				if i == count - 1 {
-					node.chain_monitor.chain_monitor.update_best_block(&prev_header.0, prev_header.1);
-					node.node.update_best_block(&prev_header.0, prev_header.1);
+					node.chain_monitor.chain_monitor.best_block_updated(&prev_header.0, prev_header.1);
+					node.node.best_block_updated(&prev_header.0, prev_header.1);
 				}
 			},
 			_ => {
-				node.chain_monitor.chain_monitor.update_best_block(&prev_header.0, prev_header.1);
-				node.node.update_best_block(&prev_header.0, prev_header.1);
+				node.chain_monitor.chain_monitor.best_block_updated(&prev_header.0, prev_header.1);
+				node.node.best_block_updated(&prev_header.0, prev_header.1);
 			},
 		}
 	}

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -10,7 +10,7 @@
 //! Further functional tests which test blockchain reorganizations.
 
 use chain::channelmonitor::{ANTI_REORG_DELAY, ChannelMonitor};
-use chain::Watch;
+use chain::{Confirm, Watch};
 use ln::channelmanager::{ChannelManager, ChannelManagerReadArgs};
 use ln::features::InitFeatures;
 use ln::msgs::{ChannelMessageHandler, ErrorAction, HTLCFailChannelUpdate};


### PR DESCRIPTION
Define a separate trait akin to `chain::Listen` for notifying when transactions have been confirmed on chain or unconfirmed during a chain reorganization. Whereas `chain::Listen` is used for block-oriented chain sources, `chain::Confirm` is used for chain sources supplying data for activity related to transactions and outputs registered via `chain::Filter`.