### PR TITLE
Add a `PaymentForwarded` Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.0.100 - WIP
+
+## Serialization Compatibility
+ * HTLCs which were in the process of being claimed on-chain when a pre-0.0.100
+   `ChannelMonitor` was serialized may generate `PaymentForwarded` events with
+   spurious `fee_earned_msat` values. This only applies to payments which were
+   unresolved at the time of the upgrade.
+ * 0.0.100 clients with pending PaymentForwarded events at serialization-time
+   will generate serialized `ChannelManager` objects which 0.0.99 and earlier
+   clients cannot read. The likelihood of this can be reduced by ensuring you
+   process all pending events immediately before serialization (as is done by
+   the `lightning-background-processor` crate).
+
+
 # 0.0.99 - 2021-07-09
 
 ## API Updates

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -805,6 +805,7 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 						},
 						events::Event::PaymentSent { .. } => {},
 						events::Event::PaymentFailed { .. } => {},
+						events::Event::PaymentForwarded { .. } if $node == 1 => {},
 						events::Event::PendingHTLCsForwardable { .. } => {
 							nodes[$node].process_pending_htlc_forwards();
 						},

--- a/fuzz/src/full_stack.rs
+++ b/fuzz/src/full_stack.rs
@@ -596,12 +596,10 @@ pub fn do_test(data: &[u8], logger: &Arc<dyn Logger>) {
 					//TODO: enhance by fetching random amounts from fuzz input?
 					payments_received.push(payment_hash);
 				},
-				Event::PaymentSent {..} => {},
-				Event::PaymentFailed {..} => {},
 				Event::PendingHTLCsForwardable {..} => {
 					should_forward = true;
 				},
-				Event::SpendableOutputs {..} => {},
+				_ => {},
 			}
 		}
 	}

--- a/lightning/src/ln/chanmon_update_fail_tests.rs
+++ b/lightning/src/ln/chanmon_update_fail_tests.rs
@@ -1159,6 +1159,7 @@ fn test_monitor_update_fail_reestablish() {
 	assert!(updates.update_fee.is_none());
 	assert_eq!(updates.update_fulfill_htlcs.len(), 1);
 	nodes[1].node.handle_update_fulfill_htlc(&nodes[2].node.get_our_node_id(), &updates.update_fulfill_htlcs[0]);
+	expect_payment_forwarded!(nodes[1], Some(1000), false);
 	check_added_monitors!(nodes[1], 1);
 	assert!(nodes[1].node.get_and_clear_pending_msg_events().is_empty());
 	commitment_signed_dance!(nodes[1], nodes[2], updates.commitment_signed, false);
@@ -2317,6 +2318,7 @@ fn do_test_reconnect_dup_htlc_claims(htlc_status: HTLCStatusAtDupClaim, second_f
 		assert_eq!(fulfill_msg, cs_updates.update_fulfill_htlcs[0]);
 	}
 	nodes[1].node.handle_update_fulfill_htlc(&nodes[2].node.get_our_node_id(), &fulfill_msg);
+	expect_payment_forwarded!(nodes[1], Some(1000), false);
 	check_added_monitors!(nodes[1], 1);
 
 	let mut bs_updates = None;

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -207,6 +207,14 @@ pub(super) enum HTLCFailReason {
 	}
 }
 
+/// Return value for claim_funds_from_hop
+enum ClaimFundsFromHop {
+	PrevHopForceClosed,
+	MonitorUpdateFail(PublicKey, MsgHandleErrInternal, Option<u64>),
+	Success(u64),
+	DuplicateClaim,
+}
+
 type ShutdownResult = (Option<(OutPoint, ChannelMonitorUpdate)>, Vec<(HTLCSource, PaymentHash)>);
 
 /// Error type returned across the channel_state mutex boundary. When an Err is generated for a
@@ -2787,16 +2795,16 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 									 HTLCFailReason::Reason { failure_code: 0x4000|15, data: htlc_msat_height_data });
 				} else {
 					match self.claim_funds_from_hop(channel_state.as_mut().unwrap(), htlc.prev_hop, payment_preimage) {
-						Err(Some(e)) => {
-							if let msgs::ErrorAction::IgnoreError = e.1.err.action {
+						ClaimFundsFromHop::MonitorUpdateFail(pk, err, _) => {
+							if let msgs::ErrorAction::IgnoreError = err.err.action {
 								// We got a temporary failure updating monitor, but will claim the
 								// HTLC when the monitor updating is restored (or on chain).
-								log_error!(self.logger, "Temporary failure claiming HTLC, treating as success: {}", e.1.err.err);
+								log_error!(self.logger, "Temporary failure claiming HTLC, treating as success: {}", err.err.err);
 								claimed_any_htlcs = true;
-							} else { errs.push(e); }
+							} else { errs.push((pk, err)); }
 						},
-						Err(None) => unreachable!("We already checked for channel existence, we can't fail here!"),
-						Ok(()) => claimed_any_htlcs = true,
+						ClaimFundsFromHop::PrevHopForceClosed => unreachable!("We already checked for channel existence, we can't fail here!"),
+						_ => claimed_any_htlcs = true,
 					}
 				}
 			}
@@ -2814,28 +2822,29 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		} else { false }
 	}
 
-	fn claim_funds_from_hop(&self, channel_state_lock: &mut MutexGuard<ChannelHolder<Signer>>, prev_hop: HTLCPreviousHopData, payment_preimage: PaymentPreimage) -> Result<(), Option<(PublicKey, MsgHandleErrInternal)>> {
+	fn claim_funds_from_hop(&self, channel_state_lock: &mut MutexGuard<ChannelHolder<Signer>>, prev_hop: HTLCPreviousHopData, payment_preimage: PaymentPreimage) -> ClaimFundsFromHop {
 		//TODO: Delay the claimed_funds relaying just like we do outbound relay!
 		let channel_state = &mut **channel_state_lock;
 		let chan_id = match channel_state.short_to_id.get(&prev_hop.short_channel_id) {
 			Some(chan_id) => chan_id.clone(),
 			None => {
-				return Err(None)
+				return ClaimFundsFromHop::PrevHopForceClosed
 			}
 		};
 
 		if let hash_map::Entry::Occupied(mut chan) = channel_state.by_id.entry(chan_id) {
 			match chan.get_mut().get_update_fulfill_htlc_and_commit(prev_hop.htlc_id, payment_preimage, &self.logger) {
 				Ok(msgs_monitor_option) => {
-					if let UpdateFulfillCommitFetch::NewClaim { msgs, monitor_update } = msgs_monitor_option {
+					if let UpdateFulfillCommitFetch::NewClaim { msgs, htlc_value_msat, monitor_update } = msgs_monitor_option {
 						if let Err(e) = self.chain_monitor.update_channel(chan.get().get_funding_txo().unwrap(), monitor_update) {
 							log_given_level!(self.logger, if e == ChannelMonitorUpdateErr::PermanentFailure { Level::Error } else { Level::Debug },
 								"Failed to update channel monitor with preimage {:?}: {:?}",
 								payment_preimage, e);
-							return Err(Some((
+							return ClaimFundsFromHop::MonitorUpdateFail(
 								chan.get().get_counterparty_node_id(),
 								handle_monitor_err!(self, e, channel_state, chan, RAACommitmentOrder::CommitmentFirst, false, msgs.is_some()).unwrap_err(),
-							)));
+								Some(htlc_value_msat)
+							);
 						}
 						if let Some((msg, commitment_signed)) = msgs {
 							log_debug!(self.logger, "Claiming funds for HTLC with preimage {} resulted in a commitment_signed for channel {}",
@@ -2852,8 +2861,10 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 								}
 							});
 						}
+						return ClaimFundsFromHop::Success(htlc_value_msat);
+					} else {
+						return ClaimFundsFromHop::DuplicateClaim;
 					}
-					return Ok(())
 				},
 				Err((e, monitor_update)) => {
 					if let Err(e) = self.chain_monitor.update_channel(chan.get().get_funding_txo().unwrap(), monitor_update) {
@@ -2866,13 +2877,13 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if drop {
 						chan.remove_entry();
 					}
-					return Err(Some((counterparty_node_id, res)));
+					return ClaimFundsFromHop::MonitorUpdateFail(counterparty_node_id, res, None);
 				},
 			}
 		} else { unreachable!(); }
 	}
 
-	fn claim_funds_internal(&self, mut channel_state_lock: MutexGuard<ChannelHolder<Signer>>, source: HTLCSource, payment_preimage: PaymentPreimage) {
+	fn claim_funds_internal(&self, mut channel_state_lock: MutexGuard<ChannelHolder<Signer>>, source: HTLCSource, payment_preimage: PaymentPreimage, forwarded_htlc_value_msat: Option<u64>, from_onchain: bool) {
 		match source {
 			HTLCSource::OutboundRoute { session_priv, .. } => {
 				mem::drop(channel_state_lock);
@@ -2891,29 +2902,51 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			},
 			HTLCSource::PreviousHopData(hop_data) => {
 				let prev_outpoint = hop_data.outpoint;
-				if let Err((counterparty_node_id, err)) = match self.claim_funds_from_hop(&mut channel_state_lock, hop_data, payment_preimage) {
-					Ok(()) => Ok(()),
-					Err(None) => {
-						let preimage_update = ChannelMonitorUpdate {
-							update_id: CLOSED_CHANNEL_UPDATE_ID,
-							updates: vec![ChannelMonitorUpdateStep::PaymentPreimage {
-								payment_preimage: payment_preimage.clone(),
-							}],
-						};
-						// We update the ChannelMonitor on the backward link, after
-						// receiving an offchain preimage event from the forward link (the
-						// event being update_fulfill_htlc).
-						if let Err(e) = self.chain_monitor.update_channel(prev_outpoint, preimage_update) {
-							log_error!(self.logger, "Critical error: failed to update channel monitor with preimage {:?}: {:?}",
-							           payment_preimage, e);
-						}
-						Ok(())
-					},
-					Err(Some(res)) => Err(res),
-				} {
-					mem::drop(channel_state_lock);
-					let res: Result<(), _> = Err(err);
-					let _ = handle_error!(self, res, counterparty_node_id);
+				let res = self.claim_funds_from_hop(&mut channel_state_lock, hop_data, payment_preimage);
+				let claimed_htlc = if let ClaimFundsFromHop::DuplicateClaim = res { false } else { true };
+				let htlc_claim_value_msat = match res {
+					ClaimFundsFromHop::MonitorUpdateFail(_, _, amt_opt) => amt_opt,
+					ClaimFundsFromHop::Success(amt) => Some(amt),
+					_ => None,
+				};
+				if let ClaimFundsFromHop::PrevHopForceClosed = res {
+					let preimage_update = ChannelMonitorUpdate {
+						update_id: CLOSED_CHANNEL_UPDATE_ID,
+						updates: vec![ChannelMonitorUpdateStep::PaymentPreimage {
+							payment_preimage: payment_preimage.clone(),
+						}],
+					};
+					// We update the ChannelMonitor on the backward link, after
+					// receiving an offchain preimage event from the forward link (the
+					// event being update_fulfill_htlc).
+					if let Err(e) = self.chain_monitor.update_channel(prev_outpoint, preimage_update) {
+						log_error!(self.logger, "Critical error: failed to update channel monitor with preimage {:?}: {:?}",
+											 payment_preimage, e);
+					}
+					// Note that we do *not* set `claimed_htlc` to false here. In fact, this
+					// totally could be a duplicate claim, but we have no way of knowing
+					// without interrogating the `ChannelMonitor` we've provided the above
+					// update to. Instead, we simply document in `PaymentForwarded` that this
+					// can happen.
+				}
+				mem::drop(channel_state_lock);
+				if let ClaimFundsFromHop::MonitorUpdateFail(pk, err, _) = res {
+					let result: Result<(), _> = Err(err);
+					let _ = handle_error!(self, result, pk);
+				}
+
+				if claimed_htlc {
+					if let Some(forwarded_htlc_value) = forwarded_htlc_value_msat {
+						let fee_earned_msat = if let Some(claimed_htlc_value) = htlc_claim_value_msat {
+							Some(claimed_htlc_value - forwarded_htlc_value)
+						} else { None };
+
+						let mut pending_events = self.pending_events.lock().unwrap();
+						pending_events.push(events::Event::PaymentForwarded {
+							fee_earned_msat,
+							claim_from_onchain_tx: from_onchain,
+						});
+					}
 				}
 			},
 		}
@@ -3309,7 +3342,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 	fn internal_update_fulfill_htlc(&self, counterparty_node_id: &PublicKey, msg: &msgs::UpdateFulfillHTLC) -> Result<(), MsgHandleErrInternal> {
 		let mut channel_lock = self.channel_state.lock().unwrap();
-		let htlc_source = {
+		let (htlc_source, forwarded_htlc_value) = {
 			let channel_state = &mut *channel_lock;
 			match channel_state.by_id.entry(msg.channel_id) {
 				hash_map::Entry::Occupied(mut chan) => {
@@ -3321,7 +3354,7 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
 			}
 		};
-		self.claim_funds_internal(channel_lock, htlc_source, msg.payment_preimage.clone());
+		self.claim_funds_internal(channel_lock, htlc_source, msg.payment_preimage.clone(), Some(forwarded_htlc_value), false);
 		Ok(())
 	}
 
@@ -3688,14 +3721,14 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	/// Process pending events from the `chain::Watch`, returning whether any events were processed.
 	fn process_pending_monitor_events(&self) -> bool {
 		let mut failed_channels = Vec::new();
-		let pending_monitor_events = self.chain_monitor.release_pending_monitor_events();
+		let mut pending_monitor_events = self.chain_monitor.release_pending_monitor_events();
 		let has_pending_monitor_events = !pending_monitor_events.is_empty();
-		for monitor_event in pending_monitor_events {
+		for monitor_event in pending_monitor_events.drain(..) {
 			match monitor_event {
 				MonitorEvent::HTLCEvent(htlc_update) => {
 					if let Some(preimage) = htlc_update.payment_preimage {
 						log_trace!(self.logger, "Claiming HTLC with preimage {} from our monitor", log_bytes!(preimage.0));
-						self.claim_funds_internal(self.channel_state.lock().unwrap(), htlc_update.source, preimage);
+						self.claim_funds_internal(self.channel_state.lock().unwrap(), htlc_update.source, preimage, htlc_update.onchain_value_satoshis.map(|v| v * 1000), true);
 					} else {
 						log_trace!(self.logger, "Failing HTLC with hash {} from our monitor", log_bytes!(htlc_update.payment_hash.0));
 						self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_update.source, &htlc_update.payment_hash, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -2804,7 +2804,13 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 							} else { errs.push((pk, err)); }
 						},
 						ClaimFundsFromHop::PrevHopForceClosed => unreachable!("We already checked for channel existence, we can't fail here!"),
-						_ => claimed_any_htlcs = true,
+						ClaimFundsFromHop::DuplicateClaim => {
+							// While we should never get here in most cases, if we do, it likely
+							// indicates that the HTLC was timed out some time ago and is no longer
+							// available to be claimed. Thus, it does not make sense to set
+							// `claimed_any_htlcs`.
+						},
+						ClaimFundsFromHop::Success(_) => claimed_any_htlcs = true,
 					}
 				}
 			}

--- a/lightning/src/ln/reorg_tests.rs
+++ b/lightning/src/ln/reorg_tests.rs
@@ -132,8 +132,9 @@ fn do_test_onchain_htlc_reorg(local_commitment: bool, claim: bool) {
 		connect_block(&nodes[1], &block);
 
 		// ChannelManager only polls chain::Watch::release_pending_monitor_events when we
-		// probe it for events, so we probe non-message events here (which should still end up empty):
-		assert_eq!(nodes[1].node.get_and_clear_pending_events().len(), 0);
+		// probe it for events, so we probe non-message events here (which should just be the
+		// PaymentForwarded event).
+		expect_payment_forwarded!(nodes[1], Some(1000), true);
 	} else {
 		// Confirm the timeout tx and check that we fail the HTLC backwards
 		let block = Block {

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -312,6 +312,8 @@ impl MaybeReadable for Event {
 				};
 				f()
 			},
+			// Versions prior to 0.0.100 did not ignore odd types, instead returning InvalidValue.
+			x if x % 2 == 1 => Ok(None),
 			_ => Err(msgs::DecodeError::InvalidValue)
 		}
 	}

--- a/lightning/src/util/events.rs
+++ b/lightning/src/util/events.rs
@@ -150,6 +150,27 @@ pub enum Event {
 		/// The outputs which you should store as spendable by you.
 		outputs: Vec<SpendableOutputDescriptor>,
 	},
+	/// This event is generated when a payment has been successfully forwarded through us and a
+	/// forwarding fee earned.
+	PaymentForwarded {
+		/// The fee, in milli-satoshis, which was earned as a result of the payment.
+		///
+		/// Note that if we force-closed the channel over which we forwarded an HTLC while the HTLC
+		/// was pending, the amount the next hop claimed will have been rounded down to the nearest
+		/// whole satoshi. Thus, the fee calculated here may be higher than expected as we still
+		/// claimed the full value in millisatoshis from the source. In this case,
+		/// `claim_from_onchain_tx` will be set.
+		///
+		/// If the channel which sent us the payment has been force-closed, we will claim the funds
+		/// via an on-chain transaction. In that case we do not yet know the on-chain transaction
+		/// fees which we will spend and will instead set this to `None`. It is possible duplicate
+		/// `PaymentForwarded` events are generated for the same payment iff `fee_earned_msat` is
+		/// `None`.
+		fee_earned_msat: Option<u64>,
+		/// If this is `true`, the forwarded HTLC was claimed by our counterparty via an on-chain
+		/// transaction.
+		claim_from_onchain_tx: bool,
+	},
 }
 
 impl Writeable for Event {
@@ -215,6 +236,13 @@ impl Writeable for Event {
 				5u8.write(writer)?;
 				write_tlv_fields!(writer, {
 					(0, VecWriteWrapper(outputs), required),
+				});
+			},
+			&Event::PaymentForwarded { fee_earned_msat, claim_from_onchain_tx } => {
+				7u8.write(writer)?;
+				write_tlv_fields!(writer, {
+					(0, fee_earned_msat, option),
+					(2, claim_from_onchain_tx, required),
 				});
 			},
 		}
@@ -309,6 +337,18 @@ impl MaybeReadable for Event {
 						(0, outputs, required),
 					});
 					Ok(Some(Event::SpendableOutputs { outputs: outputs.0 }))
+				};
+				f()
+			},
+			7u8 => {
+				let f = || {
+					let mut fee_earned_msat = None;
+					let mut claim_from_onchain_tx = false;
+					read_tlv_fields!(reader, {
+						(0, fee_earned_msat, option),
+						(2, claim_from_onchain_tx, required),
+					});
+					Ok(Some(Event::PaymentForwarded { fee_earned_msat, claim_from_onchain_tx }))
 				};
 				f()
 			},


### PR DESCRIPTION
Based on #977.

It is useful for accounting and informational reasons for users to
be informed when a payment has been successfully forwarded. Thus,
when an HTLC which represents a forwarded leg is claimed, we
generate a new `PaymentForwarded` event.

This requires some additional plumbing to return HTLC values from
`OnchainEvent`s. Further, when we have to go on-chain to claim the
inbound side of the payment, we do not inform the user of the fee
reward, as we cannot calculate it until we see what is confirmed
on-chain.