### PR TITLE
Fetch shutdown script based on `commit_upfront_shutdown_pubkey`

### DIFF
--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -396,6 +396,9 @@ pub fn do_test<Out: test_logger::Output>(data: &[u8], out: Out) {
 	let mut channel_txn = Vec::new();
 	macro_rules! make_channel {
 		($source: expr, $dest: expr, $chan_id: expr) => { {
+			$source.peer_connected(&$dest.get_our_node_id(), &Init { features: InitFeatures::known() });
+			$dest.peer_connected(&$source.get_our_node_id(), &Init { features: InitFeatures::known() });
+
 			$source.create_channel($dest.get_our_node_id(), 100_000, 42, 0, None).unwrap();
 			let open_channel = {
 				let events = $source.get_and_clear_pending_msg_events();

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -39,6 +39,7 @@ use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::ln::channelmanager::{ChainParameters, ChannelManager, PaymentSendFailure, ChannelManagerReadArgs};
 use lightning::ln::features::{ChannelFeatures, InitFeatures, NodeFeatures};
 use lightning::ln::msgs::{CommitmentUpdate, ChannelMessageHandler, DecodeError, UpdateAddHTLC, Init};
+use lightning::ln::script::ShutdownScript;
 use lightning::util::enforcing_trait_impls::{EnforcingSigner, INITIAL_REVOKED_COMMITMENT_NUMBER};
 use lightning::util::errors::APIError;
 use lightning::util::events;
@@ -164,9 +165,11 @@ impl KeysInterface for KeyProvider {
 		Builder::new().push_opcode(opcodes::all::OP_PUSHBYTES_0).push_slice(&our_channel_monitor_claim_key_hash[..]).into_script()
 	}
 
-	fn get_shutdown_pubkey(&self) -> PublicKey {
+	fn get_shutdown_scriptpubkey(&self) -> ShutdownScript {
 		let secp_ctx = Secp256k1::signing_only();
-		PublicKey::from_secret_key(&secp_ctx, &SecretKey::from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, self.node_id]).unwrap())
+		let secret_key = SecretKey::from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, self.node_id]).unwrap();
+		let pubkey_hash = WPubkeyHash::hash(&PublicKey::from_secret_key(&secp_ctx, &secret_key).serialize());
+		ShutdownScript::new_p2wpkh(&pubkey_hash)
 	}
 
 	fn get_channel_signer(&self, _inbound: bool, channel_value_satoshis: u64) -> EnforcingSigner {

--- a/fuzz/src/chanmon_consistency.rs
+++ b/fuzz/src/chanmon_consistency.rs
@@ -253,6 +253,7 @@ fn check_api_err(api_err: APIError) {
 		APIError::MonitorUpdateFailed => {
 			// We can (obviously) temp-fail a monitor update
 		},
+		APIError::IncompatibleShutdownScript { .. } => panic!("Cannot send an incompatible shutdown script"),
 	}
 }
 #[inline]

--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -223,7 +223,7 @@ mod tests {
 	use lightning::get_event_msg;
 	use lightning::ln::channelmanager::{BREAKDOWN_TIMEOUT, ChainParameters, ChannelManager, SimpleArcChannelManager};
 	use lightning::ln::features::InitFeatures;
-	use lightning::ln::msgs::ChannelMessageHandler;
+	use lightning::ln::msgs::{ChannelMessageHandler, Init};
 	use lightning::ln::peer_handler::{PeerManager, MessageHandler, SocketDescriptor};
 	use lightning::util::config::UserConfig;
 	use lightning::util::events::{Event, MessageSendEventsProvider, MessageSendEvent};
@@ -297,6 +297,14 @@ mod tests {
 			let node = Node { node: manager, peer_manager, chain_monitor, persister, tx_broadcaster, logger, best_block };
 			nodes.push(node);
 		}
+
+		for i in 0..num_nodes {
+			for j in (i+1)..num_nodes {
+				nodes[i].node.peer_connected(&nodes[j].node.get_our_node_id(), &Init { features: InitFeatures::known() });
+				nodes[j].node.peer_connected(&nodes[i].node.get_our_node_id(), &Init { features: InitFeatures::known() });
+			}
+		}
+
 		nodes
 	}
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -608,7 +608,7 @@ impl<Signer: Sign> Channel<Signer> {
 
 		if let Some(shutdown_scriptpubkey) = &shutdown_scriptpubkey {
 			if !shutdown_scriptpubkey.is_compatible(their_features) {
-				return Err(APIError::APIMisuseError { err: format!("Provided a scriptpubkey format not accepted by peer. script: ({})", shutdown_scriptpubkey.clone().into_inner().to_bytes().to_hex()) });
+				return Err(APIError::APIMisuseError { err: format!("Provided a scriptpubkey format not accepted by peer: {}", shutdown_scriptpubkey) });
 			}
 		}
 
@@ -843,7 +843,7 @@ impl<Signer: Sign> Channel<Signer> {
 					} else {
 						match ShutdownScript::try_from((script.clone(), their_features)) {
 							Ok(shutdown_script) => Some(shutdown_script.into_inner()),
-							Err(_) => return Err(ChannelError::Close(format!("Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: ({})", script.to_bytes().to_hex()))),
+							Err(_) => return Err(ChannelError::Close(format!("Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format: {}", script))),
 						}
 					}
 				},
@@ -860,7 +860,7 @@ impl<Signer: Sign> Channel<Signer> {
 
 		if let Some(shutdown_scriptpubkey) = &shutdown_scriptpubkey {
 			if !shutdown_scriptpubkey.is_compatible(&their_features) {
-				return Err(ChannelError::Close(format!("Provided a scriptpubkey format not accepted by peer. script: ({})", shutdown_scriptpubkey.clone().into_inner().to_bytes().to_hex())));
+				return Err(ChannelError::Close(format!("Provided a scriptpubkey format not accepted by peer: {}", shutdown_scriptpubkey)));
 			}
 		}
 
@@ -1587,7 +1587,7 @@ impl<Signer: Sign> Channel<Signer> {
 					} else {
 						match ShutdownScript::try_from((script.clone(), their_features)) {
 							Ok(shutdown_script) => Some(shutdown_script.into_inner()),
-							Err(_) => return Err(ChannelError::Close(format!("Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: ({})", script.to_bytes().to_hex()))),
+							Err(_) => return Err(ChannelError::Close(format!("Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format: {}", script))),
 						}
 					}
 				},
@@ -3295,7 +3295,7 @@ impl<Signer: Sign> Channel<Signer> {
 				assert!(send_shutdown);
 				let shutdown_scriptpubkey = keys_provider.get_shutdown_scriptpubkey();
 				if !shutdown_scriptpubkey.is_compatible(their_features) {
-					return Err(ChannelError::Close(format!("Provided a scriptpubkey format not accepted by peer. script: ({})", shutdown_scriptpubkey.clone().into_inner().to_bytes().to_hex())));
+					return Err(ChannelError::Close(format!("Provided a scriptpubkey format not accepted by peer: {}", shutdown_scriptpubkey)));
 				}
 				self.shutdown_scriptpubkey = Some(shutdown_scriptpubkey);
 				true
@@ -4487,7 +4487,7 @@ impl<Signer: Sign> Channel<Signer> {
 			None => {
 				let shutdown_scriptpubkey = keys_provider.get_shutdown_scriptpubkey();
 				if !shutdown_scriptpubkey.is_compatible(their_features) {
-					return Err(APIError::APIMisuseError { err: format!("Provided a scriptpubkey format not accepted by peer. script: ({})", shutdown_scriptpubkey.clone().into_inner().to_bytes().to_hex()) });
+					return Err(APIError::APIMisuseError { err: format!("Provided a scriptpubkey format not accepted by peer: {}", shutdown_scriptpubkey) });
 				}
 				self.shutdown_scriptpubkey = Some(shutdown_scriptpubkey);
 				true

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5559,7 +5559,7 @@ pub mod bench {
 	use ln::channelmanager::{BestBlock, ChainParameters, ChannelManager, PaymentHash, PaymentPreimage};
 	use ln::features::{InitFeatures, InvoiceFeatures};
 	use ln::functional_test_utils::*;
-	use ln::msgs::ChannelMessageHandler;
+	use ln::msgs::{ChannelMessageHandler, Init};
 	use routing::network_graph::NetworkGraph;
 	use routing::router::get_route;
 	use util::test_utils;
@@ -5622,6 +5622,8 @@ pub mod bench {
 		});
 		let node_b_holder = NodeHolder { node: &node_b };
 
+		node_a.peer_connected(&node_b.get_our_node_id(), &Init { features: InitFeatures::known() });
+		node_b.peer_connected(&node_a.get_our_node_id(), &Init { features: InitFeatures::known() });
 		node_a.create_channel(node_b.get_our_node_id(), 8_000_000, 100_000_000, 42, None).unwrap();
 		node_b.handle_open_channel(&node_a.get_our_node_id(), InitFeatures::known(), &get_event_msg!(node_a_holder, MessageSendEvent::SendOpenChannel, node_b.get_our_node_id()));
 		node_a.handle_accept_channel(&node_b.get_our_node_id(), InitFeatures::known(), &get_event_msg!(node_b_holder, MessageSendEvent::SendAcceptChannel, node_a.get_our_node_id()));

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -3271,15 +3271,6 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 						});
 					}
 
-					if chan_entry.get().is_shutdown() {
-						let channel = remove_channel!(channel_state, chan_entry);
-						if let Ok(channel_update) = self.get_channel_update_for_broadcast(&channel) {
-							channel_state.pending_msg_events.push(events::MessageSendEvent::BroadcastChannelUpdate {
-								msg: channel_update
-							});
-						}
-					}
-
 					break Ok(());
 				},
 				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -491,6 +491,8 @@ pub struct ChannelManager<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, 
 	/// Because adding or removing an entry is rare, we usually take an outer read lock and then
 	/// operate on the inner value freely. Sadly, this prevents parallel operation when opening a
 	/// new channel.
+	///
+	/// If also holding `channel_state` lock, must lock `channel_state` prior to `per_peer_state`.
 	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState>>>,
 
 	pending_events: Mutex<Vec<events::Event>>,
@@ -871,6 +873,18 @@ macro_rules! try_chan_entry {
 	}
 }
 
+macro_rules! remove_channel {
+	($channel_state: expr, $entry: expr) => {
+		{
+			let channel = $entry.remove_entry().1;
+			if let Some(short_id) = channel.get_short_channel_id() {
+				$channel_state.short_to_id.remove(&short_id);
+			}
+			channel
+		}
+	}
+}
+
 macro_rules! handle_monitor_err {
 	($self: ident, $err: expr, $channel_state: expr, $entry: expr, $action_type: path, $resend_raa: expr, $resend_commitment: expr) => {
 		handle_monitor_err!($self, $err, $channel_state, $entry, $action_type, $resend_raa, $resend_commitment, Vec::new(), Vec::new())
@@ -1165,8 +1179,15 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 			return Err(APIError::APIMisuseError { err: format!("Channel value must be at least 1000 satoshis. It was {}", channel_value_satoshis) });
 		}
 
+		let their_features = {
+			let per_peer_state = self.per_peer_state.read().unwrap();
+			match per_peer_state.get(&their_network_key) {
+				Some(peer_state) => peer_state.lock().unwrap().latest_features.clone(),
+				None => return Err(APIError::ChannelUnavailable { err: format!("Not connected to node: {}", their_network_key) }),
+			}
+		};
 		let config = if override_config.is_some() { override_config.as_ref().unwrap() } else { &self.default_configuration };
-		let channel = Channel::new_outbound(&self.fee_estimator, &self.keys_manager, their_network_key, channel_value_satoshis, push_msat, user_id, config)?;
+		let channel = Channel::new_outbound(&self.fee_estimator, &self.keys_manager, their_network_key, their_features, channel_value_satoshis, push_msat, user_id, config)?;
 		let res = channel.get_open_channel(self.genesis_hash.clone());
 
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(&self.total_consistency_lock, &self.persistence_notifier);
@@ -1260,40 +1281,60 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	pub fn close_channel(&self, channel_id: &[u8; 32]) -> Result<(), APIError> {
 		let _persistence_guard = PersistenceNotifierGuard::notify_on_drop(&self.total_consistency_lock, &self.persistence_notifier);
 
-		let (mut failed_htlcs, chan_option) = {
+		let counterparty_node_id;
+		let mut failed_htlcs: Vec<(HTLCSource, PaymentHash)>;
+		let result: Result<(), _> = loop {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 			match channel_state.by_id.entry(channel_id.clone()) {
 				hash_map::Entry::Occupied(mut chan_entry) => {
-					let (shutdown_msg, failed_htlcs) = chan_entry.get_mut().get_shutdown()?;
+					counterparty_node_id = chan_entry.get().get_counterparty_node_id();
+					let their_features = {
+						let per_peer_state = self.per_peer_state.read().unwrap();
+						match per_peer_state.get(&counterparty_node_id) {
+							Some(peer_state) => peer_state.lock().unwrap().latest_features.clone(),
+							None => return Err(APIError::ChannelUnavailable { err: format!("Not connected to node: {}", counterparty_node_id) }),
+						}
+					};
+					let (shutdown_msg, monitor_update, htlcs) = chan_entry.get_mut().get_shutdown(&self.keys_manager, &their_features)?;
+					failed_htlcs = htlcs;
+
+					// Update the monitor with the shutdown script if necessary.
+					if let Some(monitor_update) = monitor_update {
+						if let Err(e) = self.chain_monitor.update_channel(chan_entry.get().get_funding_txo().unwrap(), monitor_update) {
+							let (result, is_permanent) =
+								handle_monitor_err!(self, e, channel_state.short_to_id, chan_entry.get_mut(), RAACommitmentOrder::CommitmentFirst, false, false, Vec::new(), Vec::new(), chan_entry.key());
+							if is_permanent {
+								remove_channel!(channel_state, chan_entry);
+								break result;
+							}
+						}
+					}
+
 					channel_state.pending_msg_events.push(events::MessageSendEvent::SendShutdown {
-						node_id: chan_entry.get().get_counterparty_node_id(),
+						node_id: counterparty_node_id,
 						msg: shutdown_msg
 					});
+
 					if chan_entry.get().is_shutdown() {
-						if let Some(short_id) = chan_entry.get().get_short_channel_id() {
-							channel_state.short_to_id.remove(&short_id);
+						let channel = remove_channel!(channel_state, chan_entry);
+						if let Ok(channel_update) = self.get_channel_update_for_broadcast(&channel) {
+							channel_state.pending_msg_events.push(events::MessageSendEvent::BroadcastChannelUpdate {
+								msg: channel_update
+							});
 						}
-						(failed_htlcs, Some(chan_entry.remove_entry().1))
-					} else { (failed_htlcs, None) }
+					}
+					break Ok(());
 				},
 				hash_map::Entry::Vacant(_) => return Err(APIError::ChannelUnavailable{err: "No such channel".to_owned()})
 			}
 		};
+
 		for htlc_source in failed_htlcs.drain(..) {
 			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_source.0, &htlc_source.1, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
 		}
-		let chan_update = if let Some(chan) = chan_option {
-			self.get_channel_update_for_broadcast(&chan).ok()
-		} else { None };
 
-		if let Some(update) = chan_update {
-			let mut channel_state = self.channel_state.lock().unwrap();
-			channel_state.pending_msg_events.push(events::MessageSendEvent::BroadcastChannelUpdate {
-				msg: update
-			});
-		}
-
+		let _ = handle_error!(self, result, counterparty_node_id);
 		Ok(())
 	}
 
@@ -3190,7 +3231,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 	}
 
 	fn internal_shutdown(&self, counterparty_node_id: &PublicKey, their_features: &InitFeatures, msg: &msgs::Shutdown) -> Result<(), MsgHandleErrInternal> {
-		let (mut dropped_htlcs, chan_option) = {
+		let mut dropped_htlcs: Vec<(HTLCSource, PaymentHash)>;
+		let result: Result<(), _> = loop {
 			let mut channel_state_lock = self.channel_state.lock().unwrap();
 			let channel_state = &mut *channel_state_lock;
 
@@ -3199,25 +3241,46 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 					if chan_entry.get().get_counterparty_node_id() != *counterparty_node_id {
 						return Err(MsgHandleErrInternal::send_err_msg_no_close("Got a message for a channel from the wrong node!".to_owned(), msg.channel_id));
 					}
-					let (shutdown, closing_signed, dropped_htlcs) = try_chan_entry!(self, chan_entry.get_mut().shutdown(&self.fee_estimator, &their_features, &msg), channel_state, chan_entry);
+
+					let (shutdown, closing_signed, monitor_update, htlcs) = try_chan_entry!(self, chan_entry.get_mut().shutdown(&self.fee_estimator, &self.keys_manager, &their_features, &msg), channel_state, chan_entry);
+					dropped_htlcs = htlcs;
+
+					// Update the monitor with the shutdown script if necessary.
+					if let Some(monitor_update) = monitor_update {
+						if let Err(e) = self.chain_monitor.update_channel(chan_entry.get().get_funding_txo().unwrap(), monitor_update) {
+							let (result, is_permanent) =
+								handle_monitor_err!(self, e, channel_state.short_to_id, chan_entry.get_mut(), RAACommitmentOrder::CommitmentFirst, false, false, Vec::new(), Vec::new(), chan_entry.key());
+							if is_permanent {
+								remove_channel!(channel_state, chan_entry);
+								break result;
+							}
+						}
+					}
+
 					if let Some(msg) = shutdown {
 						channel_state.pending_msg_events.push(events::MessageSendEvent::SendShutdown {
-							node_id: counterparty_node_id.clone(),
+							node_id: *counterparty_node_id,
 							msg,
 						});
 					}
 					if let Some(msg) = closing_signed {
+						// TODO: Do not send this if the monitor update failed.
 						channel_state.pending_msg_events.push(events::MessageSendEvent::SendClosingSigned {
-							node_id: counterparty_node_id.clone(),
+							node_id: *counterparty_node_id,
 							msg,
 						});
 					}
+
 					if chan_entry.get().is_shutdown() {
-						if let Some(short_id) = chan_entry.get().get_short_channel_id() {
-							channel_state.short_to_id.remove(&short_id);
+						let channel = remove_channel!(channel_state, chan_entry);
+						if let Ok(channel_update) = self.get_channel_update_for_broadcast(&channel) {
+							channel_state.pending_msg_events.push(events::MessageSendEvent::BroadcastChannelUpdate {
+								msg: channel_update
+							});
 						}
-						(dropped_htlcs, Some(chan_entry.remove_entry().1))
-					} else { (dropped_htlcs, None) }
+					}
+
+					break Ok(());
 				},
 				hash_map::Entry::Vacant(_) => return Err(MsgHandleErrInternal::send_err_msg_no_close("Failed to find corresponding channel".to_owned(), msg.channel_id))
 			}
@@ -3225,14 +3288,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 		for htlc_source in dropped_htlcs.drain(..) {
 			self.fail_htlc_backwards_internal(self.channel_state.lock().unwrap(), htlc_source.0, &htlc_source.1, HTLCFailReason::Reason { failure_code: 0x4000 | 8, data: Vec::new() });
 		}
-		if let Some(chan) = chan_option {
-			if let Ok(update) = self.get_channel_update_for_broadcast(&chan) {
-				let mut channel_state = self.channel_state.lock().unwrap();
-				channel_state.pending_msg_events.push(events::MessageSendEvent::BroadcastChannelUpdate {
-					msg: update
-				});
-			}
-		}
+
+		let _ = handle_error!(self, result, *counterparty_node_id);
 		Ok(())
 	}
 

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -199,6 +199,7 @@ pub struct NodeCfg<'a> {
 	pub keys_manager: &'a test_utils::TestKeysInterface,
 	pub logger: &'a test_utils::TestLogger,
 	pub node_seed: [u8; 32],
+	pub features: InitFeatures,
 }
 
 pub struct Node<'a, 'b: 'a, 'c: 'b> {
@@ -1368,7 +1369,16 @@ pub fn create_node_cfgs<'a>(node_count: usize, chanmon_cfgs: &'a Vec<TestChanMon
 	for i in 0..node_count {
 		let chain_monitor = test_utils::TestChainMonitor::new(Some(&chanmon_cfgs[i].chain_source), &chanmon_cfgs[i].tx_broadcaster, &chanmon_cfgs[i].logger, &chanmon_cfgs[i].fee_estimator, &chanmon_cfgs[i].persister, &chanmon_cfgs[i].keys_manager);
 		let seed = [i as u8; 32];
-		nodes.push(NodeCfg { chain_source: &chanmon_cfgs[i].chain_source, logger: &chanmon_cfgs[i].logger, tx_broadcaster: &chanmon_cfgs[i].tx_broadcaster, fee_estimator: &chanmon_cfgs[i].fee_estimator, chain_monitor, keys_manager: &chanmon_cfgs[i].keys_manager, node_seed: seed });
+		nodes.push(NodeCfg {
+			chain_source: &chanmon_cfgs[i].chain_source,
+			logger: &chanmon_cfgs[i].logger,
+			tx_broadcaster: &chanmon_cfgs[i].tx_broadcaster,
+			fee_estimator: &chanmon_cfgs[i].fee_estimator,
+			chain_monitor,
+			keys_manager: &chanmon_cfgs[i].keys_manager,
+			node_seed: seed,
+			features: InitFeatures::known(),
+		});
 	}
 
 	nodes
@@ -1423,8 +1433,8 @@ pub fn create_network<'a, 'b: 'a, 'c: 'b>(node_count: usize, cfgs: &'b Vec<NodeC
 
 	for i in 0..node_count {
 		for j in (i+1)..node_count {
-			nodes[i].node.peer_connected(&nodes[j].node.get_our_node_id(), &msgs::Init { features: InitFeatures::known() });
-			nodes[j].node.peer_connected(&nodes[i].node.get_our_node_id(), &msgs::Init { features: InitFeatures::known() });
+			nodes[i].node.peer_connected(&nodes[j].node.get_our_node_id(), &msgs::Init { features: cfgs[j].features.clone() });
+			nodes[j].node.peer_connected(&nodes[i].node.get_our_node_id(), &msgs::Init { features: cfgs[i].features.clone() });
 		}
 	}
 

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -5893,7 +5893,7 @@ fn test_key_derivation_params() {
 	let seed = [42; 32];
 	let keys_manager = test_utils::TestKeysInterface::new(&seed, Network::Testnet);
 	let chain_monitor = test_utils::TestChainMonitor::new(Some(&chanmon_cfgs[0].chain_source), &chanmon_cfgs[0].tx_broadcaster, &chanmon_cfgs[0].logger, &chanmon_cfgs[0].fee_estimator, &chanmon_cfgs[0].persister, &keys_manager);
-	let node = NodeCfg { chain_source: &chanmon_cfgs[0].chain_source, logger: &chanmon_cfgs[0].logger, tx_broadcaster: &chanmon_cfgs[0].tx_broadcaster, fee_estimator: &chanmon_cfgs[0].fee_estimator, chain_monitor, keys_manager: &keys_manager, node_seed: seed };
+	let node = NodeCfg { chain_source: &chanmon_cfgs[0].chain_source, logger: &chanmon_cfgs[0].logger, tx_broadcaster: &chanmon_cfgs[0].tx_broadcaster, fee_estimator: &chanmon_cfgs[0].fee_estimator, chain_monitor, keys_manager: &keys_manager, node_seed: seed, features: InitFeatures::known() };
 	let mut node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
 	node_cfgs.remove(0);
 	node_cfgs.insert(0, node);

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7767,7 +7767,7 @@ fn test_user_configurable_csv_delay() {
 	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
 
 	// We test config.our_to_self > BREAKDOWN_TIMEOUT is enforced in Channel::new_outbound()
-	if let Err(error) = Channel::new_outbound(&&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), InitFeatures::known(), 1000000, 1000000, 0, &low_our_to_self_config) {
+	if let Err(error) = Channel::new_outbound(&&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), &InitFeatures::known(), 1000000, 1000000, 0, &low_our_to_self_config) {
 		match error {
 			APIError::APIMisuseError { err } => { assert!(regex::Regex::new(r"Configured with an unreasonable our_to_self_delay \(\d+\) putting user funds at risks").unwrap().is_match(err.as_str())); },
 			_ => panic!("Unexpected event"),
@@ -7778,7 +7778,7 @@ fn test_user_configurable_csv_delay() {
 	nodes[1].node.create_channel(nodes[0].node.get_our_node_id(), 1000000, 1000000, 42, None).unwrap();
 	let mut open_channel = get_event_msg!(nodes[1], MessageSendEvent::SendOpenChannel, nodes[0].node.get_our_node_id());
 	open_channel.to_self_delay = 200;
-	if let Err(error) = Channel::new_from_req(&&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), InitFeatures::known(), &open_channel, 0, &low_our_to_self_config) {
+	if let Err(error) = Channel::new_from_req(&&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), &InitFeatures::known(), &open_channel, 0, &low_our_to_self_config) {
 		match error {
 			ChannelError::Close(err) => { assert!(regex::Regex::new(r"Configured with an unreasonable our_to_self_delay \(\d+\) putting user funds at risks").unwrap().is_match(err.as_str()));  },
 			_ => panic!("Unexpected event"),
@@ -7804,7 +7804,7 @@ fn test_user_configurable_csv_delay() {
 	nodes[1].node.create_channel(nodes[0].node.get_our_node_id(), 1000000, 1000000, 42, None).unwrap();
 	let mut open_channel = get_event_msg!(nodes[1], MessageSendEvent::SendOpenChannel, nodes[0].node.get_our_node_id());
 	open_channel.to_self_delay = 200;
-	if let Err(error) = Channel::new_from_req(&&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), InitFeatures::known(), &open_channel, 0, &high_their_to_self_config) {
+	if let Err(error) = Channel::new_from_req(&&test_utils::TestFeeEstimator { sat_per_kw: Mutex::new(253) }, &nodes[0].keys_manager, nodes[1].node.get_our_node_id(), &InitFeatures::known(), &open_channel, 0, &high_their_to_self_config) {
 		match error {
 			ChannelError::Close(err) => { assert!(regex::Regex::new(r"They wanted our payments to be delayed by a needlessly long period\. Upper limit: \d+\. Actual: \d+").unwrap().is_match(err.as_str())); },
 			_ => panic!("Unexpected event"),

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7548,7 +7548,7 @@ fn test_unsupported_anysegwit_upfront_shutdown_script() {
 	match events[0] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[0].node.get_our_node_id());
-			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+			assert_eq!(msg.data, "Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format: Script(OP_PUSHNUM_16 OP_PUSHBYTES_2 0028)");
 		},
 		_ => panic!("Unexpected event"),
 	}
@@ -7566,7 +7566,7 @@ fn test_unsupported_anysegwit_upfront_shutdown_script() {
 	match events[0] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[1].node.get_our_node_id());
-			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+			assert_eq!(msg.data, "Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format: Script(OP_PUSHNUM_16 OP_PUSHBYTES_2 0028)");
 		},
 		_ => panic!("Unexpected event"),
 	}
@@ -7593,7 +7593,7 @@ fn test_invalid_upfront_shutdown_script() {
 	match events[0] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[0].node.get_our_node_id());
-			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+			assert_eq!(msg.data, "Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format: Script(OP_0 OP_PUSHBYTES_2 0000)");
 		},
 		_ => panic!("Unexpected event"),
 	}

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7521,10 +7521,56 @@ fn test_upfront_shutdown_script() {
 }
 
 #[test]
-fn test_upfront_shutdown_script_unsupport_segwit() {
-	// We test that channel is closed early
-	// if a segwit program is passed as upfront shutdown script,
-	// but the peer does not support segwit.
+fn test_unsupported_anysegwit_upfront_shutdown_script() {
+	let chanmon_cfgs = create_chanmon_cfgs(2);
+	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
+	let nodes = create_network(2, &node_cfgs, &node_chanmgrs);
+
+	// Use a non-v0 segwit script supported by option_shutdown_anysegwit
+	let node_features = InitFeatures::known().clear_shutdown_anysegwit();
+	let anysegwit_shutdown_script = Builder::new()
+		.push_int(16)
+		.push_slice(&[0, 40])
+		.into_script();
+
+	// Check script when handling an open_channel message
+	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 42, None).unwrap();
+	let mut open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
+	open_channel.shutdown_scriptpubkey = Present(anysegwit_shutdown_script.clone());
+	nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), node_features.clone(), &open_channel);
+
+	let events = nodes[1].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	match events[0] {
+		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
+			assert_eq!(node_id, nodes[0].node.get_our_node_id());
+			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided a non-accepted scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+		},
+		_ => panic!("Unexpected event"),
+	}
+
+	// Check script when handling an accept_channel message
+	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 42, None).unwrap();
+	let open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
+	nodes[1].node.handle_open_channel(&nodes[0].node.get_our_node_id(), InitFeatures::known(), &open_channel);
+	let mut accept_channel = get_event_msg!(nodes[1], MessageSendEvent::SendAcceptChannel, nodes[0].node.get_our_node_id());
+	accept_channel.shutdown_scriptpubkey = Present(anysegwit_shutdown_script.clone());
+	nodes[0].node.handle_accept_channel(&nodes[1].node.get_our_node_id(), node_features, &accept_channel);
+
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 1);
+	match events[0] {
+		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
+			assert_eq!(node_id, nodes[1].node.get_our_node_id());
+			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided a non-accepted scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+		},
+		_ => panic!("Unexpected event"),
+	}
+}
+
+#[test]
+fn test_invalid_upfront_shutdown_script() {
 	let chanmon_cfgs = create_chanmon_cfgs(2);
 	let node_cfgs = create_node_cfgs(2, &chanmon_cfgs);
 	let node_chanmgrs = create_node_chanmgrs(2, &node_cfgs, &[None, None]);
@@ -7532,13 +7578,12 @@ fn test_upfront_shutdown_script_unsupport_segwit() {
 
 	nodes[0].node.create_channel(nodes[1].node.get_our_node_id(), 100000, 10001, 42, None).unwrap();
 
+	// Use a segwit v0 script with an unsupported witness program
 	let mut open_channel = get_event_msg!(nodes[0], MessageSendEvent::SendOpenChannel, nodes[1].node.get_our_node_id());
-	open_channel.shutdown_scriptpubkey = Present(Builder::new().push_int(16)
+	open_channel.shutdown_scriptpubkey = Present(Builder::new().push_int(0)
 		.push_slice(&[0, 0])
 		.into_script());
-
-	let features = InitFeatures::known().clear_shutdown_anysegwit();
-	nodes[0].node.handle_open_channel(&nodes[0].node.get_our_node_id(), features, &open_channel);
+	nodes[0].node.handle_open_channel(&nodes[0].node.get_our_node_id(), InitFeatures::known(), &open_channel);
 
 	let events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 1);
@@ -7552,7 +7597,7 @@ fn test_upfront_shutdown_script_unsupport_segwit() {
 }
 
 #[test]
-fn test_shutdown_script_any_segwit_allowed() {
+fn test_segwit_v0_shutdown_script() {
 	let mut config = UserConfig::default();
 	config.channel_options.announced_channel = true;
 	config.peer_channel_config_limits.force_announced_channel_preference = false;
@@ -7563,14 +7608,16 @@ fn test_shutdown_script_any_segwit_allowed() {
 	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &user_cfgs);
 	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 
-	//// We test if the remote peer accepts opt_shutdown_anysegwit, a witness program can be used on shutdown
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, InitFeatures::known(), InitFeatures::known());
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 	nodes[1].node.close_channel(&OutPoint { txid: chan.3.txid(), index: 0 }.to_channel_id()).unwrap();
+
+	// Use a segwit v0 script supported even without option_shutdown_anysegwit
 	let mut node_0_shutdown = get_event_msg!(nodes[1], MessageSendEvent::SendShutdown, nodes[0].node.get_our_node_id());
-	node_0_shutdown.scriptpubkey = Builder::new().push_int(16)
-		.push_slice(&[0, 0])
+	node_0_shutdown.scriptpubkey = Builder::new().push_int(0)
+		.push_slice(&[0; 20])
 		.into_script();
 	nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &InitFeatures::known(), &node_0_shutdown);
+
 	let events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 2);
 	match events[0] {
@@ -7584,7 +7631,7 @@ fn test_shutdown_script_any_segwit_allowed() {
 }
 
 #[test]
-fn test_shutdown_script_any_segwit_not_allowed() {
+fn test_anysegwit_shutdown_script() {
 	let mut config = UserConfig::default();
 	config.channel_options.announced_channel = true;
 	config.peer_channel_config_limits.force_announced_channel_preference = false;
@@ -7595,22 +7642,57 @@ fn test_shutdown_script_any_segwit_not_allowed() {
 	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &user_cfgs);
 	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 
-	//// We test that if the remote peer does not accept opt_shutdown_anysegwit, the witness program cannot be used on shutdown
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, InitFeatures::known(), InitFeatures::known());
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 	nodes[1].node.close_channel(&OutPoint { txid: chan.3.txid(), index: 0 }.to_channel_id()).unwrap();
+
+	// Use a non-v0 segwit script supported by option_shutdown_anysegwit
 	let mut node_0_shutdown = get_event_msg!(nodes[1], MessageSendEvent::SendShutdown, nodes[0].node.get_our_node_id());
-	// Make an any segwit version script
 	node_0_shutdown.scriptpubkey = Builder::new().push_int(16)
 		.push_slice(&[0, 0])
 		.into_script();
-	let flags_no = InitFeatures::known().clear_shutdown_anysegwit();
-	nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &flags_no, &node_0_shutdown);
+	nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &InitFeatures::known(), &node_0_shutdown);
+
+	let events = nodes[0].node.get_and_clear_pending_msg_events();
+	assert_eq!(events.len(), 2);
+	match events[0] {
+		MessageSendEvent::SendShutdown { node_id, .. } => { assert_eq!(node_id, nodes[1].node.get_our_node_id()) }
+		_ => panic!("Unexpected event"),
+	}
+	match events[1] {
+		MessageSendEvent::SendClosingSigned { node_id, .. } => { assert_eq!(node_id, nodes[1].node.get_our_node_id()) }
+		_ => panic!("Unexpected event"),
+	}
+}
+
+#[test]
+fn test_unsupported_anysegwit_shutdown_script() {
+	let mut config = UserConfig::default();
+	config.channel_options.announced_channel = true;
+	config.peer_channel_config_limits.force_announced_channel_preference = false;
+	config.channel_options.commit_upfront_shutdown_pubkey = false;
+	let user_cfgs = [None, Some(config), None];
+	let chanmon_cfgs = create_chanmon_cfgs(3);
+	let node_cfgs = create_node_cfgs(3, &chanmon_cfgs);
+	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &user_cfgs);
+	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
+
+	let node_features = InitFeatures::known().clear_shutdown_anysegwit();
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), node_features.clone());
+	nodes[1].node.close_channel(&OutPoint { txid: chan.3.txid(), index: 0 }.to_channel_id()).unwrap();
+
+	// Use a non-v0 segwit script supported by option_shutdown_anysegwit
+	let mut node_0_shutdown = get_event_msg!(nodes[1], MessageSendEvent::SendShutdown, nodes[0].node.get_our_node_id());
+	node_0_shutdown.scriptpubkey = Builder::new().push_int(16)
+		.push_slice(&[0, 40])
+		.into_script();
+	nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &node_features, &node_0_shutdown);
+
 	let events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 2);
 	match events[1] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[1].node.get_our_node_id());
-			assert_eq!(msg.data, "Got a nonstandard scriptpubkey (60020000) from remote peer".to_owned())
+			assert_eq!(msg.data, "Got a nonstandard scriptpubkey (60020028) from remote peer".to_owned());
 		},
 		_ => panic!("Unexpected event"),
 	}
@@ -7618,7 +7700,7 @@ fn test_shutdown_script_any_segwit_not_allowed() {
 }
 
 #[test]
-fn test_shutdown_script_segwit_but_not_anysegwit() {
+fn test_invalid_shutdown_script() {
 	let mut config = UserConfig::default();
 	config.channel_options.announced_channel = true;
 	config.peer_channel_config_limits.force_announced_channel_preference = false;
@@ -7629,15 +7711,16 @@ fn test_shutdown_script_segwit_but_not_anysegwit() {
 	let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &user_cfgs);
 	let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 
-	//// We test that if shutdown any segwit is supported and we send a witness script with 0 version, this is not accepted
-	let chan = create_announced_chan_between_nodes_with_value(&nodes, 0, 1, 1000000, 1000000, InitFeatures::known(), InitFeatures::known());
+	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 	nodes[1].node.close_channel(&OutPoint { txid: chan.3.txid(), index: 0 }.to_channel_id()).unwrap();
+
+	// Use a segwit v0 script with an unsupported witness program
 	let mut node_0_shutdown = get_event_msg!(nodes[1], MessageSendEvent::SendShutdown, nodes[0].node.get_our_node_id());
-	// Make a segwit script that is not a valid as any segwit
 	node_0_shutdown.scriptpubkey = Builder::new().push_int(0)
 		.push_slice(&[0, 0])
 		.into_script();
 	nodes[0].node.handle_shutdown(&nodes[1].node.get_our_node_id(), &InitFeatures::known(), &node_0_shutdown);
+
 	let events = nodes[0].node.get_and_clear_pending_msg_events();
 	assert_eq!(events.len(), 2);
 	match events[1] {

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7693,7 +7693,9 @@ fn test_unsupported_anysegwit_shutdown_script() {
 
 	let chan = create_announced_chan_between_nodes(&nodes, 0, 1, node_cfgs[0].features.clone(), node_cfgs[1].features.clone());
 	match nodes[1].node.close_channel(&OutPoint { txid: chan.3.txid(), index: 0 }.to_channel_id()) {
-		Err(APIError::APIMisuseError { err }) => assert_eq!(err, "Provided a scriptpubkey format not accepted by peer. script: (60020028)"),
+		Err(APIError::IncompatibleShutdownScript { script }) => {
+			assert_eq!(script.into_inner(), unsupported_shutdown_script.clone().into_inner());
+		},
 		Err(e) => panic!("Unexpected error: {:?}", e),
 		Ok(_) => panic!("Expected error"),
 	}

--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -7545,7 +7545,7 @@ fn test_unsupported_anysegwit_upfront_shutdown_script() {
 	match events[0] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[0].node.get_our_node_id());
-			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided a non-accepted scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
 		},
 		_ => panic!("Unexpected event"),
 	}
@@ -7563,7 +7563,7 @@ fn test_unsupported_anysegwit_upfront_shutdown_script() {
 	match events[0] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[1].node.get_our_node_id());
-			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided a non-accepted scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
 		},
 		_ => panic!("Unexpected event"),
 	}
@@ -7590,7 +7590,7 @@ fn test_invalid_upfront_shutdown_script() {
 	match events[0] {
 		MessageSendEvent::HandleError { action: ErrorAction::SendErrorMessage { ref msg }, node_id } => {
 			assert_eq!(node_id, nodes[0].node.get_our_node_id());
-			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided a non-accepted scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
+			assert!(regex::Regex::new(r"Peer is signaling upfront_shutdown but has provided an unacceptable scriptpubkey format. script: (\([A-Fa-f0-9]+\))").unwrap().is_match(&*msg.data));
 		},
 		_ => panic!("Unexpected event"),
 	}

--- a/lightning/src/ln/mod.rs
+++ b/lightning/src/ln/mod.rs
@@ -27,6 +27,7 @@ pub mod msgs;
 pub mod peer_handler;
 pub mod chan_utils;
 pub mod features;
+pub mod script;
 
 #[cfg(feature = "fuzztarget")]
 pub mod peer_channel_encryptor;

--- a/lightning/src/ln/script.rs
+++ b/lightning/src/ln/script.rs
@@ -1,0 +1,268 @@
+//! Abstractions for scripts used in the Lightning Network.
+
+use bitcoin::blockdata::opcodes::all::OP_PUSHBYTES_0 as SEGWIT_V0;
+use bitcoin::blockdata::script::{Builder, Script};
+use bitcoin::hashes::Hash;
+use bitcoin::hash_types::{PubkeyHash, ScriptHash, WPubkeyHash, WScriptHash};
+use bitcoin::secp256k1::key::PublicKey;
+
+use ln::features::InitFeatures;
+
+use core::convert::TryFrom;
+use core::num::NonZeroU8;
+
+/// A script pubkey for shutting down a channel as defined by [BOLT #2].
+///
+/// [BOLT #2]: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md
+pub struct ShutdownScript(ShutdownScriptImpl);
+
+/// An error occurring when converting from [`Script`] to [`ShutdownScript`].
+#[derive(Debug)]
+pub struct InvalidShutdownScript {
+	/// The script that did not meet the requirements from [BOLT #2].
+	///
+	/// [BOLT #2]: https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md
+	pub script: Script
+}
+
+enum ShutdownScriptImpl {
+	/// [`PublicKey`] used to form a P2WPKH script pubkey. Used to support backward-compatible
+	/// serialization.
+	Legacy(PublicKey),
+
+	/// [`Script`] adhering to a script pubkey format specified in BOLT #2.
+	Bolt2(Script),
+}
+
+impl ShutdownScript {
+	/// Generates a P2WPKH script pubkey from the given [`PublicKey`].
+	pub fn new_p2wpkh_from_pubkey(pubkey: PublicKey) -> Self {
+		Self(ShutdownScriptImpl::Legacy(pubkey))
+	}
+
+	/// Generates a P2PKH script pubkey from the given [`PubkeyHash`].
+	pub fn new_p2pkh(pubkey_hash: &PubkeyHash) -> Self {
+		Self(ShutdownScriptImpl::Bolt2(Script::new_p2pkh(pubkey_hash)))
+	}
+
+	/// Generates a P2SH script pubkey from the given [`ScriptHash`].
+	pub fn new_p2sh(script_hash: &ScriptHash) -> Self {
+		Self(ShutdownScriptImpl::Bolt2(Script::new_p2sh(script_hash)))
+	}
+
+	/// Generates a P2WPKH script pubkey from the given [`WPubkeyHash`].
+	pub fn new_p2wpkh(pubkey_hash: &WPubkeyHash) -> Self {
+		Self(ShutdownScriptImpl::Bolt2(Script::new_v0_wpkh(pubkey_hash)))
+	}
+
+	/// Generates a P2WSH script pubkey from the given [`WScriptHash`].
+	pub fn new_p2wsh(script_hash: &WScriptHash) -> Self {
+		Self(ShutdownScriptImpl::Bolt2(Script::new_v0_wsh(script_hash)))
+	}
+
+	/// Generates a P2WSH script pubkey from the given segwit version and program.
+	///
+	/// # Errors
+	///
+	/// This function may return an error if `program` is invalid for the segwit `version`.
+	pub fn new_witness_program(version: NonZeroU8, program: &[u8]) -> Result<Self, InvalidShutdownScript> {
+		let script = Builder::new()
+			.push_int(version.get().into())
+			.push_slice(&program)
+			.into_script();
+		Self::try_from(script)
+	}
+
+	/// Converts the shutdown script into the underlying [`Script`].
+	pub fn into_inner(self) -> Script {
+		self.into()
+	}
+
+	/// Returns the [`PublicKey`] used for a P2WPKH shutdown script if constructed directly from it.
+	pub fn as_legacy_pubkey(&self) -> Option<&PublicKey> {
+		match &self.0 {
+			ShutdownScriptImpl::Legacy(pubkey) => Some(pubkey),
+			ShutdownScriptImpl::Bolt2(_) => None,
+		}
+	}
+
+	/// Returns whether the shutdown script is compatible with the features as defined by BOLT #2.
+	///
+	/// Specifically, checks for compliance with feature `option_shutdown_anysegwit`.
+	pub fn is_compatible(&self, features: &InitFeatures) -> bool {
+		match &self.0 {
+			ShutdownScriptImpl::Legacy(_) => true,
+			ShutdownScriptImpl::Bolt2(script) => is_bolt2_compliant(script, features),
+		}
+	}
+}
+
+fn is_bolt2_compliant(script: &Script, features: &InitFeatures) -> bool {
+	if script.is_p2pkh() || script.is_p2sh() || script.is_v0_p2wpkh() || script.is_v0_p2wsh() {
+		true
+	} else if features.supports_shutdown_anysegwit() {
+		script.is_witness_program() && script.as_bytes()[0] != SEGWIT_V0.into_u8()
+	} else {
+		false
+	}
+}
+
+impl TryFrom<Script> for ShutdownScript {
+	type Error = InvalidShutdownScript;
+
+	fn try_from(script: Script) -> Result<Self, Self::Error> {
+		Self::try_from((script, &InitFeatures::known()))
+	}
+}
+
+impl TryFrom<(Script, &InitFeatures)> for ShutdownScript {
+	type Error = InvalidShutdownScript;
+
+	fn try_from((script, features): (Script, &InitFeatures)) -> Result<Self, Self::Error> {
+		if is_bolt2_compliant(&script, features) {
+			Ok(Self(ShutdownScriptImpl::Bolt2(script)))
+		} else {
+			Err(InvalidShutdownScript { script })
+		}
+	}
+}
+
+impl Into<Script> for ShutdownScript {
+	fn into(self) -> Script {
+		match self.0 {
+			ShutdownScriptImpl::Legacy(pubkey) =>
+				Script::new_v0_wpkh(&WPubkeyHash::hash(&pubkey.serialize())),
+			ShutdownScriptImpl::Bolt2(script_pubkey) => script_pubkey,
+		}
+	}
+}
+
+#[cfg(test)]
+mod shutdown_script_tests {
+	use super::ShutdownScript;
+	use bitcoin::bech32::u5;
+	use bitcoin::blockdata::opcodes;
+	use bitcoin::blockdata::script::{Builder, Script};
+	use bitcoin::secp256k1::Secp256k1;
+	use bitcoin::secp256k1::key::{PublicKey, SecretKey};
+	use ln::features::InitFeatures;
+	use core::convert::TryFrom;
+	use core::num::NonZeroU8;
+
+	fn pubkey() -> bitcoin::util::ecdsa::PublicKey {
+		let secp_ctx = Secp256k1::signing_only();
+		let secret_key = SecretKey::from_slice(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]).unwrap();
+		bitcoin::util::ecdsa::PublicKey::new(PublicKey::from_secret_key(&secp_ctx, &secret_key))
+	}
+
+	fn redeem_script() -> Script {
+		let pubkey = pubkey();
+		Builder::new()
+			.push_opcode(opcodes::all::OP_PUSHNUM_2)
+			.push_key(&pubkey)
+			.push_key(&pubkey)
+			.push_opcode(opcodes::all::OP_PUSHNUM_2)
+			.push_opcode(opcodes::all::OP_CHECKMULTISIG)
+			.into_script()
+	}
+
+	#[test]
+	fn generates_p2wpkh_from_pubkey() {
+		let pubkey = pubkey();
+		let pubkey_hash = pubkey.wpubkey_hash().unwrap();
+		let p2wpkh_script = Script::new_v0_wpkh(&pubkey_hash);
+
+		let shutdown_script = ShutdownScript::new_p2wpkh_from_pubkey(pubkey.key);
+		assert!(shutdown_script.is_compatible(&InitFeatures::known()));
+		assert!(shutdown_script.is_compatible(&InitFeatures::known().clear_shutdown_anysegwit()));
+		assert_eq!(shutdown_script.into_inner(), p2wpkh_script);
+	}
+
+	#[test]
+	fn generates_p2pkh_from_pubkey_hash() {
+		let pubkey_hash = pubkey().pubkey_hash();
+		let p2pkh_script = Script::new_p2pkh(&pubkey_hash);
+
+		let shutdown_script = ShutdownScript::new_p2pkh(&pubkey_hash);
+		assert!(shutdown_script.is_compatible(&InitFeatures::known()));
+		assert!(shutdown_script.is_compatible(&InitFeatures::known().clear_shutdown_anysegwit()));
+		assert_eq!(shutdown_script.into_inner(), p2pkh_script);
+		assert!(ShutdownScript::try_from(p2pkh_script).is_ok());
+	}
+
+	#[test]
+	fn generates_p2sh_from_script_hash() {
+		let script_hash = redeem_script().script_hash();
+		let p2sh_script = Script::new_p2sh(&script_hash);
+
+		let shutdown_script = ShutdownScript::new_p2sh(&script_hash);
+		assert!(shutdown_script.is_compatible(&InitFeatures::known()));
+		assert!(shutdown_script.is_compatible(&InitFeatures::known().clear_shutdown_anysegwit()));
+		assert_eq!(shutdown_script.into_inner(), p2sh_script);
+		assert!(ShutdownScript::try_from(p2sh_script).is_ok());
+	}
+
+	#[test]
+	fn generates_p2wpkh_from_pubkey_hash() {
+		let pubkey_hash = pubkey().wpubkey_hash().unwrap();
+		let p2wpkh_script = Script::new_v0_wpkh(&pubkey_hash);
+
+		let shutdown_script = ShutdownScript::new_p2wpkh(&pubkey_hash);
+		assert!(shutdown_script.is_compatible(&InitFeatures::known()));
+		assert!(shutdown_script.is_compatible(&InitFeatures::known().clear_shutdown_anysegwit()));
+		assert_eq!(shutdown_script.into_inner(), p2wpkh_script);
+		assert!(ShutdownScript::try_from(p2wpkh_script).is_ok());
+	}
+
+	#[test]
+	fn generates_p2wsh_from_script_hash() {
+		let script_hash = redeem_script().wscript_hash();
+		let p2wsh_script = Script::new_v0_wsh(&script_hash);
+
+		let shutdown_script = ShutdownScript::new_p2wsh(&script_hash);
+		assert!(shutdown_script.is_compatible(&InitFeatures::known()));
+		assert!(shutdown_script.is_compatible(&InitFeatures::known().clear_shutdown_anysegwit()));
+		assert_eq!(shutdown_script.into_inner(), p2wsh_script);
+		assert!(ShutdownScript::try_from(p2wsh_script).is_ok());
+	}
+
+	#[test]
+	fn generates_segwit_from_non_v0_witness_program() {
+		let version = u5::try_from_u8(16).unwrap();
+		let witness_program = Script::new_witness_program(version, &[0; 40]);
+
+		let version = NonZeroU8::new(version.to_u8()).unwrap();
+		let shutdown_script = ShutdownScript::new_witness_program(version, &[0; 40]).unwrap();
+		assert!(shutdown_script.is_compatible(&InitFeatures::known()));
+		assert!(!shutdown_script.is_compatible(&InitFeatures::known().clear_shutdown_anysegwit()));
+		assert_eq!(shutdown_script.into_inner(), witness_program);
+	}
+
+	#[test]
+	fn fails_from_unsupported_script() {
+		let op_return = Script::new_op_return(&[0; 42]);
+		assert!(ShutdownScript::try_from(op_return).is_err());
+	}
+
+	#[test]
+	fn fails_from_invalid_segwit_version() {
+		let version = NonZeroU8::new(17).unwrap();
+		assert!(ShutdownScript::new_witness_program(version, &[0; 40]).is_err());
+	}
+
+	#[test]
+	fn fails_from_invalid_segwit_v0_witness_program() {
+		let witness_program = Script::new_witness_program(u5::try_from_u8(0).unwrap(), &[0; 2]);
+		assert!(ShutdownScript::try_from(witness_program).is_err());
+	}
+
+	#[test]
+	fn fails_from_invalid_segwit_non_v0_witness_program() {
+		let version = u5::try_from_u8(16).unwrap();
+		let witness_program = Script::new_witness_program(version, &[0; 42]);
+		assert!(ShutdownScript::try_from(witness_program).is_err());
+
+		let version = NonZeroU8::new(version.to_u8()).unwrap();
+		assert!(ShutdownScript::new_witness_program(version, &[0; 42]).is_err());
+	}
+}

--- a/lightning/src/ln/script.rs
+++ b/lightning/src/ln/script.rs
@@ -163,6 +163,15 @@ impl Into<Script> for ShutdownScript {
 	}
 }
 
+impl core::fmt::Display for ShutdownScript{
+	fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+		match &self.0 {
+			ShutdownScriptImpl::Legacy(_) => self.clone().into_inner().fmt(f),
+			ShutdownScriptImpl::Bolt2(script) => script.fmt(f),
+		}
+	}
+}
+
 #[cfg(test)]
 mod shutdown_script_tests {
 	use super::ShutdownScript;

--- a/lightning/src/util/errors.rs
+++ b/lightning/src/util/errors.rs
@@ -9,6 +9,8 @@
 
 //! Error types live here.
 
+use ln::script::ShutdownScript;
+
 use alloc::string::String;
 use core::fmt;
 
@@ -47,6 +49,18 @@ pub enum APIError {
 	/// An attempt to call watch/update_channel returned an Err (ie you did this!), causing the
 	/// attempted action to fail.
 	MonitorUpdateFailed,
+	/// [`KeysInterface::get_shutdown_scriptpubkey`] returned a shutdown scriptpubkey incompatible
+	/// with the channel counterparty as negotiated in [`InitFeatures`].
+	///
+	/// Using a SegWit v0 script should resolve this issue. If you cannot, you won't be able to open
+	/// a channel or cooperatively close one with this peer (and will have to force-close instead).
+	///
+	/// [`KeysInterface::get_shutdown_scriptpubkey`]: crate::chain::keysinterface::KeysInterface::get_shutdown_scriptpubkey
+	/// [`InitFeatures`]: crate::ln::features::InitFeatures
+	IncompatibleShutdownScript {
+		/// The incompatible shutdown script.
+		script: ShutdownScript,
+	},
 }
 
 impl fmt::Debug for APIError {
@@ -57,6 +71,9 @@ impl fmt::Debug for APIError {
 			APIError::RouteError {ref err} => f.write_str(err),
 			APIError::ChannelUnavailable {ref err} => f.write_str(err),
 			APIError::MonitorUpdateFailed => f.write_str("Client indicated a channel monitor update failed"),
+			APIError::IncompatibleShutdownScript { ref script } => {
+				write!(f, "Provided a scriptpubkey format not accepted by peer: {}", script)
+			},
 		}
 	}
 }

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -453,6 +453,7 @@ pub struct TestKeysInterface {
 	pub override_channel_id_priv: Mutex<Option<[u8; 32]>>,
 	pub disable_revocation_policy_check: bool,
 	revoked_commitments: Mutex<HashMap<[u8;32], Arc<Mutex<u64>>>>,
+	expectations: Mutex<Option<VecDeque<OnGetShutdownScriptpubkey>>>,
 }
 
 impl keysinterface::KeysInterface for TestKeysInterface {
@@ -460,7 +461,17 @@ impl keysinterface::KeysInterface for TestKeysInterface {
 
 	fn get_node_secret(&self) -> SecretKey { self.backing.get_node_secret() }
 	fn get_destination_script(&self) -> Script { self.backing.get_destination_script() }
-	fn get_shutdown_scriptpubkey(&self) -> ShutdownScript { self.backing.get_shutdown_scriptpubkey() }
+
+	fn get_shutdown_scriptpubkey(&self) -> ShutdownScript {
+		match &mut *self.expectations.lock().unwrap() {
+			None => self.backing.get_shutdown_scriptpubkey(),
+			Some(expectations) => match expectations.pop_front() {
+				None => panic!("Unexpected get_shutdown_scriptpubkey"),
+				Some(expectation) => expectation.returns,
+			},
+		}
+	}
+
 	fn get_channel_signer(&self, inbound: bool, channel_value_satoshis: u64) -> EnforcingSigner {
 		let keys = self.backing.get_channel_signer(inbound, channel_value_satoshis);
 		let revoked_commitment = self.make_revoked_commitment_cell(keys.commitment_seed);
@@ -503,7 +514,6 @@ impl keysinterface::KeysInterface for TestKeysInterface {
 	}
 }
 
-
 impl TestKeysInterface {
 	pub fn new(seed: &[u8; 32], network: Network) -> Self {
 		let now = Duration::from_secs(genesis_block(network).header.time as u64);
@@ -513,8 +523,19 @@ impl TestKeysInterface {
 			override_channel_id_priv: Mutex::new(None),
 			disable_revocation_policy_check: false,
 			revoked_commitments: Mutex::new(HashMap::new()),
+			expectations: Mutex::new(None),
 		}
 	}
+
+	/// Sets an expectation that [`keysinterface::KeysInterface::get_shutdown_scriptpubkey`] is
+	/// called.
+	pub fn expect(&self, expectation: OnGetShutdownScriptpubkey) -> &Self {
+		self.expectations.lock().unwrap()
+			.get_or_insert_with(|| VecDeque::new())
+			.push_back(expectation);
+		self
+	}
+
 	pub fn derive_channel_keys(&self, channel_value_satoshis: u64, id: &[u8; 32]) -> EnforcingSigner {
 		let keys = self.backing.derive_channel_keys(channel_value_satoshis, id);
 		let revoked_commitment = self.make_revoked_commitment_cell(keys.commitment_seed);
@@ -528,6 +549,33 @@ impl TestKeysInterface {
 		}
 		let cell = revoked_commitments.get(&commitment_seed).unwrap();
 		Arc::clone(cell)
+	}
+}
+
+impl Drop for TestKeysInterface {
+	fn drop(&mut self) {
+		if std::thread::panicking() {
+			return;
+		}
+
+		if let Some(expectations) = &*self.expectations.lock().unwrap() {
+			if !expectations.is_empty() {
+				panic!("Unsatisfied expectations: {:?}", expectations);
+			}
+		}
+	}
+}
+
+/// An expectation that [`keysinterface::KeysInterface::get_shutdown_scriptpubkey`] was called and
+/// returns a [`ShutdownScript`].
+pub struct OnGetShutdownScriptpubkey {
+	/// A shutdown script used to close a channel.
+	pub returns: ShutdownScript,
+}
+
+impl core::fmt::Debug for OnGetShutdownScriptpubkey {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.debug_struct("OnGetShutdownScriptpubkey").finish()
 	}
 }
 

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -19,6 +19,7 @@ use chain::keysinterface;
 use ln::features::{ChannelFeatures, InitFeatures};
 use ln::msgs;
 use ln::msgs::OptionalField;
+use ln::script::ShutdownScript;
 use util::enforcing_trait_impls::{EnforcingSigner, INITIAL_REVOKED_COMMITMENT_NUMBER};
 use util::events;
 use util::logger::{Logger, Level, Record};
@@ -71,7 +72,7 @@ impl keysinterface::KeysInterface for OnlyReadsKeysInterface {
 
 	fn get_node_secret(&self) -> SecretKey { unreachable!(); }
 	fn get_destination_script(&self) -> Script { unreachable!(); }
-	fn get_shutdown_pubkey(&self) -> PublicKey { unreachable!(); }
+	fn get_shutdown_scriptpubkey(&self) -> ShutdownScript { unreachable!(); }
 	fn get_channel_signer(&self, _inbound: bool, _channel_value_satoshis: u64) -> EnforcingSigner { unreachable!(); }
 	fn get_secure_random_bytes(&self) -> [u8; 32] { [0; 32] }
 
@@ -459,7 +460,7 @@ impl keysinterface::KeysInterface for TestKeysInterface {
 
 	fn get_node_secret(&self) -> SecretKey { self.backing.get_node_secret() }
 	fn get_destination_script(&self) -> Script { self.backing.get_destination_script() }
-	fn get_shutdown_pubkey(&self) -> PublicKey { self.backing.get_shutdown_pubkey() }
+	fn get_shutdown_scriptpubkey(&self) -> ShutdownScript { self.backing.get_shutdown_scriptpubkey() }
 	fn get_channel_signer(&self, inbound: bool, channel_value_satoshis: u64) -> EnforcingSigner {
 		let keys = self.backing.get_channel_signer(inbound, channel_value_satoshis);
 		let revoked_commitment = self.make_revoked_commitment_cell(keys.commitment_seed);


### PR DESCRIPTION
Rather than fetching a channel's shutdown script from `KeysInterface` at creation time, do so based on `ChannelConfig::commit_upfront_shutdown_pubkey` (i.e., either creation or shutdown time).

Additionally, support any acceptable shutdown script pubkey as defined by BOLT 2 while maintaining backwards compatibility with the legacy `KeysInterface::get_shutdown_pubkey`, which is replaced by `KeysInterface::get_shutdown_scriptpubkey`.

This change requires storing an optional script as a TLV field for both `Channel` and `ChannelMonitor`. Additionally, since the field is now optional, a new `ChannelMonitorUpdateStep` is needed for when the script is generated at shutdown time.

Fixes #994.