### PR TITLE
Align get_route's interface with ChannelManager and Invoice

### DIFF
--- a/fuzz/src/router.rs
+++ b/fuzz/src/router.rs
@@ -16,7 +16,7 @@ use lightning::chain::transaction::OutPoint;
 use lightning::ln::channelmanager::ChannelDetails;
 use lightning::ln::features::InitFeatures;
 use lightning::ln::msgs;
-use lightning::routing::router::{get_route, RouteHintHop};
+use lightning::routing::router::{get_route, RouteHint, RouteHintHop};
 use lightning::util::logger::Logger;
 use lightning::util::ser::Readable;
 use lightning::routing::network_graph::{NetworkGraph, RoutingFees};
@@ -225,13 +225,13 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 						Some(&first_hops_vec[..])
 					},
 				};
-				let mut last_hops_vec = Vec::new();
+				let mut last_hops = Vec::new();
 				{
 					let count = get_slice!(1)[0];
 					for _ in 0..count {
 						scid += 1;
 						let rnid = node_pks.iter().skip(slice_to_be16(get_slice!(2))as usize % node_pks.len()).next().unwrap();
-						last_hops_vec.push(RouteHintHop {
+						last_hops.push(RouteHint(vec![RouteHintHop {
 							src_node_id: *rnid,
 							short_channel_id: scid,
 							fees: RoutingFees {
@@ -241,10 +241,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 							cltv_expiry_delta: slice_to_be16(get_slice!(2)),
 							htlc_minimum_msat: Some(slice_to_be64(get_slice!(8))),
 							htlc_maximum_msat: None,
-						});
+						}]));
 					}
 				}
-				let last_hops = &last_hops_vec[..];
 				for target in node_pks.iter() {
 					let _ = get_route(&our_pubkey, &net_graph, target, None,
 						first_hops.map(|c| c.iter().collect::<Vec<_>>()).as_ref().map(|a| a.as_slice()),

--- a/lightning-invoice/src/lib.rs
+++ b/lightning-invoice/src/lib.rs
@@ -1066,7 +1066,7 @@ impl Invoice {
 		Ok(())
 	}
 
-	/// Constructs an `Invoice` from a `SignedInvoice` by checking all its invariants.
+	/// Constructs an `Invoice` from a `SignedRawInvoice` by checking all its invariants.
 	/// ```
 	/// use lightning_invoice::*;
 	///

--- a/lightning-invoice/src/ser.rs
+++ b/lightning-invoice/src/ser.rs
@@ -3,7 +3,7 @@ use std::fmt::{Display, Formatter};
 use bech32::{ToBase32, u5, WriteBase32, Base32Len};
 
 use super::{Invoice, Sha256, TaggedField, ExpiryTime, MinFinalCltvExpiry, Fallback, PayeePubKey, InvoiceSignature, PositiveTimestamp,
-	RouteHint, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawInvoice, RawDataPart};
+	PrivateRoute, Description, RawTaggedField, Currency, RawHrp, SiPrefix, constants, SignedRawInvoice, RawDataPart};
 
 /// Converts a stream of bytes written to it to base32. On finalization the according padding will
 /// be applied. That means the results of writing two data blocks with one or two `BytesToBase32`
@@ -356,11 +356,11 @@ impl Base32Len for Fallback {
 	}
 }
 
-impl ToBase32 for RouteHint {
+impl ToBase32 for PrivateRoute {
 	fn write_base32<W: WriteBase32>(&self, writer: &mut W) -> Result<(), <W as WriteBase32>::Err> {
 		let mut converter = BytesToBase32::new(writer);
 
-		for hop in self.iter() {
+		for hop in (self.0).0.iter() {
 			converter.append(&hop.src_node_id.serialize()[..])?;
 			let short_channel_id = try_stretch(
 				encode_int_be_base256(hop.short_channel_id),
@@ -392,9 +392,9 @@ impl ToBase32 for RouteHint {
 	}
 }
 
-impl Base32Len for RouteHint {
+impl Base32Len for PrivateRoute {
 	fn base32_len(&self) -> usize {
-		bytes_size_to_base32_size(self.0.len() * 51)
+		bytes_size_to_base32_size((self.0).0.len() * 51)
 	}
 }
 
@@ -439,8 +439,8 @@ impl ToBase32 for TaggedField {
 			TaggedField::Fallback(ref fallback_address) => {
 				write_tagged_field(writer, constants::TAG_FALLBACK, fallback_address)
 			},
-			TaggedField::Route(ref route_hops) => {
-				write_tagged_field(writer, constants::TAG_ROUTE, route_hops)
+			TaggedField::PrivateRoute(ref route_hops) => {
+				write_tagged_field(writer, constants::TAG_PRIVATE_ROUTE, route_hops)
 			},
 			TaggedField::PaymentSecret(ref payment_secret) => {
 				  write_tagged_field(writer, constants::TAG_PAYMENT_SECRET, payment_secret)


### PR DESCRIPTION
Update `get_route`'s interface to work better with `ChannelManager` and `Invoice`.
- ~~pass result of `ChannelManager::list_usable_channels` as `first_hops` without converting~~
- accept multi-hop hints for `last_hops` from `Invoice::routes` without copying

This is only the interface change for #945. Only the last hop from each `RouteHint` is considered by `get_route` for now.