### PR TITLE
Enforces sig_rec length in message_signing

### DIFF
--- a/lightning/src/util/message_signing.rs
+++ b/lightning/src/util/message_signing.rs
@@ -36,6 +36,11 @@ fn sigrec_encode(sig_rec: RecoverableSignature) -> Vec<u8> {
 }
 
 fn sigrec_decode(sig_rec: Vec<u8>) -> Result<RecoverableSignature, Error> {
+    // Signature must be 64 + 1 bytes long (compact signature + recovery id)
+    if sig_rec.len() != 65 {
+        return Err(Error::InvalidSignature);
+    }
+
     let rsig = &sig_rec[1..];
     let rid = sig_rec[0] as i32 - 31;
 


### PR DESCRIPTION
Enforces signature length to be 65-bytes long in `message_signing::sig_rec` (64 bytes for the compact signature + 1 byte for the recovery id).

close #1005 