### PR TITLE
Expose test_process_background_events

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2321,7 +2321,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	}
 
 	#[cfg(any(test, feature = "_test_utils"))]
-	pub(crate) fn test_process_background_events(&self) {
+	/// Process background events, for functional testing
+	pub fn test_process_background_events(&self) {
 		self.process_background_events();
 	}
 


### PR DESCRIPTION
Needed for functional tests outside the crate, now that `timer_tick_occured` is no longer a reasonable approximation (results in spurious channel update messages).