### PR TITLE
Multi-hop route hints are now considered. Issue #945

### DIFF
--- a/lightning/src/routing/router.rs
+++ b/lightning/src/routing/router.rs
@@ -374,7 +374,7 @@ pub fn get_route<L: Deref>(our_node_id: &PublicKey, network: &NetworkGraph, paye
 		return Err(LightningError{err: "Cannot send a payment of 0 msat".to_owned(), action: ErrorAction::IgnoreError});
 	}
 	
-	let last_hops = last_hops.clone().iter().map(|hops| hops.0.clone()).collect::<Vec<_>>();
+	let last_hops = &(*last_hops).clone().iter().map(|hops| hops.0.clone()).collect::<Vec<_>>();
 
 	for routes in last_hops.iter() {
 		for last_hop in routes.iter() {


### PR DESCRIPTION
Probable Solution to Issue #945 .

Edited the last_hops to now consider all the RouteHintHop(s) in the RouteHint instead of only the last RouteHintHop. The tests modified are:-

1. last_hops_test_1() - This now tests the last RouteHintHop per RouteHint. In case all the RouteHint(s) only contain one RouteHintHop.
2. last_hops_test_2() - This creates a RouteHint vec from the multiple_last_hops() and tests if multi-hop route hint in at least one of the routes is considered.