### PR TITLE
Check all outputs meet the dust threshold in `check_spends!()`

### DIFF
--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -380,7 +380,8 @@ impl<ChannelSigner: Sign> OnchainTxHandler<ChannelSigner> {
 		let new_timer = Some(cached_request.get_height_timer(cur_height));
 		if cached_request.is_malleable() {
 			let predicted_weight = cached_request.package_weight(&self.destination_script);
-			if let Some((output_value, new_feerate)) = cached_request.compute_package_output(predicted_weight, fee_estimator, logger) {
+			if let Some((output_value, new_feerate)) =
+					cached_request.compute_package_output(predicted_weight, self.destination_script.dust_value().as_sat(), fee_estimator, logger) {
 				assert!(new_feerate != 0);
 
 				let transaction = cached_request.finalize_package(self, output_value, self.destination_script.clone(), logger).unwrap();

--- a/lightning/src/ln/functional_test_utils.rs
+++ b/lightning/src/ln/functional_test_utils.rs
@@ -690,6 +690,14 @@ pub fn update_nodes_with_chan_announce<'a, 'b, 'c, 'd>(nodes: &'a Vec<Node<'b, '
 macro_rules! check_spends {
 	($tx: expr, $($spends_txn: expr),*) => {
 		{
+			$(
+			for outp in $spends_txn.output.iter() {
+				assert!(outp.value >= outp.script_pubkey.dust_value().as_sat(), "Input tx output didn't meet dust limit");
+			}
+			)*
+			for outp in $tx.output.iter() {
+				assert!(outp.value >= outp.script_pubkey.dust_value().as_sat(), "Spending tx output didn't meet dust limit");
+			}
 			let get_output = |out_point: &bitcoin::blockdata::transaction::OutPoint| {
 				$(
 					if out_point.txid == $spends_txn.txid() {


### PR DESCRIPTION
This is basically a no-op functionality-wise, but I figured it was a useful test to have for the future.

cc #630.