### PR TITLE
Correct default invoice expiry

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -272,7 +272,7 @@ fn get_payment_secret_hash(dest: &ChanMan, payment_id: &mut u8) -> Option<(Payme
 	let mut payment_hash;
 	for _ in 0..256 {
 		payment_hash = PaymentHash(Sha256::hash(&[*payment_id; 1]).into_inner());
-		if let Ok(payment_secret) = dest.create_inbound_payment_for_hash(payment_hash, None, 7200, 0) {
+		if let Ok(payment_secret) = dest.create_inbound_payment_for_hash(payment_hash, None, 3600, 0) {
 			return Some((payment_secret, payment_hash));
 		}
 		*payment_id = payment_id.wrapping_add(1);

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -1,5 +1,5 @@
 //! Convenient utilities to create an invoice.
-use {Currency, Invoice, InvoiceBuilder, SignOrCreationError, RawInvoice};
+use {Currency, DEFAULT_EXPIRY_TIME, Invoice, InvoiceBuilder, SignOrCreationError, RawInvoice};
 use bech32::ToBase32;
 use bitcoin_hashes::Hash;
 use lightning::chain;
@@ -9,6 +9,7 @@ use lightning::ln::channelmanager::{ChannelManager, MIN_FINAL_CLTV_EXPIRY};
 use lightning::routing::network_graph::RoutingFees;
 use lightning::routing::router::RouteHintHop;
 use lightning::util::logger::Logger;
+use std::convert::TryInto;
 use std::ops::Deref;
 
 /// Utility to construct an invoice. Generally, unless you want to do something like a custom
@@ -54,7 +55,7 @@ where
 
 	let (payment_hash, payment_secret) = channelmanager.create_inbound_payment(
 		amt_msat,
-		7200, // default invoice expiry is 2 hours
+		DEFAULT_EXPIRY_TIME.try_into().unwrap(),
 		0,
 	);
 	let our_node_pubkey = channelmanager.get_our_node_id();

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3477,7 +3477,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	/// `invoice_expiry_delta_secs` describes the number of seconds that the invoice is valid for
 	/// in excess of the current time. This should roughly match the expiry time set in the invoice.
 	/// After this many seconds, we will remove the inbound payment, resulting in any attempts to
-	/// pay the invoice failing. The BOLT spec suggests 7,200 secs as a default validity time for
+	/// pay the invoice failing. The BOLT spec suggests 3,600 secs as a default validity time for
 	/// invoices when no timeout is set.
 	///
 	/// Note that we use block header time to time-out pending inbound payments (with some margin


### PR DESCRIPTION
We previously stated in the codebase that the default invoice expiry
stated in the spec is 2 hours. It's actually 1 hour.

Relevant spec: https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#tagged-fields