### PR TITLE
Disable fast-fail to let CI actually run even though beta is broken

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ ubuntu-latest ]
         toolchain: [ stable,


### PR DESCRIPTION
CI is currently failing on rustc beta due to https://github.com/rust-lang/rust/issues/86442#issuecomment-889332775