### PR TITLE
Expand tests for Features::to_context

### DIFF
--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -490,13 +490,14 @@ impl<T: sealed::Context> Features<T> {
 	/// Converts `Features<T>` to `Features<C>`. Only known `T` features relevant to context `C` are
 	/// included in the result.
 	fn to_context_internal<C: sealed::Context>(&self) -> Features<C> {
-		let byte_count = C::KNOWN_FEATURE_MASK.len();
+		let from_byte_count = T::KNOWN_FEATURE_MASK.len();
+		let to_byte_count = C::KNOWN_FEATURE_MASK.len();
 		let mut flags = Vec::new();
 		for (i, byte) in self.flags.iter().enumerate() {
-			if i < byte_count {
-				let known_source_features = T::KNOWN_FEATURE_MASK[i];
-				let known_target_features = C::KNOWN_FEATURE_MASK[i];
-				flags.push(byte & known_source_features & known_target_features);
+			if i < from_byte_count && i < to_byte_count {
+				let from_known_features = T::KNOWN_FEATURE_MASK[i];
+				let to_known_features = C::KNOWN_FEATURE_MASK[i];
+				flags.push(byte & from_known_features & to_known_features);
 			}
 		}
 		Features::<C> { flags, mark: PhantomData, }

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -301,7 +301,7 @@ mod sealed {
 		set_shutdown_any_segwit_required);
 
 	#[cfg(test)]
-	define_feature!(123456789, UnknownFeature, [NodeContext, ChannelContext],
+	define_feature!(123456789, UnknownFeature, [NodeContext, ChannelContext, InvoiceContext],
 		"Feature flags for an unknown feature used in testing.", set_unknown_feature_optional,
 		set_unknown_feature_required);
 }
@@ -772,6 +772,16 @@ mod tests {
 		assert!(!features.initial_routing_sync());
 		assert!(!features.supports_upfront_shutdown_script());
 		assert!(!init_features.supports_gossip_queries());
+	}
+
+	#[test]
+	fn convert_to_context_with_unknown_flags() {
+		// Ensure the `from` context has fewer known feature bytes than the `to` context.
+		assert!(InvoiceFeatures::known().byte_count() < NodeFeatures::known().byte_count());
+		let invoice_features = InvoiceFeatures::known().set_unknown_feature_optional();
+		assert!(invoice_features.supports_unknown_bits());
+		let node_features: NodeFeatures = invoice_features.to_context();
+		assert!(!node_features.supports_unknown_bits());
 	}
 
 	#[test]

--- a/lightning/src/ln/features.rs
+++ b/lightning/src/ln/features.rs
@@ -301,27 +301,7 @@ mod sealed {
 		set_shutdown_any_segwit_required);
 
 	#[cfg(test)]
-	define_context!(TestingContext {
-		required_features: [
-			// Byte 0
-			,
-			// Byte 1
-			,
-			// Byte 2
-			UnknownFeature,
-		],
-		optional_features: [
-			// Byte 0
-			,
-			// Byte 1
-			,
-			// Byte 2
-			,
-		],
-	});
-
-	#[cfg(test)]
-	define_feature!(23, UnknownFeature, [TestingContext],
+	define_feature!(123456789, UnknownFeature, [NodeContext, ChannelContext],
 		"Feature flags for an unknown feature used in testing.", set_unknown_feature_optional,
 		set_unknown_feature_required);
 }
@@ -553,21 +533,6 @@ impl<T: sealed::Context> Features<T> {
 	pub(crate) fn byte_count(&self) -> usize {
 		self.flags.len()
 	}
-
-	#[cfg(test)]
-	pub(crate) fn set_required_unknown_bits(&mut self) {
-		<sealed::TestingContext as sealed::UnknownFeature>::set_required_bit(&mut self.flags);
-	}
-
-	#[cfg(test)]
-	pub(crate) fn set_optional_unknown_bits(&mut self) {
-		<sealed::TestingContext as sealed::UnknownFeature>::set_optional_bit(&mut self.flags);
-	}
-
-	#[cfg(test)]
-	pub(crate) fn clear_unknown_bits(&mut self) {
-		<sealed::TestingContext as sealed::UnknownFeature>::clear_bits(&mut self.flags);
-	}
 }
 
 impl<T: sealed::DataLossProtect> Features<T> {
@@ -765,19 +730,15 @@ mod tests {
 
 	#[test]
 	fn sanity_test_unknown_bits() {
-		let mut features = ChannelFeatures::empty();
+		let features = ChannelFeatures::empty();
 		assert!(!features.requires_unknown_bits());
 		assert!(!features.supports_unknown_bits());
 
-		features.set_required_unknown_bits();
+		let features = ChannelFeatures::empty().set_unknown_feature_required();
 		assert!(features.requires_unknown_bits());
 		assert!(features.supports_unknown_bits());
 
-		features.clear_unknown_bits();
-		assert!(!features.requires_unknown_bits());
-		assert!(!features.supports_unknown_bits());
-
-		features.set_optional_unknown_bits();
+		let features = ChannelFeatures::empty().set_unknown_feature_optional();
 		assert!(!features.requires_unknown_bits());
 		assert!(features.supports_unknown_bits());
 	}

--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -1992,8 +1992,7 @@ mod tests {
 		let (_, our_id, privkeys, nodes) = get_nodes(&secp_ctx);
 
 		// Disable nodes 1, 2, and 8 by requiring unknown feature bits
-		let mut unknown_features = NodeFeatures::known();
-		unknown_features.set_required_unknown_bits();
+		let unknown_features = NodeFeatures::known().set_unknown_feature_required();
 		add_or_update_node(&net_graph_msg_handler, &secp_ctx, &privkeys[0], unknown_features.clone(), 1);
 		add_or_update_node(&net_graph_msg_handler, &secp_ctx, &privkeys[1], unknown_features.clone(), 1);
 		add_or_update_node(&net_graph_msg_handler, &secp_ctx, &privkeys[7], unknown_features.clone(), 1);


### PR DESCRIPTION
When there are fewer known `from` feature bytes than known `to` feature bytes, an index-out-of-bounds error can occur if the `from` features have unknown features set in a byte past the greatest known `from` feature byte. This may happen when parsing an invoice, for instance.

This PR adds a test for the fix in #1002. It also removes some unnecessary test code.