### PR TITLE
Fix bogus `Event::PaymentSent` serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.0.99 - WIP
+
+## Serialization Compatibility
+
+ * Due to a bug discovered in 0.0.98, if a `ChannelManager` is serialized on
+   version 0.0.98 while an `Event::PaymentSent` is pending processing, the
+   `ChannelManager` will fail to deserialize both on version 0.0.98 and later
+   versions. If you have such a `ChannelManager` available, a simple patch will
+   allow it to deserialize, please file an issue if you need assistance.
+
 # 0.0.98 - 2021-06-11
 
 0.0.98 should be considered a release candidate to the first alpha release of

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -160,7 +160,6 @@ impl Writeable for Event {
 				write_tlv_fields!(writer, {
 					(0, payment_preimage, required),
 				});
-				payment_preimage.write(writer)?;
 			},
 			&Event::PaymentFailed { ref payment_hash, ref rejected_by_dest,
 				#[cfg(test)]


### PR DESCRIPTION
`Event::PaymentSent` serialization has a bug where we
double-serialize the payment_preimage field but do not attempt to
read it twice. This results in a failure to read `ChannelManager`s
from disk if we have a pending `Event::PaymentSent` pending
awaiting handling when we serialize.

Instead of attempting to read both versions, we opt to simply fix
the serialization, assuming it is exceedingly rare for such a
scenario to appear (and if it does, we can assist in manual
recovery).

The release notes have been updated to note this inconsistency.

Found by the chanmon_consistency fuzz target.