### PR TITLE
Return more error details on http's read_response

### DIFF
--- a/lightning-block-sync/src/rest.rs
+++ b/lightning-block-sync/src/rest.rs
@@ -84,7 +84,7 @@ mod tests {
 		let mut client = RestClient::new(server.endpoint()).unwrap();
 
 		match client.request_resource::<BinaryResponse, u32>("/").await {
-			Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+			Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::Other),
 			Ok(_) => panic!("Expected error"),
 		}
 	}

--- a/lightning-block-sync/src/rpc.rs
+++ b/lightning-block-sync/src/rpc.rs
@@ -118,7 +118,7 @@ mod tests {
 		let mut client = RpcClient::new(CREDENTIALS, server.endpoint()).unwrap();
 
 		match client.call_method::<u64>("getblockcount", &[]).await {
-			Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::NotFound),
+			Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::Other),
 			Ok(_) => panic!("Expected error"),
 		}
 	}


### PR DESCRIPTION
Otherwise helpful error information gets swallowed.

Closes #877 