### PR TITLE
Minor Tweaks to lightning-invoice for C bindings

### DIFF
--- a/lightning-invoice/src/de.rs
+++ b/lightning-invoice/src/de.rs
@@ -20,7 +20,9 @@ use secp256k1;
 use secp256k1::recovery::{RecoveryId, RecoverableSignature};
 use secp256k1::key::PublicKey;
 
-use super::*;
+use super::{Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiry, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
+	SemanticError, RouteHint, Description, RawTaggedField, Currency, RawHrp, SiPrefix, RawInvoice, constants, SignedRawInvoice,
+	RawDataPart, CreationError, InvoiceFeatures};
 
 use self::hrp_sm::parse_hrp;
 

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1322,10 +1322,8 @@ impl std::error::Error for SemanticError { }
 
 /// When signing using a fallible method either an user-supplied `SignError` or a `CreationError`
 /// may occur.
-///
-/// (C-not exported) As we don't support unbounded generics
 #[derive(Eq, PartialEq, Debug, Clone)]
-pub enum SignOrCreationError<S> {
+pub enum SignOrCreationError<S = ()> {
 	/// An error occurred during signing
 	SignError(S),
 

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -332,6 +332,8 @@ pub enum Currency {
 }
 
 /// Tagged field which may have an unknown tag
+///
+/// (C-not exported) as we don't currently support TaggedField
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum RawTaggedField {
 	/// Parsed tagged field with known tag
@@ -343,6 +345,9 @@ pub enum RawTaggedField {
 /// Tagged field with known tag
 ///
 /// For descriptions of the enum values please refer to the enclosed type's docs.
+///
+/// (C-not exported) As we don't yet support enum variants with the same name the struct contained
+/// in the variant.
 #[allow(missing_docs)]
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum TaggedField {

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -123,6 +123,7 @@ impl Display for SignedRawInvoice {
 	}
 }
 
+/// (C-not exported)
 impl Display for RawHrp {
 	fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
 		let amount = match self.raw_amount {

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -2,7 +2,8 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use bech32::{ToBase32, u5, WriteBase32, Base32Len};
 
-use ::*;
+use super::{Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiry, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
+	RouteHint, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawInvoice, RawDataPart};
 
 /// Converts a stream of bytes written to it to base32. On finalization the according padding will
 /// be applied. That means the results of writing two data blocks with one or two `BytesToBase32`


### PR DESCRIPTION
This + https://github.com/lightningdevkit/ldk-c-bindings/pull/19 correctly builds the new invoice construction utility method for C (+Java).