### PR TITLE
Drop the cdylib export of lightning-invoice

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -17,7 +17,3 @@ bitcoin_hashes = "0.9.4"
 
 [dev-dependencies]
 lightning = { version = "0.0.98", path = "../lightning", features = ["_test_utils"] }
-
-[lib]
-crate-type = ["cdylib", "rlib"]
-


### PR DESCRIPTION
There are ~zero functions in lightning-invoice that are materially
callable from C, so there isn't any reason to tag it as a cdylib
(and make rustc build it as such). Instead, we have C bindings now.