### PR TITLE
Ensure payments don't ever duplicatively fail/succeed on reload

### DIFF
--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, BinaryHeap};
 use std::ops::Deref;
 
 /// A hop in a route
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct RouteHop {
 	/// The node_id of the node at this hop.
 	pub pubkey: PublicKey,
@@ -84,7 +84,7 @@ impl Readable for Vec<RouteHop> {
 
 /// A route directs a payment from the sender (us) to the recipient. If the recipient supports MPP,
 /// it can take multiple paths. Each path is composed of one or more hops through the network.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Route {
 	/// The list of routes taken for a single (potentially-)multi-part payment. The pubkey of the
 	/// last RouteHop in each path must be the same.


### PR DESCRIPTION
When a Channel is closed, any outbound HTLCs which were relayed
through it are simply dropped when the Channel is. From there, the
ChannelManager relies on the ChannelMonitor having a copy of the
relevant fail-/claim-back data and processes the HTLC fail/claim
when the ChannelMonitor tells it to.

If, due to an on-chain event, an HTLC is failed/claimed, and then
we serialize the ChannelManager, we generally expect there not to
be a duplicate HTLC fail/claim (eg via a PaymentFailed event
appearing). However, because we may not serialize the relevant
ChannelMonitor at the same time, we may end up getting a
duplicative event, potentially confusing user payment tracking.

In order to provide this consistency, we add explicit tracking of
pending-onchain-resolution outbound HTLCs in the ChannelManager,
using it to de-duplicate ChannelMonitor events.