### PR TITLE
Connect peers on startup in tests

### DIFF
--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -5180,6 +5180,12 @@ mod tests {
 		let node_chanmgrs = create_node_chanmgrs(3, &node_cfgs, &[None, None, None]);
 		let nodes = create_network(3, &node_cfgs, &node_chanmgrs);
 
+		// All nodes start with a persistable update pending as `create_network` connects each node
+		// with all other nodes to make most tests simpler.
+		assert!(nodes[0].node.await_persistable_update_timeout(Duration::from_millis(1)));
+		assert!(nodes[1].node.await_persistable_update_timeout(Duration::from_millis(1)));
+		assert!(nodes[2].node.await_persistable_update_timeout(Duration::from_millis(1)));
+
 		let mut chan = create_announced_chan_between_nodes(&nodes, 0, 1, InitFeatures::known(), InitFeatures::known());
 
 		// We check that the channel info nodes have doesn't change too early, even though we try

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -1404,6 +1404,13 @@ pub fn create_network<'a, 'b: 'a, 'c: 'b>(node_count: usize, cfgs: &'b Vec<NodeC
 		})
 	}
 
+	for i in 0..node_count {
+		for j in (i+1)..node_count {
+			nodes[i].node.peer_connected(&nodes[j].node.get_our_node_id(), &msgs::Init { features: InitFeatures::known() });
+			nodes[j].node.peer_connected(&nodes[i].node.get_our_node_id(), &msgs::Init { features: InitFeatures::known() });
+		}
+	}
+
 	nodes
 }
 


### PR DESCRIPTION
This avoids `ChannelManager` ever being confused by the fact that
it received a message from a peer which it didn't think it was
connected to.

This supersedes #971 cc @jkczyz 