### PR TITLE
Fix TLV serialization to work with large types

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -73,14 +73,14 @@ impl DelayedPaymentOutputDescriptor {
 }
 
 impl_writeable_tlv_based!(DelayedPaymentOutputDescriptor, {
-	(0, outpoint),
-	(2, per_commitment_point),
-	(4, to_self_delay),
-	(6, output),
-	(8, revocation_pubkey),
-	(10, channel_keys_id),
-	(12, channel_value_satoshis),
-}, {}, {});
+	(0, outpoint, required),
+	(2, per_commitment_point, required),
+	(4, to_self_delay, required),
+	(6, output, required),
+	(8, revocation_pubkey, required),
+	(10, channel_keys_id, required),
+	(12, channel_value_satoshis, required),
+});
 
 /// Information about a spendable output to our "payment key". See
 /// SpendableOutputDescriptor::StaticPaymentOutput for more details on how to spend this.
@@ -104,11 +104,11 @@ impl StaticPaymentOutputDescriptor {
 	pub const MAX_WITNESS_LENGTH: usize = 1 + 73 + 34;
 }
 impl_writeable_tlv_based!(StaticPaymentOutputDescriptor, {
-	(0, outpoint),
-	(2, output),
-	(4, channel_keys_id),
-	(6, channel_value_satoshis),
-}, {}, {});
+	(0, outpoint, required),
+	(2, output, required),
+	(4, channel_keys_id, required),
+	(6, channel_value_satoshis, required),
+});
 
 /// When on-chain outputs are created by rust-lightning (which our counterparty is not able to
 /// claim at any point in the future) an event is generated which you must track and be able to
@@ -169,9 +169,9 @@ pub enum SpendableOutputDescriptor {
 
 impl_writeable_tlv_based_enum!(SpendableOutputDescriptor,
 	(0, StaticOutput) => {
-		(0, outpoint),
-		(2, output),
-	}, {}, {},
+		(0, outpoint, required),
+		(2, output, required),
+	},
 ;
 	(1, DelayedPaymentOutput),
 	(2, StaticPaymentOutput),
@@ -692,7 +692,7 @@ impl Writeable for InMemorySigner {
 		self.channel_value_satoshis.write(writer)?;
 		self.channel_keys_id.write(writer)?;
 
-		write_tlv_fields!(writer, {}, {});
+		write_tlv_fields!(writer, {});
 
 		Ok(())
 	}
@@ -717,7 +717,7 @@ impl Readable for InMemorySigner {
 			                                     &htlc_base_key);
 		let keys_id = Readable::read(reader)?;
 
-		read_tlv_fields!(reader, {}, {});
+		read_tlv_fields!(reader, {});
 
 		Ok(InMemorySigner {
 			funding_key,

--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -79,18 +79,18 @@ enum OnchainEvent {
 }
 
 impl_writeable_tlv_based!(OnchainEventEntry, {
-	(0, txid),
-	(2, height),
-	(4, event),
-}, {}, {});
+	(0, txid, required),
+	(2, height, required),
+	(4, event, required),
+});
 
 impl_writeable_tlv_based_enum!(OnchainEvent,
 	(0, Claim) => {
-		(0, claim_request),
-	}, {}, {},
+		(0, claim_request, required),
+	},
 	(1, ContentiousOutpoint) => {
-		(0, package),
-	}, {}, {},
+		(0, package, required),
+	},
 ;);
 
 impl Readable for Option<Vec<Option<(usize, Signature)>>> {
@@ -236,7 +236,7 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 			entry.write(writer)?;
 		}
 
-		write_tlv_fields!(writer, {}, {});
+		write_tlv_fields!(writer, {});
 		Ok(())
 	}
 }
@@ -298,7 +298,7 @@ impl<'a, K: KeysInterface> ReadableArgs<&'a K> for OnchainTxHandler<K::Signer> {
 			onchain_events_awaiting_threshold_conf.push(Readable::read(reader)?);
 		}
 
-		read_tlv_fields!(reader, {}, {});
+		read_tlv_fields!(reader, {});
 
 		let mut secp_ctx = Secp256k1::new();
 		secp_ctx.seeded_randomize(&keys_manager.get_secure_random_bytes());

--- a/lightning/src/chain/package.rs
+++ b/lightning/src/chain/package.rs
@@ -87,14 +87,14 @@ impl RevokedOutput {
 }
 
 impl_writeable_tlv_based!(RevokedOutput, {
-	(0, per_commitment_point),
-	(2, counterparty_delayed_payment_base_key),
-	(4, counterparty_htlc_base_key),
-	(6, per_commitment_key),
-	(8, weight),
-	(10, amount),
-	(12, on_counterparty_tx_csv),
-}, {}, {});
+	(0, per_commitment_point, required),
+	(2, counterparty_delayed_payment_base_key, required),
+	(4, counterparty_htlc_base_key, required),
+	(6, per_commitment_key, required),
+	(8, weight, required),
+	(10, amount, required),
+	(12, on_counterparty_tx_csv, required),
+});
 
 /// A struct to describe a revoked offered output and corresponding information to generate a
 /// solving witness.
@@ -131,14 +131,14 @@ impl RevokedHTLCOutput {
 }
 
 impl_writeable_tlv_based!(RevokedHTLCOutput, {
-	(0, per_commitment_point),
-	(2, counterparty_delayed_payment_base_key),
-	(4, counterparty_htlc_base_key),
-	(6, per_commitment_key),
-	(8, weight),
-	(10, amount),
-	(12, htlc),
-}, {}, {});
+	(0, per_commitment_point, required),
+	(2, counterparty_delayed_payment_base_key, required),
+	(4, counterparty_htlc_base_key, required),
+	(6, per_commitment_key, required),
+	(8, weight, required),
+	(10, amount, required),
+	(12, htlc, required),
+});
 
 /// A struct to describe a HTLC output on a counterparty commitment transaction.
 ///
@@ -168,12 +168,12 @@ impl CounterpartyOfferedHTLCOutput {
 }
 
 impl_writeable_tlv_based!(CounterpartyOfferedHTLCOutput, {
-	(0, per_commitment_point),
-	(2, counterparty_delayed_payment_base_key),
-	(4, counterparty_htlc_base_key),
-	(6, preimage),
-	(8, htlc),
-}, {}, {});
+	(0, per_commitment_point, required),
+	(2, counterparty_delayed_payment_base_key, required),
+	(4, counterparty_htlc_base_key, required),
+	(6, preimage, required),
+	(8, htlc, required),
+});
 
 /// A struct to describe a HTLC output on a counterparty commitment transaction.
 ///
@@ -199,11 +199,11 @@ impl CounterpartyReceivedHTLCOutput {
 }
 
 impl_writeable_tlv_based!(CounterpartyReceivedHTLCOutput, {
-	(0, per_commitment_point),
-	(2, counterparty_delayed_payment_base_key),
-	(4, counterparty_htlc_base_key),
-	(6, htlc),
-}, {}, {});
+	(0, per_commitment_point, required),
+	(2, counterparty_delayed_payment_base_key, required),
+	(4, counterparty_htlc_base_key, required),
+	(6, htlc, required),
+});
 
 /// A struct to describe a HTLC output on holder commitment transaction.
 ///
@@ -236,11 +236,10 @@ impl HolderHTLCOutput {
 }
 
 impl_writeable_tlv_based!(HolderHTLCOutput, {
-	(0, amount),
-	(2, cltv_expiry),
-}, {
-	(4, preimage),
-}, {});
+	(0, amount, required),
+	(2, cltv_expiry, required),
+	(4, preimage, option)
+});
 
 /// A struct to describe the channel output on the funding transaction.
 ///
@@ -259,8 +258,8 @@ impl HolderFundingOutput {
 }
 
 impl_writeable_tlv_based!(HolderFundingOutput, {
-	(0, funding_redeemscript),
-}, {}, {});
+	(0, funding_redeemscript, required),
+});
 
 /// A wrapper encapsulating all in-protocol differing outputs types.
 ///
@@ -690,10 +689,11 @@ impl Writeable for PackageTemplate {
 			rev_outp.write(writer)?;
 		}
 		write_tlv_fields!(writer, {
-			(0, self.soonest_conf_deadline),
-			(2, self.feerate_previous),
-			(4, self.height_original),
-		}, { (6, self.height_timer) });
+			(0, self.soonest_conf_deadline, required),
+			(2, self.feerate_previous, required),
+			(4, self.height_original, required),
+			(6, self.height_timer, option)
+		});
 		Ok(())
 	}
 }
@@ -722,10 +722,11 @@ impl Readable for PackageTemplate {
 		let mut height_timer = None;
 		let mut height_original = 0;
 		read_tlv_fields!(reader, {
-			(0, soonest_conf_deadline),
-			(2, feerate_previous),
-			(4, height_original)
-		}, { (6, height_timer) });
+			(0, soonest_conf_deadline, required),
+			(2, feerate_previous, required),
+			(4, height_original, required),
+			(6, height_timer, option),
+		});
 		Ok(PackageTemplate {
 			inputs,
 			malleability,

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -172,7 +172,7 @@ impl Writeable for CounterpartyCommitmentSecrets {
 			writer.write_all(secret)?;
 			writer.write_all(&byte_utils::be64_to_array(*idx))?;
 		}
-		write_tlv_fields!(writer, {}, {});
+		write_tlv_fields!(writer, {});
 		Ok(())
 	}
 }
@@ -183,7 +183,7 @@ impl Readable for CounterpartyCommitmentSecrets {
 			*secret = Readable::read(reader)?;
 			*idx = Readable::read(reader)?;
 		}
-		read_tlv_fields!(reader, {}, {});
+		read_tlv_fields!(reader, {});
 		Ok(Self { old_secrets })
 	}
 }
@@ -318,12 +318,12 @@ pub struct TxCreationKeys {
 }
 
 impl_writeable_tlv_based!(TxCreationKeys, {
-	(0, per_commitment_point),
-	(2, revocation_key),
-	(4, broadcaster_htlc_key),
-	(6, countersignatory_htlc_key),
-	(8, broadcaster_delayed_payment_key),
-}, {}, {});
+	(0, per_commitment_point, required),
+	(2, revocation_key, required),
+	(4, broadcaster_htlc_key, required),
+	(6, countersignatory_htlc_key, required),
+	(8, broadcaster_delayed_payment_key, required),
+});
 
 /// One counterparty's public keys which do not change over the life of a channel.
 #[derive(Clone, PartialEq)]
@@ -350,12 +350,12 @@ pub struct ChannelPublicKeys {
 }
 
 impl_writeable_tlv_based!(ChannelPublicKeys, {
-	(0, funding_pubkey),
-	(2, revocation_basepoint),
-	(4, payment_point),
-	(6, delayed_payment_basepoint),
-	(8, htlc_basepoint),
-}, {}, {});
+	(0, funding_pubkey, required),
+	(2, revocation_basepoint, required),
+	(4, payment_point, required),
+	(6, delayed_payment_basepoint, required),
+	(8, htlc_basepoint, required),
+});
 
 impl TxCreationKeys {
 	/// Create per-state keys from channel base points and the per-commitment point.
@@ -429,13 +429,12 @@ pub struct HTLCOutputInCommitment {
 }
 
 impl_writeable_tlv_based!(HTLCOutputInCommitment, {
-	(0, offered),
-	(2, amount_msat),
-	(4, cltv_expiry),
-	(6, payment_hash),
-}, {
-	(8, transaction_output_index)
-}, {});
+	(0, offered, required),
+	(2, amount_msat, required),
+	(4, cltv_expiry, required),
+	(6, payment_hash, required),
+	(8, transaction_output_index, option),
+});
 
 #[inline]
 pub(crate) fn get_htlc_redeemscript_with_explicit_keys(htlc: &HTLCOutputInCommitment, broadcaster_htlc_key: &PublicKey, countersignatory_htlc_key: &PublicKey, revocation_key: &PublicKey) -> Script {
@@ -626,18 +625,17 @@ impl ChannelTransactionParameters {
 }
 
 impl_writeable_tlv_based!(CounterpartyChannelTransactionParameters, {
-	(0, pubkeys),
-	(2, selected_contest_delay),
-}, {}, {});
+	(0, pubkeys, required),
+	(2, selected_contest_delay, required),
+});
 
 impl_writeable_tlv_based!(ChannelTransactionParameters, {
-	(0, holder_pubkeys),
-	(2, holder_selected_contest_delay),
-	(4, is_outbound_from_holder),
-}, {
-	(6, counterparty_parameters),
-	(8, funding_outpoint),
-}, {});
+	(0, holder_pubkeys, required),
+	(2, holder_selected_contest_delay, required),
+	(4, is_outbound_from_holder, required),
+	(6, counterparty_parameters, option),
+	(8, funding_outpoint, option),
+});
 
 /// Static channel fields used to build transactions given per-commitment fields, organized by
 /// broadcaster/countersignatory.
@@ -720,11 +718,10 @@ impl PartialEq for HolderCommitmentTransaction {
 }
 
 impl_writeable_tlv_based!(HolderCommitmentTransaction, {
-	(0, inner),
-	(2, counterparty_sig),
-	(4, holder_sig_first),
-}, {}, {
-	(6, counterparty_htlc_sigs),
+	(0, inner, required),
+	(2, counterparty_sig, required),
+	(4, holder_sig_first, required),
+	(6, counterparty_htlc_sigs, vec_type),
 });
 
 impl HolderCommitmentTransaction {
@@ -809,9 +806,9 @@ pub struct BuiltCommitmentTransaction {
 }
 
 impl_writeable_tlv_based!(BuiltCommitmentTransaction, {
-	(0, transaction),
-	(2, txid)
-}, {}, {});
+	(0, transaction, required),
+	(2, txid, required),
+});
 
 impl BuiltCommitmentTransaction {
 	/// Get the SIGHASH_ALL sighash value of the transaction.
@@ -866,14 +863,13 @@ impl PartialEq for CommitmentTransaction {
 }
 
 impl_writeable_tlv_based!(CommitmentTransaction, {
-	(0, commitment_number),
-	(2, to_broadcaster_value_sat),
-	(4, to_countersignatory_value_sat),
-	(6, feerate_per_kw),
-	(8, keys),
-	(10, built),
-}, {}, {
-	(12, htlcs),
+	(0, commitment_number, required),
+	(2, to_broadcaster_value_sat, required),
+	(4, to_countersignatory_value_sat, required),
+	(6, feerate_per_kw, required),
+	(8, keys, required),
+	(10, built, required),
+	(12, htlcs, vec_type),
 });
 
 impl CommitmentTransaction {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -4606,7 +4606,7 @@ impl<Signer: Sign> Writeable for Channel<Signer> {
 
 		self.channel_update_status.write(writer)?;
 
-		write_tlv_fields!(writer, {}, {(0, self.announcement_sigs)});
+		write_tlv_fields!(writer, {(0, self.announcement_sigs, option)});
 
 		Ok(())
 	}
@@ -4779,7 +4779,7 @@ impl<'a, Signer: Sign, K: Deref> ReadableArgs<&'a K> for Channel<Signer>
 		let channel_update_status = Readable::read(reader)?;
 
 		let mut announcement_sigs = None;
-		read_tlv_fields!(reader, {}, {(0, announcement_sigs)});
+		read_tlv_fields!(reader, {(0, announcement_sigs, option)});
 
 		let mut secp_ctx = Secp256k1::new();
 		secp_ctx.seeded_randomize(&keys_source.get_secure_random_bytes());

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -4320,22 +4320,22 @@ const MIN_SERIALIZATION_VERSION: u8 = 1;
 
 impl_writeable_tlv_based_enum!(PendingHTLCRouting,
 	(0, Forward) => {
-		(0, onion_packet),
-		(2, short_channel_id),
-	}, {}, {},
+		(0, onion_packet, required),
+		(2, short_channel_id, required),
+	},
 	(1, Receive) => {
-		(0, payment_data),
-		(2, incoming_cltv_expiry),
-	}, {}, {}
+		(0, payment_data, required),
+		(2, incoming_cltv_expiry, required),
+	}
 ;);
 
 impl_writeable_tlv_based!(PendingHTLCInfo, {
-	(0, routing),
-	(2, incoming_shared_secret),
-	(4, payment_hash),
-	(6, amt_to_forward),
-	(8, outgoing_cltv_value)
-}, {}, {});
+	(0, routing, required),
+	(2, incoming_shared_secret, required),
+	(4, payment_hash, required),
+	(6, amt_to_forward, required),
+	(8, outgoing_cltv_value, required)
+});
 
 impl_writeable_tlv_based_enum!(HTLCFailureMsg, ;
 	(0, Relay),
@@ -4347,60 +4347,58 @@ impl_writeable_tlv_based_enum!(PendingHTLCStatus, ;
 );
 
 impl_writeable_tlv_based!(HTLCPreviousHopData, {
-	(0, short_channel_id),
-	(2, outpoint),
-	(4, htlc_id),
-	(6, incoming_packet_shared_secret)
-}, {}, {});
+	(0, short_channel_id, required),
+	(2, outpoint, required),
+	(4, htlc_id, required),
+	(6, incoming_packet_shared_secret, required)
+});
 
 impl_writeable_tlv_based!(ClaimableHTLC, {
-	(0, prev_hop),
-	(2, value),
-	(4, payment_data),
-	(6, cltv_expiry),
-}, {}, {});
+	(0, prev_hop, required),
+	(2, value, required),
+	(4, payment_data, required),
+	(6, cltv_expiry, required),
+});
 
 impl_writeable_tlv_based_enum!(HTLCSource,
 	(0, OutboundRoute) => {
-		(0, session_priv),
-		(2, first_hop_htlc_msat),
-	}, {}, {
-		(4, path),
-	};
+		(0, session_priv, required),
+		(2, first_hop_htlc_msat, required),
+		(4, path, vec_type),
+	}, ;
 	(1, PreviousHopData)
 );
 
 impl_writeable_tlv_based_enum!(HTLCFailReason,
 	(0, LightningError) => {
-		(0, err),
-	}, {}, {},
+		(0, err, required),
+	},
 	(1, Reason) => {
-		(0, failure_code),
-	}, {}, {
-		(2, data),
+		(0, failure_code, required),
+		(2, data, vec_type),
 	},
 ;);
 
 impl_writeable_tlv_based_enum!(HTLCForwardInfo,
 	(0, AddHTLC) => {
-		(0, forward_info),
-		(2, prev_short_channel_id),
-		(4, prev_htlc_id),
-		(6, prev_funding_outpoint),
-	}, {}, {},
+		(0, forward_info, required),
+		(2, prev_short_channel_id, required),
+		(4, prev_htlc_id, required),
+		(6, prev_funding_outpoint, required),
+	},
 	(1, FailHTLC) => {
-		(0, htlc_id),
-		(2, err_packet),
-	}, {}, {},
+		(0, htlc_id, required),
+		(2, err_packet, required),
+	},
 ;);
 
 impl_writeable_tlv_based!(PendingInboundPayment, {
-	(0, payment_secret),
-	(2, expiry_time),
-	(4, user_payment_id),
-	(6, payment_preimage),
-	(8, min_value_msat),
-}, {}, {});
+	(0, payment_secret, required),
+	(2, expiry_time, required),
+	(4, user_payment_id, required),
+	(6, payment_preimage, required),
+	(8, min_value_msat, required),
+});
 
 impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable for ChannelManager<Signer, M, T, K, F, L>
 	where M::Target: chain::Watch<Signer>,
@@ -4495,7 +4493,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> Writeable f
 			session_priv.write(writer)?;
 		}
 
-		write_tlv_fields!(writer, {}, {});
+		write_tlv_fields!(writer, {});
 
 		Ok(())
 	}
@@ -4740,7 +4738,7 @@ impl<'a, Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref>
 			}
 		}
 
-		read_tlv_fields!(reader, {}, {});
+		read_tlv_fields!(reader, {});
 
 		let mut secp_ctx = Secp256k1::new();
 		secp_ctx.seeded_randomize(&args.keys_manager.get_secure_random_bytes());

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -460,14 +460,14 @@ impl fmt::Display for DirectionalChannelInfo {
 }
 
 impl_writeable_tlv_based!(DirectionalChannelInfo, {
-	(0, last_update),
-	(2, enabled),
-	(4, cltv_expiry_delta),
-	(6, htlc_minimum_msat),
-	(8, htlc_maximum_msat),
-	(10, fees),
-	(12, last_update_message),
-}, {}, {});
+	(0, last_update, required),
+	(2, enabled, required),
+	(4, cltv_expiry_delta, required),
+	(6, htlc_minimum_msat, required),
+	(8, htlc_maximum_msat, required),
+	(10, fees, required),
+	(12, last_update_message, required),
+});
 
 #[derive(Clone, Debug, PartialEq)]
 /// Details about a channel (both directions).
@@ -501,14 +501,14 @@ impl fmt::Display for ChannelInfo {
 }
 
 impl_writeable_tlv_based!(ChannelInfo, {
-	(0, features),
-	(2, node_one),
-	(4, one_to_two),
-	(6, node_two),
-	(8, two_to_one),
-	(10, capacity_sats),
-	(12, announcement_message),
-}, {}, {});
+	(0, features, required),
+	(2, node_one, required),
+	(4, one_to_two, required),
+	(6, node_two, required),
+	(8, two_to_one, required),
+	(10, capacity_sats, required),
+	(12, announcement_message, required),
+});
 
 
 /// Fees for routing via a given channel or a node
@@ -521,7 +521,10 @@ pub struct RoutingFees {
 	pub proportional_millionths: u32,
 }
 
-impl_writeable_tlv_based!(RoutingFees, {(0, base_msat), (2, proportional_millionths)}, {}, {});
+impl_writeable_tlv_based!(RoutingFees, {
+	(0, base_msat, required),
+	(2, proportional_millionths, required)
+});
 
 #[derive(Clone, Debug, PartialEq)]
 /// Information received in the latest node_announcement from this node.
@@ -547,14 +550,12 @@ pub struct NodeAnnouncementInfo {
 }
 
 impl_writeable_tlv_based!(NodeAnnouncementInfo, {
-	(0, features),
-	(2, last_update),
-	(4, rgb),
-	(6, alias),
-}, {
-	(8, announcement_message),
-}, {
-	(10, addresses),
+	(0, features, required),
+	(2, last_update, required),
+	(4, rgb, required),
+	(6, alias, required),
+	(8, announcement_message, option),
+	(10, addresses, vec_type),
 });
 
 #[derive(Clone, Debug, PartialEq)]
@@ -580,11 +581,10 @@ impl fmt::Display for NodeInfo {
 	}
 }
 
-impl_writeable_tlv_based!(NodeInfo, {}, {
-	(0, lowest_inbound_channel_fees),
-	(2, announcement_info),
-}, {
-	(4, channels),
+impl_writeable_tlv_based!(NodeInfo, {
+	(0, lowest_inbound_channel_fees, option),
+	(2, announcement_info, option),
+	(4, channels, vec_type),
 });
 
 const SERIALIZATION_VERSION: u8 = 1;
@@ -606,7 +606,7 @@ impl Writeable for NetworkGraph {
 			node_info.write(writer)?;
 		}
 
-		write_tlv_fields!(writer, {}, {});
+		write_tlv_fields!(writer, {});
 		Ok(())
 	}
 }
@@ -630,7 +630,7 @@ impl Readable for NetworkGraph {
 			let node_info = Readable::read(reader)?;
 			nodes.insert(node_id, node_info);
 		}
-		read_tlv_fields!(reader, {}, {});
+		read_tlv_fields!(reader, {});
 
 		Ok(NetworkGraph {
 			genesis_hash,

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -49,13 +49,13 @@ pub struct RouteHop {
 }
 
 impl_writeable_tlv_based!(RouteHop, {
-	(0, pubkey),
-	(2, node_features),
-	(4, short_channel_id),
-	(6, channel_features),
-	(8, fee_msat),
-	(10, cltv_expiry_delta),
-}, {}, {});
+	(0, pubkey, required),
+	(2, node_features, required),
+	(4, short_channel_id, required),
+	(6, channel_features, required),
+	(8, fee_msat, required),
+	(10, cltv_expiry_delta, required),
+});
 
 /// A route directs a payment from the sender (us) to the recipient. If the recipient supports MPP,
 /// it can take multiple paths. Each path is composed of one or more hops through the network.
@@ -83,7 +83,7 @@ impl Writeable for Route {
 				hop.write(writer)?;
 			}
 		}
-		write_tlv_fields!(writer, {}, {});
+		write_tlv_fields!(writer, {});
 		Ok(())
 	}
 }
@@ -101,7 +101,7 @@ impl Readable for Route {
 			}
 			paths.push(hops);
 		}
-		read_tlv_fields!(reader, {}, {});
+		read_tlv_fields!(reader, {});
 		Ok(Route { paths })
 	}
 }


### PR DESCRIPTION
Previous to this PR, TLV serialization involved iterating from 0 to the highest
given TLV type. This worked until we decided to implement keysend, which has a
TLV type of ~5.48 billion.

So instead, we now specify the type of whatever is being (de)serialized (which
can be an Option, a Vec type, or "something else" (specified in the serialization macros as "required").