### PR TITLE
Fix lightning-persister tests for upcoming rustc changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,15 @@ jobs:
             platform: macos-latest
             build-net-tokio: true
             build-no-std: true
+          - toolchain: beta
+            platform: macos-latest
+            build-net-tokio: true
+            build-no-std: true
           - toolchain: stable
+            platform: windows-latest
+            build-net-tokio: true
+            build-no-std: true
+          - toolchain: beta
             platform: windows-latest
             build-net-tokio: true
             build-no-std: true

--- a/lightning-block-sync/src/http.rs
+++ b/lightning-block-sync/src/http.rs
@@ -636,7 +636,10 @@ pub(crate) mod client_tests {
 	#[test]
 	fn connect_to_unresolvable_host() {
 		match HttpClient::connect(("example.invalid", 80)) {
-			Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::Other),
+			Err(e) => {
+				assert!(e.to_string().contains("failed to lookup address information") ||
+					e.to_string().contains("No such host"), "{:?}", e);
+			},
 			Ok(_) => panic!("Expected error"),
 		}
 	}

--- a/lightning-persister/src/util.rs
+++ b/lightning-persister/src/util.rs
@@ -135,7 +135,7 @@ mod tests {
 		// Create the channel data file and make it a directory.
 		fs::create_dir_all(get_full_filepath(path.clone(), filename.to_string())).unwrap();
 		match write_to_file(path.clone(), filename.to_string(), &test_writeable) {
-			Err(e) => assert_eq!(e.kind(), io::ErrorKind::Other),
+			Err(e) => assert_eq!(e.raw_os_error(), Some(libc::EISDIR)),
 			_ => panic!("Unexpected Ok(())")
 		}
 		fs::remove_dir_all(path).unwrap();
@@ -178,7 +178,7 @@ mod tests {
 		match write_to_file(path, filename, &test_writeable) {
 			Err(e) => {
 				#[cfg(not(target_os = "windows"))]
-				assert_eq!(e.kind(), io::ErrorKind::Other);
+				assert_eq!(e.raw_os_error(), Some(libc::EISDIR));
 				#[cfg(target_os = "windows")]
 				assert_eq!(e.kind(), io::ErrorKind::PermissionDenied);
 			}


### PR DESCRIPTION
Upcoming versions of rustc will break existing code (:scream:), so we need to tweak two tests in `lightning-persister` to work around this. This should fix tests on rustc-beta.