### PR TITLE
Fix #[warn(clippy::try_err)] in ser_macros.rs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,4 +262,4 @@ jobs:
           rustup component add clippy
       - name: Run default clippy linting
         run: |
-          cargo clippy -- -Aclippy::erasing_op -Aclippy::never_loop -Aclippy::if_same_then_else
+          cargo clippy -- -Aclippy::erasing_op -Aclippy::never_loop -Aclippy::if_same_then_else -Dclippy::try_err


### PR DESCRIPTION
Some heavily used macros are using `?` directly on an `Err`. Using a `return` is easier to read and removes hundreds of linter warnings.

https://rust-lang.github.io/rust-clippy/master/index.html#try_err