### PR TITLE
Use alloc for no_std builds

### DIFF
--- a/lightning/src/chain/chainmonitor.rs
+++ b/lightning/src/chain/chainmonitor.rs
@@ -37,6 +37,7 @@ use util::logger::Logger;
 use util::events;
 use util::events::EventHandler;
 
+use prelude::*;
 use std::collections::{HashMap, hash_map};
 use std::sync::RwLock;
 use core::ops::Deref;
@@ -143,7 +144,7 @@ where C::Target: chain::Filter,
 	#[cfg(any(test, feature = "fuzztarget", feature = "_test_utils"))]
 	pub fn get_and_clear_pending_events(&self) -> Vec<events::Event> {
 		use util::events::EventsProvider;
-		let events = std::cell::RefCell::new(Vec::new());
+		let events = core::cell::RefCell::new(Vec::new());
 		let event_handler = |event| events.borrow_mut().push(event);
 		self.process_pending_events(&event_handler);
 		events.into_inner()

--- a/lightning/src/chain/channelmonitor.rs
+++ b/lightning/src/chain/channelmonitor.rs
@@ -51,6 +51,7 @@ use util::ser::{Readable, ReadableArgs, MaybeReadable, Writer, Writeable, U48};
 use util::byte_utils;
 use util::events::Event;
 
+use prelude::*;
 use std::collections::{HashMap, HashSet};
 use core::{cmp, mem};
 use std::io::Error;
@@ -2911,6 +2912,7 @@ mod tests {
 	use bitcoin::secp256k1::Secp256k1;
 	use std::sync::{Arc, Mutex};
 	use chain::keysinterface::InMemorySigner;
+	use prelude::*;
 
 	#[test]
 	fn test_prune_preimages() {

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -37,6 +37,7 @@ use ln::chan_utils;
 use ln::chan_utils::{HTLCOutputInCommitment, make_funding_redeemscript, ChannelPublicKeys, HolderCommitmentTransaction, ChannelTransactionParameters, CommitmentTransaction};
 use ln::msgs::UnsignedChannelAnnouncement;
 
+use prelude::*;
 use std::collections::HashSet;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Error;

--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -18,6 +18,8 @@ use chain::channelmonitor::{ChannelMonitor, ChannelMonitorUpdate, ChannelMonitor
 use chain::keysinterface::Sign;
 use chain::transaction::{OutPoint, TransactionData};
 
+use prelude::*;
+
 pub mod chaininterface;
 pub mod chainmonitor;
 pub mod channelmonitor;

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -32,6 +32,7 @@ use util::logger::Logger;
 use util::ser::{Readable, ReadableArgs, Writer, Writeable, VecWriter};
 use util::byte_utils;
 
+use prelude::*;
 use std::collections::HashMap;
 use core::cmp;
 use core::ops::Deref;

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -31,9 +31,9 @@ use util::byte_utils;
 use util::logger::Logger;
 use util::ser::{Readable, Writer, Writeable};
 
-use std::cmp;
-use std::mem;
-use std::ops::Deref;
+use core::cmp;
+use core::mem;
+use core::ops::Deref;
 
 const MAX_ALLOC_SIZE: usize = 64*1024;
 

--- a/lightning/src/lib.rs
+++ b/lightning/src/lib.rs
@@ -31,6 +31,7 @@
 #![cfg_attr(all(any(test, feature = "_test_utils"), feature = "unstable"), feature(test))]
 #[cfg(all(any(test, feature = "_test_utils"), feature = "unstable"))] extern crate test;
 
+extern crate alloc;
 extern crate bitcoin;
 extern crate core;
 #[cfg(any(test, feature = "_test_utils"))] extern crate hex;
@@ -41,3 +42,7 @@ pub mod util;
 pub mod chain;
 pub mod ln;
 pub mod routing;
+
+mod prelude {
+	pub use alloc::{vec, vec::Vec, string::String};
+}

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -31,6 +31,7 @@ use bitcoin::secp256k1::{Secp256k1, Signature, Message};
 use bitcoin::secp256k1::Error as SecpError;
 use bitcoin::secp256k1;
 
+use prelude::*;
 use core::cmp;
 use ln::chan_utils;
 use util::transaction_utils::sort_outputs;
@@ -1235,6 +1236,7 @@ fn script_for_p2wpkh(key: &PublicKey) -> Script {
 mod tests {
 	use super::CounterpartyCommitmentSecrets;
 	use hex;
+	use prelude::*;
 
 	#[test]
 	fn test_per_commitment_storage() {

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -38,6 +38,7 @@ use ln::functional_test_utils::*;
 
 use util::test_utils;
 
+use prelude::*;
 use std::collections::HashMap;
 
 // If persister_fail is true, we have the persister return a PermanentFailure

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -40,6 +40,7 @@ use util::errors::APIError;
 use util::config::{UserConfig,ChannelConfig};
 use util::scid_utils::scid_from_parts;
 
+use prelude::*;
 use core::{cmp,mem,fmt};
 use core::ops::Deref;
 #[cfg(any(test, feature = "fuzztarget"))]
@@ -4928,6 +4929,7 @@ mod tests {
 	use bitcoin::hashes::Hash;
 	use bitcoin::hash_types::{Txid, WPubkeyHash};
 	use std::sync::Arc;
+	use prelude::*;
 
 	struct TestFeeEstimator {
 		fee_est: u32

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -61,8 +61,9 @@ use util::chacha20::{ChaCha20, ChaChaReader};
 use util::logger::Logger;
 use util::errors::APIError;
 
+use prelude::*;
 use core::{cmp, mem};
-use std::cell::RefCell;
+use core::cell::RefCell;
 use std::collections::{HashMap, hash_map, HashSet};
 use std::io::{Cursor, Read};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard};
@@ -3685,7 +3686,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 	#[cfg(any(test, feature = "fuzztarget", feature = "_test_utils"))]
 	pub fn get_and_clear_pending_events(&self) -> Vec<events::Event> {
-		let events = std::cell::RefCell::new(Vec::new());
+		let events = core::cell::RefCell::new(Vec::new());
 		let event_handler = |event| events.borrow_mut().push(event);
 		self.process_pending_events(&event_handler);
 		events.into_inner()

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -22,6 +22,7 @@
 //! [BOLT #9]: https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md
 //! [messages]: crate::ln::msgs
 
+use prelude::*;
 use core::{cmp, fmt};
 use core::marker::PhantomData;
 
@@ -31,6 +32,7 @@ use ln::msgs::DecodeError;
 use util::ser::{Readable, Writeable, Writer};
 
 mod sealed {
+	use prelude::*;
 	use ln::features::Features;
 
 	/// The context in which [`Features`] are applicable. Defines which features are required and

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -39,6 +39,7 @@ use bitcoin::hash_types::BlockHash;
 
 use bitcoin::secp256k1::key::PublicKey;
 
+use prelude::*;
 use core::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Mutex;

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -50,7 +50,9 @@ use bitcoin::secp256k1::key::{PublicKey,SecretKey};
 
 use regex;
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use prelude::*;
+use alloc::collections::BTreeSet;
+use std::collections::{HashMap, HashSet};
 use core::default::Default;
 use std::sync::Mutex;
 

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -68,6 +68,7 @@ pub struct PaymentPreimage(pub [u8;32]);
 #[derive(Hash, Copy, Clone, PartialEq, Eq, Debug)]
 pub struct PaymentSecret(pub [u8;32]);
 
+use prelude::*;
 use bitcoin::bech32;
 use bitcoin::bech32::{Base32Len, FromBase32, ToBase32, WriteBase32, u5};
 

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -32,6 +32,7 @@ use bitcoin::hash_types::{Txid, BlockHash};
 
 use ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 
+use prelude::*;
 use core::{cmp, fmt};
 use core::fmt::Debug;
 use std::io::Read;
@@ -867,6 +868,7 @@ pub trait RoutingMessageHandler : MessageSendEventsProvider {
 }
 
 mod fuzzy_internal_msgs {
+	use prelude::*;
 	use ln::PaymentSecret;
 
 	// These types aren't intended to be pub, but are exposed for direct fuzzing (as we deserialize
@@ -1841,6 +1843,7 @@ mod tests {
 	use bitcoin::secp256k1::key::{PublicKey,SecretKey};
 	use bitcoin::secp256k1::{Secp256k1, Message};
 
+	use prelude::*;
 	use std::io::Cursor;
 
 	#[test]

--- a/lightning/src/ln/onion_route_tests.rs
+++ b/lightning/src/ln/onion_route_tests.rs
@@ -32,6 +32,7 @@ use bitcoin::hashes::Hash;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::secp256k1::key::SecretKey;
 
+use prelude::*;
 use core::default::Default;
 use std::io;
 

--- a/lightning/src/ln/onion_utils.rs
+++ b/lightning/src/ln/onion_utils.rs
@@ -27,6 +27,7 @@ use bitcoin::secp256k1::Secp256k1;
 use bitcoin::secp256k1::ecdh::SharedSecret;
 use bitcoin::secp256k1;
 
+use prelude::*;
 use std::io::Cursor;
 use core::ops::Deref;
 
@@ -478,6 +479,7 @@ pub(super) fn process_onion_failure<T: secp256k1::Signing, L: Deref>(secp_ctx: &
 
 #[cfg(test)]
 mod tests {
+	use prelude::*;
 	use ln::PaymentHash;
 	use ln::features::{ChannelFeatures, NodeFeatures};
 	use routing::router::{Route, RouteHop};

--- a/lightning/src/ln/peer_channel_encryptor.rs
+++ b/lightning/src/ln/peer_channel_encryptor.rs
@@ -7,6 +7,8 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+use prelude::*;
+
 use ln::msgs::LightningError;
 use ln::msgs;
 

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -30,7 +30,9 @@ use util::events::{MessageSendEvent, MessageSendEventsProvider};
 use util::logger::Logger;
 use routing::network_graph::NetGraphMsgHandler;
 
-use std::collections::{HashMap,hash_map,HashSet,LinkedList};
+use prelude::*;
+use alloc::collections::LinkedList;
+use std::collections::{HashMap,hash_map,HashSet};
 use std::sync::{Arc, Mutex};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{cmp, hash, fmt, mem};
@@ -1421,6 +1423,7 @@ mod tests {
 	use bitcoin::secp256k1::Secp256k1;
 	use bitcoin::secp256k1::key::{SecretKey, PublicKey};
 
+	use prelude::*;
 	use std::sync::{Arc, Mutex};
 	use core::sync::atomic::Ordering;
 

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -22,6 +22,7 @@ use util::ser::{ReadableArgs, Writeable};
 use bitcoin::blockdata::block::{Block, BlockHeader};
 use bitcoin::hash_types::BlockHash;
 
+use prelude::*;
 use std::collections::HashMap;
 use core::mem;
 

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -351,6 +351,7 @@ impl Encode for msgs::GossipTimestampFilter {
 mod tests {
 	use super::*;
 	use util::byte_utils;
+	use prelude::*;
 
 	// Big-endian wire encoding of Pong message (type = 19, byteslen = 2).
 	const ENCODED_PONG: [u8; 6] = [0u8, 19u8, 0u8, 2u8, 0u8, 0u8];

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -32,12 +32,12 @@ use util::logger::Logger;
 use util::events::{MessageSendEvent, MessageSendEventsProvider};
 use util::scid_utils::{block_from_scid, scid_from_parts, MAX_SCID_BLOCK};
 
+use prelude::*;
+use alloc::collections::{BTreeMap, btree_map::Entry as BtreeEntry};
 use core::{cmp, fmt};
 use std::sync::{RwLock, RwLockReadGuard};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
-use std::collections::BTreeMap;
-use std::collections::btree_map::Entry as BtreeEntry;
 use core::ops::Deref;
 use bitcoin::hashes::hex::ToHex;
 
@@ -1140,6 +1140,7 @@ mod tests {
 	use bitcoin::secp256k1::key::{PublicKey, SecretKey};
 	use bitcoin::secp256k1::{All, Secp256k1};
 
+	use prelude::*;
 	use std::sync::Arc;
 
 	fn create_net_graph_msg_handler() -> (Secp256k1<All>, NetGraphMsgHandler<Arc<test_utils::TestChainSource>, Arc<test_utils::TestLogger>>) {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -21,8 +21,10 @@ use routing::network_graph::{NetworkGraph, RoutingFees};
 use util::ser::{Writeable, Readable};
 use util::logger::Logger;
 
+use prelude::*;
+use alloc::collections::BinaryHeap;
 use core::cmp;
-use std::collections::{HashMap, BinaryHeap};
+use std::collections::HashMap;
 use core::ops::Deref;
 
 /// A hop in a route
@@ -1193,6 +1195,7 @@ mod tests {
 	use bitcoin::secp256k1::key::{PublicKey,SecretKey};
 	use bitcoin::secp256k1::{Secp256k1, All};
 
+	use prelude::*;
 	use std::sync::Arc;
 
 	// Using the same keys for LN and BTC ids
@@ -3945,6 +3948,7 @@ mod benches {
 	use super::*;
 	use util::logger::{Logger, Record};
 
+	use prelude::*;
 	use test::Bencher;
 
 	struct DummyLogger {}

--- a/lightning/src/util/chacha20.rs
+++ b/lightning/src/util/chacha20.rs
@@ -318,6 +318,7 @@ impl<'a, R: io::Read> io::Read for ChaChaReader<'a, R> {
 
 #[cfg(test)]
 mod test {
+	use prelude::*;
 	use core::iter::repeat;
 
 	use super::ChaCha20;

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -11,6 +11,7 @@ use ln::chan_utils::{HTLCOutputInCommitment, ChannelPublicKeys, HolderCommitment
 use ln::{chan_utils, msgs};
 use chain::keysinterface::{Sign, InMemorySigner, BaseSign};
 
+use prelude::*;
 use core::cmp;
 use std::sync::{Mutex, Arc};
 

--- a/lightning/src/util/errors.rs
+++ b/lightning/src/util/errors.rs
@@ -9,6 +9,7 @@
 
 //! Error types live here.
 
+use alloc::string::String;
 use core::fmt;
 
 /// Indicates an error on the client's part (usually some variant of attempting to use too-low or

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -23,8 +23,9 @@ use bitcoin::blockdata::script::Script;
 
 use bitcoin::secp256k1::key::PublicKey;
 
+use prelude::*;
 use core::time::Duration;
-use std::ops::Deref;
+use core::ops::Deref;
 
 /// An Event which you should probably take some action in response to.
 ///

--- a/lightning/src/util/message_signing.rs
+++ b/lightning/src/util/message_signing.rs
@@ -20,6 +20,7 @@
 //! https://lightning.readthedocs.io/lightning-signmessage.7.html
 //! https://api.lightning.community/#signmessage
 
+use prelude::*;
 use crate::util::zbase32;
 use bitcoin::hashes::{sha256d, Hash};
 use bitcoin::secp256k1::recovery::{RecoverableSignature, RecoveryId};

--- a/lightning/src/util/poly1305.rs
+++ b/lightning/src/util/poly1305.rs
@@ -205,6 +205,7 @@ impl Poly1305 {
 
 #[cfg(test)]
 mod test {
+	use prelude::*;
 	use core::iter::repeat;
 
 	use util::poly1305::Poly1305;

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -10,6 +10,7 @@
 //! A very simple serialization framework which is used to serialize/deserialize messages as well
 //! as ChannelsManagers and ChannelMonitors.
 
+use prelude::*;
 use std::io::{Read, Write};
 use std::collections::HashMap;
 use core::hash::Hash;

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -277,6 +277,7 @@ macro_rules! read_tlv_fields {
 
 #[cfg(test)]
 mod tests {
+	use prelude::*;
 	use std::io::{Cursor, Read};
 	use ln::msgs::DecodeError;
 	use util::ser::{Readable, Writeable, HighZeroBytesDroppedVarInt, VecWriter};

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -36,6 +36,7 @@ use bitcoin::secp256k1::recovery::RecoverableSignature;
 
 use regex;
 
+use prelude::*;
 use core::time::Duration;
 use std::sync::{Mutex, Arc};
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};

--- a/lightning/src/util/transaction_utils.rs
+++ b/lightning/src/util/transaction_utils.rs
@@ -14,6 +14,7 @@ use bitcoin::consensus::encode::VarInt;
 
 use ln::msgs::MAX_VALUE_MSAT;
 
+use prelude::*;
 use core::cmp::Ordering;
 
 pub fn sort_outputs<T, C : Fn(&T, &T) -> Ordering>(outputs: &mut Vec<(TxOut, T)>, tie_breaker: C) {
@@ -82,6 +83,8 @@ mod tests {
 	use bitcoin::hashes::sha256d::Hash as Sha256dHash;
 
 	use hex::decode;
+
+	use alloc::vec;
 
 	#[test]
 	fn sort_output_by_value() {

--- a/lightning/src/util/zbase32.rs
+++ b/lightning/src/util/zbase32.rs
@@ -8,6 +8,8 @@
  * at your option.
 */
 
+use prelude::*;
+
 const ALPHABET: &'static [u8] = b"ybndrfg8ejkmcpqxot1uwisza345h769";
 
 /// Encodes some bytes as a zbase32 string


### PR DESCRIPTION
Replace std structs with alloc equivalents to support no_std builds