### PR TITLE
Speed up deserialization of secp256k1 objects significantly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ panic = "abort"
 opt-level = 3
 lto = true
 panic = "abort"
+
+[profile.bench]
+opt-level = 3
+codegen-units = 1
+lto = true

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -350,8 +350,8 @@ impl Encode for msgs::GossipTimestampFilter {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use util::byte_utils;
 	use prelude::*;
+	use core::convert::TryInto;
 
 	// Big-endian wire encoding of Pong message (type = 19, byteslen = 2).
 	const ENCODED_PONG: [u8; 6] = [0u8, 19u8, 0u8, 2u8, 0u8, 0u8];
@@ -397,7 +397,7 @@ mod tests {
 
 	#[test]
 	fn read_unknown_message() {
-		let buffer = &byte_utils::be16_to_array(::core::u16::MAX);
+		let buffer = &::core::u16::MAX.to_be_bytes();
 		let mut reader = ::std::io::Cursor::new(buffer);
 		let message = read(&mut reader).unwrap();
 		match message {
@@ -414,7 +414,7 @@ mod tests {
 
 		let type_length = ::core::mem::size_of::<u16>();
 		let (type_bytes, payload_bytes) = buffer.split_at(type_length);
-		assert_eq!(byte_utils::slice_to_be16(type_bytes), msgs::Pong::TYPE);
+		assert_eq!(u16::from_be_bytes(type_bytes.try_into().unwrap()), msgs::Pong::TYPE);
 		assert_eq!(payload_bytes, &ENCODED_PONG[type_length..]);
 	}
 

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -2424,3 +2424,30 @@ mod tests {
 		assert!(result.is_err());
 	}
 }
+
+#[cfg(all(test, feature = "unstable"))]
+mod benches {
+	use super::*;
+
+	use test::Bencher;
+	use std::io::Read;
+
+	#[bench]
+	fn read_network_graph(bench: &mut Bencher) {
+		let mut d = ::routing::router::test_utils::get_route_file().unwrap();
+		let mut v = Vec::new();
+		d.read_to_end(&mut v).unwrap();
+		bench.iter(|| {
+			let _ = NetworkGraph::read(&mut std::io::Cursor::new(&v)).unwrap();
+		});
+	}
+
+	#[bench]
+	fn write_network_graph(bench: &mut Bencher) {
+		let mut d = ::routing::router::test_utils::get_route_file().unwrap();
+		let net_graph = NetworkGraph::read(&mut d).unwrap();
+		bench.iter(|| {
+			let _ = net_graph.encode();
+		});
+	}
+}

--- a/lightning/src/util/byte_utils.rs
+++ b/lightning/src/util/byte_utils.rs
@@ -8,26 +8,6 @@
 // licenses.
 
 #[inline]
-pub fn slice_to_be16(v: &[u8]) -> u16 {
-	((v[0] as u16) << 8*1) |
-	((v[1] as u16) << 8*0)
-}
-#[inline]
-pub fn slice_to_be32(v: &[u8]) -> u32 {
-	((v[0] as u32) << 8*3) |
-	((v[1] as u32) << 8*2) |
-	((v[2] as u32) << 8*1) |
-	((v[3] as u32) << 8*0)
-}
-#[cfg(not(feature = "fuzztarget"))] // Used only by poly1305
-#[inline]
-pub fn slice_to_le32(v: &[u8]) -> u32 {
-	((v[0] as u32) << 8*0) |
-	((v[1] as u32) << 8*1) |
-	((v[2] as u32) << 8*2) |
-	((v[3] as u32) << 8*3)
-}
-#[inline]
 pub fn slice_to_be48(v: &[u8]) -> u64 {
 	((v[0] as u64) << 8*5) |
 	((v[1] as u64) << 8*4) |
@@ -62,16 +42,6 @@ pub fn be32_to_array(u: u32) -> [u8; 4] {
 	v[1] = ((u >> 8*2) & 0xff) as u8;
 	v[2] = ((u >> 8*1) & 0xff) as u8;
 	v[3] = ((u >> 8*0) & 0xff) as u8;
-	v
-}
-#[cfg(not(feature = "fuzztarget"))] // Used only by poly1305
-#[inline]
-pub fn le32_to_array(u: u32) -> [u8; 4] {
-	let mut v = [0; 4];
-	v[0] = ((u >> 8*0) & 0xff) as u8;
-	v[1] = ((u >> 8*1) & 0xff) as u8;
-	v[2] = ((u >> 8*2) & 0xff) as u8;
-	v[3] = ((u >> 8*3) & 0xff) as u8;
 	v
 }
 #[inline]
@@ -120,14 +90,10 @@ mod tests {
 	
 	#[test]
 	fn test_all() {
-		assert_eq!(slice_to_be16(&[0xde, 0xad]), 0xdead);
-		assert_eq!(slice_to_be32(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
-		assert_eq!(slice_to_le32(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);
 		assert_eq!(slice_to_be48(&[0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad]), 0xdeadbeef1bad);
 		assert_eq!(slice_to_be64(&[0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad, 0x1d, 0xea]), 0xdeadbeef1bad1dea);
 		assert_eq!(be16_to_array(0xdead), [0xde, 0xad]);
 		assert_eq!(be32_to_array(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
-		assert_eq!(le32_to_array(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
 		assert_eq!(be48_to_array(0xdeadbeef1bad), [0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad]);
 		assert_eq!(be64_to_array(0xdeadbeef1bad1dea), [0xde, 0xad, 0xbe, 0xef, 0x1b, 0xad, 0x1d, 0xea]);
 		assert_eq!(le64_to_array(0xdeadbeef1bad1dea), [0xea, 0x1d, 0xad, 0x1b, 0xef, 0xbe, 0xad, 0xde]);

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -47,29 +47,36 @@ macro_rules! encode_tlv {
 	} }
 }
 
-macro_rules! encode_varint_length_prefixed_tlv {
-	($stream: expr, {$(($type: expr, $field: expr)),*}, {$(($optional_type: expr, $optional_field: expr)),*}) => { {
-		use util::ser::{BigSize, LengthCalculatingWriter};
+macro_rules! get_varint_length_prefixed_tlv_length {
+	({$(($type: expr, $field: expr)),*}, {$(($optional_type: expr, $optional_field: expr)),* $(,)*}) => { {
+		use util::ser::LengthCalculatingWriter;
 		#[allow(unused_mut)]
 		let mut len = LengthCalculatingWriter(0);
 		{
 			$(
-				BigSize($type).write(&mut len)?;
+				BigSize($type).write(&mut len).expect("No in-memory data may fail to serialize");
 				let field_len = $field.serialized_length();
-				BigSize(field_len as u64).write(&mut len)?;
+				BigSize(field_len as u64).write(&mut len).expect("No in-memory data may fail to serialize");
 				len.0 += field_len;
 			)*
 			$(
 				if let Some(ref field) = $optional_field {
-					BigSize($optional_type).write(&mut len)?;
+					BigSize($optional_type).write(&mut len).expect("No in-memory data may fail to serialize");
 					let field_len = field.serialized_length();
-					BigSize(field_len as u64).write(&mut len)?;
+					BigSize(field_len as u64).write(&mut len).expect("No in-memory data may fail to serialize");
 					len.0 += field_len;
 				}
 			)*
 		}
+		len.0
+	} }
+}
 
-		BigSize(len.0 as u64).write($stream)?;
+macro_rules! encode_varint_length_prefixed_tlv {
+	($stream: expr, {$(($type: expr, $field: expr)),*}, {$(($optional_type: expr, $optional_field: expr)),*}) => { {
+		use util::ser::BigSize;
+		let len = get_varint_length_prefixed_tlv_length!({ $(($type, $field)),* }, { $(($optional_type, $optional_field)),* });
+		BigSize(len as u64).write($stream)?;
 		encode_tlv!($stream, { $(($type, $field)),* }, { $(($optional_type, $optional_field)),* });
 	} }
 }
@@ -167,12 +174,28 @@ macro_rules! impl_writeable {
 					if $len != 0 {
 						use util::ser::LengthCalculatingWriter;
 						let mut len_calc = LengthCalculatingWriter(0);
-						$( self.$field.write(&mut len_calc)?; )*
+						$( self.$field.write(&mut len_calc).expect("No in-memory data may fail to serialize"); )*
 						assert_eq!(len_calc.0, $len);
+						assert_eq!(self.serialized_length(), $len);
 					}
 				}
 				$( self.$field.write(w)?; )*
 				Ok(())
+			}
+
+			#[inline]
+			fn serialized_length(&self) -> usize {
+				if $len == 0 || cfg!(any(test, feature = "fuzztarget")) {
+					let mut len_calc = 0;
+					$( len_calc += self.$field.serialized_length(); )*
+					if $len != 0 {
+						// In tests, assert that the hard-coded length matches the actual one
+						assert_eq!(len_calc, $len);
+					} else {
+						return len_calc;
+					}
+				}
+				$len
 			}
 		}
 
@@ -186,7 +209,7 @@ macro_rules! impl_writeable {
 	}
 }
 macro_rules! impl_writeable_len_match {
-	($struct: ident, $cmp: tt, {$({$match: pat, $length: expr}),*}, {$($field:ident),*}) => {
+	($struct: ident, $cmp: tt, ($calc_len: expr), {$({$match: pat, $length: expr}),*}, {$($field:ident),*}) => {
 		impl Writeable for $struct {
 			fn write<W: Writer>(&self, w: &mut W) -> Result<(), ::std::io::Error> {
 				let len = match *self {
@@ -198,11 +221,29 @@ macro_rules! impl_writeable_len_match {
 					// In tests, assert that the hard-coded length matches the actual one
 					use util::ser::LengthCalculatingWriter;
 					let mut len_calc = LengthCalculatingWriter(0);
-					$( self.$field.write(&mut len_calc)?; )*
+					$( self.$field.write(&mut len_calc).expect("No in-memory data may fail to serialize"); )*
 					assert!(len_calc.0 $cmp len);
+					assert_eq!(len_calc.0, self.serialized_length());
 				}
 				$( self.$field.write(w)?; )*
 				Ok(())
+			}
+
+			#[inline]
+			fn serialized_length(&self) -> usize {
+				if $calc_len || cfg!(any(test, feature = "fuzztarget")) {
+					let mut len_calc = 0;
+					$( len_calc += self.$field.serialized_length(); )*
+					if !$calc_len {
+						assert_eq!(len_calc, match *self {
+							$($match => $length,)*
+						});
+					}
+					return len_calc
+				}
+				match *self {
+					$($match => $length,)*
+				}
 			}
 		}
 
@@ -214,8 +255,11 @@ macro_rules! impl_writeable_len_match {
 			}
 		}
 	};
+	($struct: ident, $cmp: tt, {$({$match: pat, $length: expr}),*}, {$($field:ident),*}) => {
+		impl_writeable_len_match!($struct, $cmp, (true), { $({ $match, $length }),* }, { $($field),* });
+	};
 	($struct: ident, {$({$match: pat, $length: expr}),*}, {$($field:ident),*}) => {
-		impl_writeable_len_match!($struct, ==, { $({ $match, $length }),* }, { $($field),* });
+		impl_writeable_len_match!($struct, ==, (false), { $({ $match, $length }),* }, { $($field),* });
 	}
 }
 
@@ -319,6 +363,14 @@ macro_rules! _write_tlv_fields {
 		write_tlv_fields!($stream, {$(($type, $field)),*} , {$(($optional_type, $optional_field)),*, $(($optional_type_2, $optional_field_2)),*});
 	}
 }
+macro_rules! _get_tlv_len {
+	({$(($type: expr, $field: expr)),* $(,)*}, {}, {$(($optional_type: expr, $optional_field: expr)),* $(,)*}) => {
+		get_varint_length_prefixed_tlv_length!({$(($type, $field)),*} , {$(($optional_type, $optional_field)),*})
+	};
+	({$(($type: expr, $field: expr)),* $(,)*}, {$(($optional_type: expr, $optional_field: expr)),* $(,)*}, {$(($optional_type_2: expr, $optional_field_2: expr)),* $(,)*}) => {
+		get_varint_length_prefixed_tlv_length!({$(($type, $field)),*} , {$(($optional_type, $optional_field)),*, $(($optional_type_2, $optional_field_2)),*})
+	}
+}
 macro_rules! _read_tlv_fields {
 	($stream: expr, {$(($reqtype: expr, $reqfield: ident)),* $(,)*}, {}, {$(($type: expr, $field: ident)),* $(,)*}) => {
 		read_tlv_fields!($stream, {$(($reqtype, $reqfield)),*}, {$(($type, $field)),*});
@@ -345,6 +397,21 @@ macro_rules! impl_writeable_tlv_based {
 					$(($vectype, Some(::util::ser::VecWriteWrapper(&self.$vecfield)))),*
 				});
 				Ok(())
+			}
+
+			#[inline]
+			fn serialized_length(&self) -> usize {
+				let len = _get_tlv_len!({
+					$(($reqtype, self.$reqfield)),*
+				}, {
+					$(($type, self.$field)),*
+				}, {
+					$(($vectype, Some(::util::ser::VecWriteWrapper(&self.$vecfield)))),*
+				});
+				use util::ser::{BigSize, LengthCalculatingWriter};
+				let mut len_calc = LengthCalculatingWriter(0);
+				BigSize(len as u64).write(&mut len_calc).expect("No in-memory data may fail to serialize");
+				len + len_calc.0
 			}
 		}
 


### PR DESCRIPTION
When we switched to TLV-ing nearly all objects we ended up with a substantial performance regression when writing secp256k1 objects. The chanmon_consistency_test fuzz target alone increased enough to nearly double our CI fuzz test time. This more than fixes the issue, actually decreasing runtime by avoiding one additional secp256k1 call in many cases. See individual commits for more info.