### PR TITLE
Require min_final_cltv_expiry in invoices

### DIFF
--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -54,6 +54,11 @@ const SYSTEM_TIME_MAX_UNIX_TIMESTAMP: u64 = std::i32::MAX as u64;
 /// it should be rather low as long as we still have to support 32bit time representations
 const MAX_EXPIRY_TIME: u64 = 60 * 60 * 24 * 356;
 
+/// Default expiry time as defined by [BOLT 11].
+///
+/// [BOLT 11]: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
+const DEFAULT_EXPIRY_TIME: u64 = 3600;
+
 /// This function is used as a static assert for the size of `SystemTime`. If the crate fails to
 /// compile due to it this indicates that your system uses unexpected bounds for `SystemTime`. You
 /// can remove this functions and run the test `test_system_time_bounds_assumptions`. In any case,
@@ -1041,11 +1046,11 @@ impl Invoice {
 		self.signed_invoice.recover_payee_pub_key().expect("was checked by constructor").0
 	}
 
-	/// Returns the invoice's expiry time if present
+	/// Returns the invoice's expiry time, if present, otherwise [`DEFAULT_EXPIRY_TIME`].
 	pub fn expiry_time(&self) -> Duration {
 		self.signed_invoice.expiry_time()
 			.map(|x| x.0)
-			.unwrap_or(Duration::from_secs(3600))
+			.unwrap_or(Duration::from_secs(DEFAULT_EXPIRY_TIME))
 	}
 
 	/// Returns the invoice's `min_cltv_expiry` time if present

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -59,6 +59,11 @@ const MAX_EXPIRY_TIME: u64 = 60 * 60 * 24 * 356;
 /// [BOLT 11]: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
 const DEFAULT_EXPIRY_TIME: u64 = 3600;
 
+/// Default minimum final CLTV expiry as defined by [BOLT 11].
+///
+/// [BOLT 11]: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md
+const DEFAULT_MIN_FINAL_CLTV_EXPIRY: u64 = 18;
+
 /// This function is used as a static assert for the size of `SystemTime`. If the crate fails to
 /// compile due to it this indicates that your system uses unexpected bounds for `SystemTime`. You
 /// can remove this functions and run the test `test_system_time_bounds_assumptions`. In any case,
@@ -1053,9 +1058,12 @@ impl Invoice {
 			.unwrap_or(Duration::from_secs(DEFAULT_EXPIRY_TIME))
 	}
 
-	/// Returns the invoice's `min_cltv_expiry` time if present
-	pub fn min_final_cltv_expiry(&self) -> Option<u64> {
-		self.signed_invoice.min_final_cltv_expiry().map(|x| x.0)
+	/// Returns the invoice's `min_final_cltv_expiry` time, if present, otherwise
+	/// [`DEFAULT_MIN_FINAL_CLTV_EXPIRY`].
+	pub fn min_final_cltv_expiry(&self) -> u64 {
+		self.signed_invoice.min_final_cltv_expiry()
+			.map(|x| x.0)
+			.unwrap_or(DEFAULT_MIN_FINAL_CLTV_EXPIRY)
 	}
 
 	/// Returns a list of all fallback addresses
@@ -1620,7 +1628,7 @@ mod test {
 		);
 		assert_eq!(invoice.payee_pub_key(), Some(&public_key));
 		assert_eq!(invoice.expiry_time(), Duration::from_secs(54321));
-		assert_eq!(invoice.min_final_cltv_expiry(), Some(144));
+		assert_eq!(invoice.min_final_cltv_expiry(), 144);
 		assert_eq!(invoice.fallbacks(), vec![&Fallback::PubKeyHash([0;20])]);
 		assert_eq!(invoice.routes(), vec![&RouteHint(route_1), &RouteHint(route_2)]);
 		assert_eq!(

--- a/lightning-invoice/tests/ser_de.rs
+++ b/lightning-invoice/tests/ser_de.rs
@@ -110,13 +110,14 @@ fn get_test_tuples() -> Vec<(String, SignedRawInvoice, Option<SemanticError>)> {
 				.amount_pico_btc(20000000000)
 				.timestamp(UNIX_EPOCH + Duration::from_secs(1496314658))
 				.payment_secret(PaymentSecret([42; 32]))
-				.build_signed(|msg_hash| {
+				.build_raw()
+				.unwrap()
+				.sign::<_, ()>(|msg_hash| {
 					let privkey = SecretKey::from_slice(&[41; 32]).unwrap();
 					let secp_ctx = Secp256k1::new();
-					secp_ctx.sign_recoverable(msg_hash, &privkey)
+					Ok(secp_ctx.sign_recoverable(msg_hash, &privkey))
 				})
-				.unwrap()
-				.into_signed_raw(),
+				.unwrap(),
 			None
 		)
 	]


### PR DESCRIPTION
Lightning invoices must be constructed with the `min_final_cltv_expiry` field set. For backwards compatibility, use a default value if not set.

Fixes #879.