### PR TITLE
Add new `(C-not implementable)` tag on `EventsProvider`

### DIFF
--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -395,6 +395,9 @@ pub trait MessageSendEventsProvider {
 /// may safely use the provider (e.g., see [`ChannelManager::process_pending_events`] and
 /// [`ChainMonitor::process_pending_events`]).
 ///
+/// (C-not implementable) As there is likely no reason for a user to implement this trait on their
+/// own type(s).
+///
 /// [`process_pending_events`]: Self::process_pending_events
 /// [`handle_event`]: EventHandler::handle_event
 /// [`ChannelManager::process_pending_events`]: crate::ln::channelmanager::ChannelManager#method.process_pending_events


### PR DESCRIPTION
This makes it so that users cannot usefully implement their own
`EventsProvider`, which would require substantial new logic in the
bindings generator (for generic methods). In the case of
`EventsProvider`, because there are no Rust methods which accept an
`EventsProvider` as an argument, this is perfectly OK as the
generated code would be entirely unused anyway.

LDK-C-Bindings PR which implements checking for the new tag is at https://github.com/lightningdevkit/ldk-c-bindings/pull/24