### PR TITLE
Make payments not duplicatively fail/succeed on reload/reconnect

### DIFF
--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -95,8 +95,6 @@ pub enum Event {
 	},
 	/// Indicates an outbound payment we made succeeded (ie it made it all the way to its target
 	/// and we got back the payment preimage for it).
-	/// Note that duplicative PaymentSent Events may be generated - it is your responsibility to
-	/// deduplicate them by payment_preimage (which MUST be unique)!
 	PaymentSent {
 		/// The preimage to the hash given to ChannelManager::send_payment.
 		/// Note that this serves as a payment receipt, if you wish to have such a thing, you must
@@ -105,8 +103,6 @@ pub enum Event {
 	},
 	/// Indicates an outbound payment we made failed. Probably some intermediary node dropped
 	/// something. You may wish to retry with a different route.
-	/// Note that duplicative PaymentFailed Events may be generated - it is your responsibility to
-	/// deduplicate them by payment_hash (which MUST be unique)!
 	PaymentFailed {
 		/// The hash which was given to ChannelManager::send_payment.
 		payment_hash: PaymentHash,


### PR DESCRIPTION
We currently generate duplicative PaymentFailed/PaymentSent events
in two cases:

a) If we receive a update_fulfill_htlc message, followed by a
   disconnect, then a resend of the same update_fulfill_htlc
   message, we will generate a PaymentSent event for each message.

b) When a Channel is closed, any outbound HTLCs which were relayed
   through it are simply dropped when the Channel is. From there,
   the ChannelManager relies on the ChannelMonitor having a copy of
   the relevant fail-/claim-back data and processes the HTLC
   fail/claim when the ChannelMonitor tells it to.

   If, due to an on-chain event, an HTLC is failed/claimed, and
   then we serialize the ChannelManager, but do not re-serialize
   the relevant ChannelMonitor, we may end up getting a duplicative
   event.

In order to provide the expected consistency, we add explicit
tracking of pending outbound payments using their unique
session_priv field which is generated when the payment is sent.
Then, before generating PaymentFailed/PaymentSent events, we check
that the session_priv for the payment is still pending.

Thix fixes #209.