### PR TITLE
Suggest faster ping in `PeerManager::timer_tick_occurred` docs

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -1372,9 +1372,12 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref> PeerManager<D
 		}
 	}
 
-	/// This function should be called roughly once every 30 seconds.
-	/// It will send pings to each peer and disconnect those which did not respond to the last
-	/// round of pings.
+	/// Send pings to each peer and disconnect those which did not respond to the last round of
+	/// pings.
+	///
+	/// This may be called on any timescale you want, however, roughly once every five to ten
+	/// seconds is preferred. The call rate determines both how often we send a ping to our peers
+	/// and how much time they have to respond before we disconnect them.
 	///
 	/// May call [`send_data`] on all [`SocketDescriptor`]s. Thus, be very careful with reentrancy
 	/// issues!


### PR DESCRIPTION
This clarifies the docs for `PeerManager::timer_tick_occurred` to
note that the call rate is entirely up to the user, and also
suggests a faster ping rate of "once every five to ten seconds"
instead of "every 30 seconds". There isn't a lot of reason to want
to ping less often, and faster ping means we detect disconnects
sooner, which is important.