### PR TITLE
Migrate some inner structs to TLVs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,13 +143,13 @@ jobs:
         id: cache-graph
         uses: actions/cache@v2
         with:
-          path: lightning/net_graph-2021-02-12.bin
-          key: ldk-net_graph-05f0c5a0d772-2020-02-12.bin
+          path: lightning/net_graph-2021-05-27.bin
+          key: ldk-net_graph-45d86ead641d-2021-05-27.bin
       - name: Fetch routing graph snapshot
         if: steps.cache-graph.outputs.cache-hit != 'true'
         run: |
-          wget -O lightning/net_graph-2021-02-12.bin https://bitcoin.ninja/ldk-net_graph-05f0c5a0d772-2020-02-12.bin
-          if [ "$(sha256sum lightning/net_graph-2021-02-12.bin | awk '{ print $1 }')" != "7116fca78551fedc714a604cec0ad1ca66caa77bb4d0051290258e7a10e0c6e7" ]; then
+          wget -O lightning/net_graph-2021-05-27.bin https://bitcoin.ninja/ldk-net_graph-45d86ead641d-2021-05-27.bin
+          if [ "$(sha256sum lightning/net_graph-2021-05-27.bin | awk '{ print $1 }')" != "3d6261187cfa583255d978efb908b51c2f4dc4ad9a7160cd2c5263c9a4830121" ]; then
             echo "Bad hash"
             exit 1
           fi

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -703,10 +703,11 @@ impl Writeable for PackageTemplate {
 			outpoint.write(writer)?;
 			rev_outp.write(writer)?;
 		}
-		self.soonest_conf_deadline.write(writer)?;
-		self.feerate_previous.write(writer)?;
-		self.height_timer.write(writer)?;
-		self.height_original.write(writer)?;
+		write_tlv_fields!(writer, {
+			(0, self.soonest_conf_deadline),
+			(2, self.feerate_previous),
+			(4, self.height_original),
+		}, { (6, self.height_timer) });
 		Ok(())
 	}
 }
@@ -730,10 +731,15 @@ impl Readable for PackageTemplate {
 				PackageSolvingData::HolderFundingOutput(..) => { (PackageMalleability::Untractable, false) },
 			}
 		} else { return Err(DecodeError::InvalidValue); };
-		let soonest_conf_deadline = Readable::read(reader)?;
-		let feerate_previous = Readable::read(reader)?;
-		let height_timer = Readable::read(reader)?;
-		let height_original = Readable::read(reader)?;
+		let mut soonest_conf_deadline = 0;
+		let mut feerate_previous = 0;
+		let mut height_timer = None;
+		let mut height_original = 0;
+		read_tlv_fields!(reader, {
+			(0, soonest_conf_deadline),
+			(2, feerate_previous),
+			(4, height_original)
+		}, { (6, height_timer) });
 		Ok(PackageTemplate {
 			inputs,
 			malleability,

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -21,7 +21,7 @@ use bitcoin::hash_types::Txid;
 use bitcoin::secp256k1::key::{SecretKey,PublicKey};
 
 use ln::PaymentPreimage;
-use ln::chan_utils::{TxCreationKeys, HTLCOutputInCommitment, HTLC_OUTPUT_IN_COMMITMENT_SIZE};
+use ln::chan_utils::{TxCreationKeys, HTLCOutputInCommitment};
 use ln::chan_utils;
 use ln::msgs::DecodeError;
 use chain::chaininterface::{FeeEstimator, ConfirmationTarget, MIN_RELAY_FEE_SAT_PER_1000_WEIGHT};
@@ -86,15 +86,15 @@ impl RevokedOutput {
 	}
 }
 
-impl_writeable!(RevokedOutput, 33*3 + 32 + 8 + 8 + 2, {
-	per_commitment_point,
-	counterparty_delayed_payment_base_key,
-	counterparty_htlc_base_key,
-	per_commitment_key,
-	weight,
-	amount,
-	on_counterparty_tx_csv
-});
+impl_writeable_tlv_based!(RevokedOutput, {
+	(0, per_commitment_point),
+	(2, counterparty_delayed_payment_base_key),
+	(4, counterparty_htlc_base_key),
+	(6, per_commitment_key),
+	(8, weight),
+	(10, amount),
+	(12, on_counterparty_tx_csv),
+}, {}, {});
 
 /// A struct to describe a revoked offered output and corresponding information to generate a
 /// solving witness.
@@ -130,15 +130,15 @@ impl RevokedHTLCOutput {
 	}
 }
 
-impl_writeable!(RevokedHTLCOutput, 33*3 + 32 + 8 + 8 + HTLC_OUTPUT_IN_COMMITMENT_SIZE, {
-	per_commitment_point,
-	counterparty_delayed_payment_base_key,
-	counterparty_htlc_base_key,
-	per_commitment_key,
-	weight,
-	amount,
-	htlc
-});
+impl_writeable_tlv_based!(RevokedHTLCOutput, {
+	(0, per_commitment_point),
+	(2, counterparty_delayed_payment_base_key),
+	(4, counterparty_htlc_base_key),
+	(6, per_commitment_key),
+	(8, weight),
+	(10, amount),
+	(12, htlc),
+}, {}, {});
 
 /// A struct to describe a HTLC output on a counterparty commitment transaction.
 ///
@@ -167,13 +167,13 @@ impl CounterpartyOfferedHTLCOutput {
 	}
 }
 
-impl_writeable!(CounterpartyOfferedHTLCOutput, 33*3 + 32 + HTLC_OUTPUT_IN_COMMITMENT_SIZE, {
-	per_commitment_point,
-	counterparty_delayed_payment_base_key,
-	counterparty_htlc_base_key,
-	preimage,
-	htlc
-});
+impl_writeable_tlv_based!(CounterpartyOfferedHTLCOutput, {
+	(0, per_commitment_point),
+	(2, counterparty_delayed_payment_base_key),
+	(4, counterparty_htlc_base_key),
+	(6, preimage),
+	(8, htlc),
+}, {}, {});
 
 /// A struct to describe a HTLC output on a counterparty commitment transaction.
 ///
@@ -198,12 +198,12 @@ impl CounterpartyReceivedHTLCOutput {
 	}
 }
 
-impl_writeable!(CounterpartyReceivedHTLCOutput, 33*3 + HTLC_OUTPUT_IN_COMMITMENT_SIZE, {
-	per_commitment_point,
-	counterparty_delayed_payment_base_key,
-	counterparty_htlc_base_key,
-	htlc
-});
+impl_writeable_tlv_based!(CounterpartyReceivedHTLCOutput, {
+	(0, per_commitment_point),
+	(2, counterparty_delayed_payment_base_key),
+	(4, counterparty_htlc_base_key),
+	(6, htlc),
+}, {}, {});
 
 /// A struct to describe a HTLC output on holder commitment transaction.
 ///
@@ -224,10 +224,11 @@ impl HolderHTLCOutput {
 	}
 }
 
-impl_writeable!(HolderHTLCOutput, 0, {
-	preimage,
-	amount
-});
+impl_writeable_tlv_based!(HolderHTLCOutput, {
+	(0, amount),
+}, {
+	(2, preimage),
+}, {});
 
 /// A struct to describe the channel output on the funding transaction.
 ///
@@ -245,9 +246,9 @@ impl HolderFundingOutput {
 	}
 }
 
-impl_writeable!(HolderFundingOutput, 0, {
-	funding_redeemscript
-});
+impl_writeable_tlv_based!(HolderFundingOutput, {
+	(0, funding_redeemscript),
+}, {}, {});
 
 /// A wrapper encapsulating all in-protocol differing outputs types.
 ///

--- a/lightning/src/chain/transaction.rs
+++ b/lightning/src/chain/transaction.rs
@@ -73,6 +73,14 @@ impl OutPoint {
 			vout: self.index as u32,
 		}
 	}
+
+	/// Creates a dummy BitcoinOutPoint, useful for deserializing into.
+	pub(crate) fn null() -> Self {
+		Self {
+			txid: Default::default(),
+			index: 0
+		}
+	}
 }
 
 impl_writeable!(OutPoint, 0, { txid, index });

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4316,9 +4316,9 @@ impl PersistenceNotifier {
 const SERIALIZATION_VERSION: u8 = 1;
 const MIN_SERIALIZATION_VERSION: u8 = 1;
 
-impl Writeable for PendingHTLCInfo {
+impl Writeable for PendingHTLCRouting {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
-		match &self.routing {
+		match &self {
 			&PendingHTLCRouting::Forward { ref onion_packet, ref short_channel_id } => {
 				0u8.write(writer)?;
 				onion_packet.write(writer)?;
@@ -4331,38 +4331,36 @@ impl Writeable for PendingHTLCInfo {
 				incoming_cltv_expiry.write(writer)?;
 			},
 		}
-		self.incoming_shared_secret.write(writer)?;
-		self.payment_hash.write(writer)?;
-		self.amt_to_forward.write(writer)?;
-		self.outgoing_cltv_value.write(writer)?;
 		Ok(())
 	}
 }
 
-impl Readable for PendingHTLCInfo {
-	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<PendingHTLCInfo, DecodeError> {
-		Ok(PendingHTLCInfo {
-			routing: match Readable::read(reader)? {
-				0u8 => PendingHTLCRouting::Forward {
-					onion_packet: Readable::read(reader)?,
-					short_channel_id: Readable::read(reader)?,
+impl Readable for PendingHTLCRouting {
+	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<PendingHTLCRouting, DecodeError> {
+		match Readable::read(reader)? {
+			0u8 => Ok(PendingHTLCRouting::Forward {
+				onion_packet: Readable::read(reader)?,
+				short_channel_id: Readable::read(reader)?,
+			}),
+			1u8 => Ok(PendingHTLCRouting::Receive {
+				payment_data: msgs::FinalOnionHopData {
+					payment_secret: Readable::read(reader)?,
+					total_msat: Readable::read(reader)?,
 				},
-				1u8 => PendingHTLCRouting::Receive {
-					payment_data: msgs::FinalOnionHopData {
-						payment_secret: Readable::read(reader)?,
-						total_msat: Readable::read(reader)?,
-					},
-					incoming_cltv_expiry: Readable::read(reader)?,
-				},
-				_ => return Err(DecodeError::InvalidValue),
-			},
-			incoming_shared_secret: Readable::read(reader)?,
-			payment_hash: Readable::read(reader)?,
-			amt_to_forward: Readable::read(reader)?,
-			outgoing_cltv_value: Readable::read(reader)?,
-		})
+				incoming_cltv_expiry: Readable::read(reader)?,
+			}),
+			_ => Err(DecodeError::InvalidValue),
+		}
 	}
 }
+
+impl_writeable_tlv_based!(PendingHTLCInfo, {
+	(0, routing),
+	(2, incoming_shared_secret),
+	(4, payment_hash),
+	(6, amt_to_forward),
+	(8, outgoing_cltv_value)
+}, {}, {});
 
 impl Writeable for HTLCFailureMsg {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
@@ -4416,33 +4414,52 @@ impl Readable for PendingHTLCStatus {
 	}
 }
 
-impl_writeable!(HTLCPreviousHopData, 0, {
-	short_channel_id,
-	outpoint,
-	htlc_id,
-	incoming_packet_shared_secret
-});
+impl_writeable_tlv_based!(HTLCPreviousHopData, {
+	(0, short_channel_id),
+	(2, outpoint),
+	(4, htlc_id),
+	(6, incoming_packet_shared_secret)
+}, {}, {});
 
 impl Writeable for ClaimableHTLC {
 	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
-		self.prev_hop.write(writer)?;
-		self.value.write(writer)?;
-		self.payment_data.payment_secret.write(writer)?;
-		self.payment_data.total_msat.write(writer)?;
-		self.cltv_expiry.write(writer)
+		write_tlv_fields!(writer, {
+			(0, self.prev_hop),
+			(2, self.value),
+			(4, self.payment_data.payment_secret),
+			(6, self.payment_data.total_msat),
+			(8, self.cltv_expiry)
+		}, {});
+		Ok(())
 	}
 }
 
 impl Readable for ClaimableHTLC {
 	fn read<R: ::std::io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		let mut prev_hop = HTLCPreviousHopData {
+			short_channel_id: 0, htlc_id: 0,
+			incoming_packet_shared_secret: [0; 32],
+			outpoint: OutPoint::null(),
+		};
+		let mut value = 0;
+		let mut payment_secret = PaymentSecret([0; 32]);
+		let mut total_msat = 0;
+		let mut cltv_expiry = 0;
+		read_tlv_fields!(reader, {
+			(0, prev_hop),
+			(2, value),
+			(4, payment_secret),
+			(6, total_msat),
+			(8, cltv_expiry)
+		}, {});
 		Ok(ClaimableHTLC {
-			prev_hop: Readable::read(reader)?,
-			value: Readable::read(reader)?,
+			prev_hop,
+			value,
 			payment_data: msgs::FinalOnionHopData {
-				payment_secret: Readable::read(reader)?,
-				total_msat: Readable::read(reader)?,
+				payment_secret,
+				total_msat,
 			},
-			cltv_expiry: Readable::read(reader)?,
+			cltv_expiry,
 		})
 	}
 }
@@ -4547,13 +4564,13 @@ impl Readable for HTLCForwardInfo {
 	}
 }
 
-impl_writeable!(PendingInboundPayment, 0, {
-	payment_secret,
-	expiry_time,
-	user_payment_id,
-	payment_preimage,
-	min_value_msat
-});
+impl_writeable_tlv_based!(PendingInboundPayment, {
+	(0, payment_secret),
+	(2, expiry_time),
+	(4, user_payment_id),
+	(6, payment_preimage),
+	(8, min_value_msat),
+}, {}, {});
 
 impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable for ChannelManager<Signer, M, T, K, F, L>
 	where M::Target: chain::Watch<Signer>,

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -482,6 +482,17 @@ impl Readable for Result<NetAddress, u8> {
 	}
 }
 
+impl Readable for NetAddress {
+	fn read<R: Read>(reader: &mut R) -> Result<NetAddress, DecodeError> {
+		match Readable::read(reader) {
+			Ok(Ok(res)) => Ok(res),
+			Ok(Err(_)) => Err(DecodeError::UnknownVersion),
+			Err(e) => Err(e),
+		}
+	}
+}
+
+
 /// The unsigned part of a node_announcement
 #[derive(Clone, Debug, PartialEq)]
 pub struct UnsignedNodeAnnouncement {

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -3857,8 +3857,8 @@ mod tests {
 	use util::ser::Readable;
 	/// Tries to open a network graph file, or panics with a URL to fetch it.
 	pub(super) fn get_route_file() -> Result<std::fs::File, std::io::Error> {
-		let res = File::open("net_graph-2021-02-12.bin") // By default we're run in RL/lightning
-			.or_else(|_| File::open("lightning/net_graph-2021-02-12.bin")) // We may be run manually in RL/
+		let res = File::open("net_graph-2021-05-27.bin") // By default we're run in RL/lightning
+			.or_else(|_| File::open("lightning/net_graph-2021-05-27.bin")) // We may be run manually in RL/
 			.or_else(|_| { // Fall back to guessing based on the binary location
 				// path is likely something like .../rust-lightning/target/debug/deps/lightning-...
 				let mut path = std::env::current_exe().unwrap();
@@ -3867,7 +3867,7 @@ mod tests {
 				path.pop(); // debug
 				path.pop(); // target
 				path.push("lightning");
-				path.push("net_graph-2021-02-12.bin");
+				path.push("net_graph-2021-05-27.bin");
 				eprintln!("{}", path.to_str().unwrap());
 				File::open(path)
 			});
@@ -3890,7 +3890,7 @@ mod tests {
 		let mut d = match get_route_file() {
 			Ok(f) => f,
 			Err(_) => {
-				eprintln!("Please fetch https://bitcoin.ninja/ldk-net_graph-05f0c5a0d772-2020-02-12.bin and place it at lightning/net_graph-2021-02-12.bin");
+				eprintln!("Please fetch https://bitcoin.ninja/ldk-net_graph-45d86ead641d-2021-05-27.bin and place it at lightning/net_graph-2021-05-27.bin");
 				return;
 			},
 		};
@@ -3917,7 +3917,7 @@ mod tests {
 		let mut d = match get_route_file() {
 			Ok(f) => f,
 			Err(_) => {
-				eprintln!("Please fetch https://bitcoin.ninja/ldk-net_graph-05f0c5a0d772-2020-02-12.bin and place it at lightning/net_graph-2021-02-12.bin");
+				eprintln!("Please fetch https://bitcoin.ninja/ldk-net_graph-45d86ead641d-2021-05-27.bin and place it at lightning/net_graph-2021-05-27.bin");
 				return;
 			},
 		};
@@ -3955,7 +3955,7 @@ mod benches {
 	#[bench]
 	fn generate_routes(bench: &mut Bencher) {
 		let mut d = tests::get_route_file()
-			.expect("Please fetch https://bitcoin.ninja/ldk-net_graph-05f0c5a0d772-2020-02-12.bin and place it at lightning/net_graph-2021-02-12.bin");
+			.expect("Please fetch https://bitcoin.ninja/ldk-net_graph-45d86ead641d-2021-05-27.bin and place it at lightning/net_graph-2021-05-27.bin");
 		let graph = NetworkGraph::read(&mut d).unwrap();
 
 		// First, get 100 (source, destination) pairs for which route-getting actually succeeds...
@@ -3987,7 +3987,7 @@ mod benches {
 	#[bench]
 	fn generate_mpp_routes(bench: &mut Bencher) {
 		let mut d = tests::get_route_file()
-			.expect("Please fetch https://bitcoin.ninja/ldk-net_graph-05f0c5a0d772-2020-02-12.bin and place it at lightning/net_graph-2021-02-12.bin");
+			.expect("Please fetch https://bitcoin.ninja/ldk-net_graph-45d86ead641d-2021-05-27.bin and place it at lightning/net_graph-2021-05-27.bin");
 		let graph = NetworkGraph::read(&mut d).unwrap();
 
 		// First, get 100 (source, destination) pairs for which route-getting actually succeeds...

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -222,6 +222,40 @@ pub trait MaybeReadable
 	fn read<R: Read>(reader: &mut R) -> Result<Option<Self>, DecodeError>;
 }
 
+pub(crate) struct OptionDeserWrapper<T: Readable>(pub Option<T>);
+impl<T: Readable> Readable for OptionDeserWrapper<T> {
+	fn read<R: Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		Ok(Self(Some(Readable::read(reader)?)))
+	}
+}
+
+const MAX_ALLOC_SIZE: u64 = 64*1024;
+
+pub(crate) struct VecWriteWrapper<'a, T: Writeable>(pub &'a Vec<T>);
+impl<'a, T: Writeable> Writeable for VecWriteWrapper<'a, T> {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), ::std::io::Error> {
+		(self.0.len() as u64).write(writer)?;
+		for ref v in self.0.iter() {
+			v.write(writer)?;
+		}
+		Ok(())
+	}
+}
+pub(crate) struct VecReadWrapper<T: Readable>(pub Vec<T>);
+impl<T: Readable> Readable for VecReadWrapper<T> {
+	fn read<R: Read>(reader: &mut R) -> Result<Self, DecodeError> {
+		let count: u64 = Readable::read(reader)?;
+		let mut values = Vec::with_capacity(cmp::min(count, MAX_ALLOC_SIZE / (core::mem::size_of::<T>() as u64)) as usize);
+		for _ in 0..count {
+			match Readable::read(reader) {
+				Ok(v) => { values.push(v); },
+				Err(e) => return Err(e),
+			}
+		}
+		Ok(Self(values))
+	}
+}
+
 pub(crate) struct U48(pub u64);
 impl Writeable for U48 {
 	#[inline]

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -115,8 +115,12 @@ macro_rules! decode_tlv {
 				_ => {},
 			}
 			// As we read types, make sure we hit every required type:
-			$(if (last_seen_type.is_none() || last_seen_type.unwrap() < $reqtype) && typ.0 > $reqtype {
-				Err(DecodeError::InvalidValue)?
+			$({
+				#[allow(unused_comparisons)] // Note that $reqtype may be 0 making the second comparison always true
+				let invalid_order = (last_seen_type.is_none() || last_seen_type.unwrap() < $reqtype) && typ.0 > $reqtype;
+				if invalid_order {
+					Err(DecodeError::InvalidValue)?
+				}
 			})*
 			last_seen_type = Some(typ.0);
 
@@ -146,8 +150,12 @@ macro_rules! decode_tlv {
 			s.eat_remaining()?;
 		}
 		// Make sure we got to each required type after we've read every TLV:
-		$(if last_seen_type.is_none() || last_seen_type.unwrap() < $reqtype {
-			Err(DecodeError::InvalidValue)?
+		$({
+			#[allow(unused_comparisons)] // Note that $reqtype may be 0 making the second comparison always true
+			let missing_req_type = last_seen_type.is_none() || last_seen_type.unwrap() < $reqtype;
+			if missing_req_type {
+				Err(DecodeError::InvalidValue)?
+			}
 		})*
 	} }
 }


### PR DESCRIPTION
This adds more TLVs to various serialized structs to provide more forward/backward compatibility.

I need to update the routing graph that is used in benchmarks to support this. Based on #642.