### PR TITLE
Correct Channel outbound HTLC serialization and expand fuzzing coverage

### DIFF
--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -543,7 +543,7 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 				}
 			},
 			11 => {
-				let mut txn = broadcast.txn_broadcasted.lock().unwrap();
+				let mut txn = broadcast.txn_broadcasted.lock().unwrap().split_off(0);
 				if !txn.is_empty() {
 					loss_detector.connect_block(&txn[..]);
 					for _ in 2..100 {

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -39,6 +39,7 @@ use lightning::ln::msgs::DecodeError;
 use lightning::routing::router::get_route;
 use lightning::routing::network_graph::NetGraphMsgHandler;
 use lightning::util::config::UserConfig;
+use lightning::util::errors::APIError;
 use lightning::util::events::Event;
 use lightning::util::enforcing_trait_impls::EnforcingSigner;
 use lightning::util::logger::Logger;
@@ -531,7 +532,13 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 							continue 'outer_loop;
 						}
 					};
-					channelmanager.funding_transaction_generated(&funding_generation.0, tx.clone()).unwrap();
+					if let Err(e) = channelmanager.funding_transaction_generated(&funding_generation.0, tx.clone()) {
+						// It's possible the channel has been closed in the mean time, but any other
+						// failure may be a bug.
+						if let APIError::ChannelUnavailable { err } = e {
+							assert_eq!(err, "No such channel");
+						} else { panic!(); }
+					}
 					pending_funding_signatures.insert(funding_output, tx);
 				}
 			},

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4451,9 +4451,10 @@ impl<Signer: Sign> Writeable for Channel<Signer> {
 				&OutboundHTLCState::Committed => {
 					1u8.write(writer)?;
 				},
-				&OutboundHTLCState::RemoteRemoved(ref fail_reason) => {
-					2u8.write(writer)?;
-					fail_reason.write(writer)?;
+				&OutboundHTLCState::RemoteRemoved(_) => {
+					// Treat this as a Committed because we haven't received the CS - they'll
+					// resend the claim/fail on reconnect as we all (hopefully) the missing CS.
+					1u8.write(writer)?;
 				},
 				&OutboundHTLCState::AwaitingRemoteRevokeToRemove(ref fail_reason) => {
 					3u8.write(writer)?;


### PR DESCRIPTION
This is based on #851 as it is required to get chanmon_consistency_target to run clean anyway.

This fixes a few trivial bugs in full_stack_target, then expands the coverage of chanmon_consistency_target significantly, fixing one bug that that expansion found (so far).