### PR TITLE
Remove unwanted check in accept_channel

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1428,9 +1428,6 @@ impl<Signer: Sign> Channel<Signer> {
 		if msg.channel_reserve_satoshis > self.channel_value_satoshis {
 			return Err(ChannelError::Close(format!("Bogus channel_reserve_satoshis ({}). Must not be greater than ({})", msg.channel_reserve_satoshis, self.channel_value_satoshis)));
 		}
-		if msg.dust_limit_satoshis > msg.channel_reserve_satoshis {
-			return Err(ChannelError::Close(format!("Bogus channel_reserve ({}) and dust_limit ({})", msg.channel_reserve_satoshis, msg.dust_limit_satoshis)));
-		}
 		if msg.channel_reserve_satoshis < self.holder_dust_limit_satoshis {
 			return Err(ChannelError::Close(format!("Peer never wants payout outputs? channel_reserve_satoshis was ({}). dust_limit is ({})", msg.channel_reserve_satoshis, self.holder_dust_limit_satoshis)));
 		}


### PR DESCRIPTION
This caused an interoperability issue with lnd, because they can propose a reserve lower than their dust limit (but not lower than ours).  The BOLT only specifically talks about the local dust limit when handling an Accept Funding message.