### PR TITLE
Introduce EnforcementState, validate release of revocation secret

### DIFF
--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -216,6 +216,8 @@ pub trait BaseSign {
 	///
 	/// This is required in order for the signer to make sure that releasing a commitment
 	/// secret won't leave us without a broadcastable holder transaction.
+	/// Policy checks should be implemented in this function, including checking the amount
+	/// sent to us and checking the HTLCs.
 	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction);
 	/// Gets the holder's channel public keys and basepoints
 	fn pubkeys(&self) -> &ChannelPublicKeys;
@@ -227,6 +229,9 @@ pub trait BaseSign {
 	/// Create a signature for a counterparty's commitment transaction and associated HTLC transactions.
 	///
 	/// Note that if signing fails or is rejected, the channel will be force-closed.
+	///
+	/// Policy checks should be implemented in this function, including checking the amount
+	/// sent to us and checking the HTLCs.
 	//
 	// TODO: Document the things someone using this interface should enforce before signing.
 	fn sign_counterparty_commitment(&self, commitment_tx: &CommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()>;

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -212,6 +212,11 @@ pub trait BaseSign {
 	/// Note that the commitment number starts at (1 << 48) - 1 and counts backwards.
 	// TODO: return a Result so we can signal a validation error
 	fn release_commitment_secret(&self, idx: u64) -> [u8; 32];
+	/// Validate the counterparty's signatures on the holder commitment transaction and HTLCs.
+	///
+	/// This is required in order for the signer to make sure that releasing a commitment
+	/// secret won't leave us without a broadcastable holder transaction.
+	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction);
 	/// Gets the holder's channel public keys and basepoints
 	fn pubkeys(&self) -> &ChannelPublicKeys;
 	/// Gets an arbitrary identifier describing the set of keys which are provided back to you in
@@ -556,6 +561,9 @@ impl BaseSign for InMemorySigner {
 
 	fn release_commitment_secret(&self, idx: u64) -> [u8; 32] {
 		chan_utils::build_commitment_secret(&self.commitment_seed, idx)
+	}
+
+	fn validate_holder_commitment(&self, _holder_tx: &HolderCommitmentTransaction) {
 	}
 
 	fn pubkeys(&self) -> &ChannelPublicKeys { &self.holder_channel_pubkeys }

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -230,6 +230,11 @@ pub trait BaseSign {
 	//
 	// TODO: Document the things someone using this interface should enforce before signing.
 	fn sign_counterparty_commitment(&self, commitment_tx: &CommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()>;
+	/// Validate the counterparty's revocation.
+	///
+	/// This is required in order for the signer to make sure that the state has moved
+	/// forward and it is safe to sign the next counterparty commitment.
+	fn validate_counterparty_revocation(&self, idx: u64, secret: &SecretKey);
 
 	/// Create a signatures for a holder's commitment transaction and its claiming HTLC transactions.
 	/// This will only ever be called with a non-revoked commitment_tx.  This will be called with the
@@ -590,6 +595,9 @@ impl BaseSign for InMemorySigner {
 		}
 
 		Ok((commitment_sig, htlc_sigs))
+	}
+
+	fn validate_counterparty_revocation(&self, _idx: u64, _secret: &SecretKey) {
 	}
 
 	fn sign_holder_commitment_and_htlcs(&self, commitment_tx: &HolderCommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()> {

--- a/lightning/src/chain/keysinterface.rs
+++ b/lightning/src/chain/keysinterface.rs
@@ -218,7 +218,7 @@ pub trait BaseSign {
 	/// secret won't leave us without a broadcastable holder transaction.
 	/// Policy checks should be implemented in this function, including checking the amount
 	/// sent to us and checking the HTLCs.
-	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction);
+	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction) -> Result<(), ()>;
 	/// Gets the holder's channel public keys and basepoints
 	fn pubkeys(&self) -> &ChannelPublicKeys;
 	/// Gets an arbitrary identifier describing the set of keys which are provided back to you in
@@ -239,7 +239,7 @@ pub trait BaseSign {
 	///
 	/// This is required in order for the signer to make sure that the state has moved
 	/// forward and it is safe to sign the next counterparty commitment.
-	fn validate_counterparty_revocation(&self, idx: u64, secret: &SecretKey);
+	fn validate_counterparty_revocation(&self, idx: u64, secret: &SecretKey) -> Result<(), ()>;
 
 	/// Create a signatures for a holder's commitment transaction and its claiming HTLC transactions.
 	/// This will only ever be called with a non-revoked commitment_tx.  This will be called with the
@@ -573,7 +573,8 @@ impl BaseSign for InMemorySigner {
 		chan_utils::build_commitment_secret(&self.commitment_seed, idx)
 	}
 
-	fn validate_holder_commitment(&self, _holder_tx: &HolderCommitmentTransaction) {
+	fn validate_holder_commitment(&self, _holder_tx: &HolderCommitmentTransaction) -> Result<(), ()> {
+		Ok(())
 	}
 
 	fn pubkeys(&self) -> &ChannelPublicKeys { &self.holder_channel_pubkeys }
@@ -602,7 +603,8 @@ impl BaseSign for InMemorySigner {
 		Ok((commitment_sig, htlc_sigs))
 	}
 
-	fn validate_counterparty_revocation(&self, _idx: u64, _secret: &SecretKey) {
+	fn validate_counterparty_revocation(&self, _idx: u64, _secret: &SecretKey) -> Result<(), ()> {
+		Ok(())
 	}
 
 	fn sign_holder_commitment_and_htlcs(&self, commitment_tx: &HolderCommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()> {

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1791,6 +1791,8 @@ impl<Signer: Sign> Channel<Signer> {
 			self.counterparty_funding_pubkey()
 		);
 
+		self.holder_signer.validate_holder_commitment(&holder_commitment_tx);
+
 		// Now that we're past error-generating stuff, update our local state:
 
 		let funding_redeemscript = self.get_funding_redeemscript();
@@ -1865,6 +1867,7 @@ impl<Signer: Sign> Channel<Signer> {
 			self.counterparty_funding_pubkey()
 		);
 
+		self.holder_signer.validate_holder_commitment(&holder_commitment_tx);
 
 		let funding_redeemscript = self.get_funding_redeemscript();
 		let funding_txo = self.get_funding_txo().unwrap();
@@ -2502,6 +2505,7 @@ impl<Signer: Sign> Channel<Signer> {
 		);
 
 		let next_per_commitment_point = self.holder_signer.get_per_commitment_point(self.cur_holder_commitment_transaction_number - 1, &self.secp_ctx);
+		self.holder_signer.validate_holder_commitment(&holder_commitment_tx);
 		let per_commitment_secret = self.holder_signer.release_commitment_secret(self.cur_holder_commitment_transaction_number + 1);
 
 		// Update state now that we've passed all the can-fail calls...

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -1791,7 +1791,8 @@ impl<Signer: Sign> Channel<Signer> {
 			self.counterparty_funding_pubkey()
 		);
 
-		self.holder_signer.validate_holder_commitment(&holder_commitment_tx);
+		self.holder_signer.validate_holder_commitment(&holder_commitment_tx)
+			.map_err(|_| ChannelError::Close("Failed to validate our commitment".to_owned()))?;
 
 		// Now that we're past error-generating stuff, update our local state:
 
@@ -1867,7 +1868,9 @@ impl<Signer: Sign> Channel<Signer> {
 			self.counterparty_funding_pubkey()
 		);
 
-		self.holder_signer.validate_holder_commitment(&holder_commitment_tx);
+		self.holder_signer.validate_holder_commitment(&holder_commitment_tx)
+			.map_err(|_| ChannelError::Close("Failed to validate our commitment".to_owned()))?;
+
 
 		let funding_redeemscript = self.get_funding_redeemscript();
 		let funding_txo = self.get_funding_txo().unwrap();
@@ -2505,7 +2508,8 @@ impl<Signer: Sign> Channel<Signer> {
 		);
 
 		let next_per_commitment_point = self.holder_signer.get_per_commitment_point(self.cur_holder_commitment_transaction_number - 1, &self.secp_ctx);
-		self.holder_signer.validate_holder_commitment(&holder_commitment_tx);
+		self.holder_signer.validate_holder_commitment(&holder_commitment_tx)
+			.map_err(|_| (None, ChannelError::Close("Failed to validate our commitment".to_owned())))?;
 		let per_commitment_secret = self.holder_signer.release_commitment_secret(self.cur_holder_commitment_transaction_number + 1);
 
 		// Update state now that we've passed all the can-fail calls...
@@ -2770,7 +2774,8 @@ impl<Signer: Sign> Channel<Signer> {
 		self.holder_signer.validate_counterparty_revocation(
 			self.cur_counterparty_commitment_transaction_number + 1,
 			&secret
-		);
+		).map_err(|_| ChannelError::Close("Failed to validate revocation from peer".to_owned()))?;
+
 		self.commitment_secrets.provide_secret(self.cur_counterparty_commitment_transaction_number + 1, msg.per_commitment_secret)
 			.map_err(|_| ChannelError::Close("Previous secrets did not match new one".to_owned()))?;
 		self.latest_monitor_update_id += 1;

--- a/lightning/src/ln/msgs.rs
+++ b/lightning/src/ln/msgs.rs
@@ -194,7 +194,7 @@ pub struct FundingCreated {
 	pub funding_txid: Txid,
 	/// The specific output index funding this channel
 	pub funding_output_index: u16,
-	/// The signature of the channel initiator (funder) on the funding transaction
+	/// The signature of the channel initiator (funder) on the initial commitment transaction
 	pub signature: Signature,
 }
 
@@ -203,7 +203,7 @@ pub struct FundingCreated {
 pub struct FundingSigned {
 	/// The channel ID
 	pub channel_id: [u8; 32],
-	/// The signature of the channel acceptor (fundee) on the funding transaction
+	/// The signature of the channel acceptor (fundee) on the initial commitment transaction
 	pub signature: Signature,
 }
 

--- a/lightning/src/util/enforcing_trait_impls.rs
+++ b/lightning/src/util/enforcing_trait_impls.rs
@@ -100,11 +100,12 @@ impl BaseSign for EnforcingSigner {
 		self.inner.release_commitment_secret(idx)
 	}
 
-	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction) {
+	fn validate_holder_commitment(&self, holder_tx: &HolderCommitmentTransaction) -> Result<(), ()> {
 		let mut state = self.state.lock().unwrap();
 		let idx = holder_tx.commitment_number();
 		assert!(idx == state.last_holder_commitment || idx == state.last_holder_commitment - 1, "expecting to validate the current or next holder commitment - trying {}, current {}", idx, state.last_holder_commitment);
 		state.last_holder_commitment = idx;
+		Ok(())
 	}
 
 	fn pubkeys(&self) -> &ChannelPublicKeys { self.inner.pubkeys() }
@@ -129,10 +130,11 @@ impl BaseSign for EnforcingSigner {
 		Ok(self.inner.sign_counterparty_commitment(commitment_tx, secp_ctx).unwrap())
 	}
 
-	fn validate_counterparty_revocation(&self, idx: u64, _secret: &SecretKey) {
+	fn validate_counterparty_revocation(&self, idx: u64, _secret: &SecretKey) -> Result<(), ()> {
 		let mut state = self.state.lock().unwrap();
 		assert!(idx == state.last_counterparty_revoked_commitment || idx == state.last_counterparty_revoked_commitment - 1, "expecting to validate the current or next counterparty revocation - trying {}, current {}", idx, state.last_counterparty_revoked_commitment);
 		state.last_counterparty_revoked_commitment = idx;
+		Ok(())
 	}
 
 	fn sign_holder_commitment_and_htlcs(&self, commitment_tx: &HolderCommitmentTransaction, secp_ctx: &Secp256k1<secp256k1::All>) -> Result<(Signature, Vec<Signature>), ()> {

--- a/lightning/src/util/test_utils.rs
+++ b/lightning/src/util/test_utils.rs
@@ -20,7 +20,7 @@ use ln::features::{ChannelFeatures, InitFeatures};
 use ln::msgs;
 use ln::msgs::OptionalField;
 use ln::script::ShutdownScript;
-use util::enforcing_trait_impls::{EnforcingSigner, INITIAL_REVOKED_COMMITMENT_NUMBER};
+use util::enforcing_trait_impls::{EnforcingSigner, EnforcementState};
 use util::events;
 use util::logger::{Logger, Level, Record};
 use util::ser::{Readable, ReadableArgs, Writer, Writeable};
@@ -452,7 +452,7 @@ pub struct TestKeysInterface {
 	pub override_session_priv: Mutex<Option<[u8; 32]>>,
 	pub override_channel_id_priv: Mutex<Option<[u8; 32]>>,
 	pub disable_revocation_policy_check: bool,
-	revoked_commitments: Mutex<HashMap<[u8;32], Arc<Mutex<u64>>>>,
+	enforcement_states: Mutex<HashMap<[u8;32], Arc<Mutex<EnforcementState>>>>,
 	expectations: Mutex<Option<VecDeque<OnGetShutdownScriptpubkey>>>,
 }
 
@@ -474,8 +474,8 @@ impl keysinterface::KeysInterface for TestKeysInterface {
 
 	fn get_channel_signer(&self, inbound: bool, channel_value_satoshis: u64) -> EnforcingSigner {
 		let keys = self.backing.get_channel_signer(inbound, channel_value_satoshis);
-		let revoked_commitment = self.make_revoked_commitment_cell(keys.commitment_seed);
-		EnforcingSigner::new_with_revoked(keys, revoked_commitment, self.disable_revocation_policy_check)
+		let state = self.make_enforcement_state_cell(keys.commitment_seed);
+		EnforcingSigner::new_with_revoked(keys, state, self.disable_revocation_policy_check)
 	}
 
 	fn get_secure_random_bytes(&self) -> [u8; 32] {
@@ -497,14 +497,11 @@ impl keysinterface::KeysInterface for TestKeysInterface {
 		let mut reader = io::Cursor::new(buffer);
 
 		let inner: InMemorySigner = Readable::read(&mut reader)?;
-		let revoked_commitment = self.make_revoked_commitment_cell(inner.commitment_seed);
-
-		let last_commitment_number = Readable::read(&mut reader)?;
+		let state = self.make_enforcement_state_cell(inner.commitment_seed);
 
 		Ok(EnforcingSigner {
 			inner,
-			last_commitment_number: Arc::new(Mutex::new(last_commitment_number)),
-			revoked_commitment,
+			state,
 			disable_revocation_policy_check: self.disable_revocation_policy_check,
 		})
 	}
@@ -522,7 +519,7 @@ impl TestKeysInterface {
 			override_session_priv: Mutex::new(None),
 			override_channel_id_priv: Mutex::new(None),
 			disable_revocation_policy_check: false,
-			revoked_commitments: Mutex::new(HashMap::new()),
+			enforcement_states: Mutex::new(HashMap::new()),
 			expectations: Mutex::new(None),
 		}
 	}
@@ -538,16 +535,17 @@ impl TestKeysInterface {
 
 	pub fn derive_channel_keys(&self, channel_value_satoshis: u64, id: &[u8; 32]) -> EnforcingSigner {
 		let keys = self.backing.derive_channel_keys(channel_value_satoshis, id);
-		let revoked_commitment = self.make_revoked_commitment_cell(keys.commitment_seed);
-		EnforcingSigner::new_with_revoked(keys, revoked_commitment, self.disable_revocation_policy_check)
+		let state = self.make_enforcement_state_cell(keys.commitment_seed);
+		EnforcingSigner::new_with_revoked(keys, state, self.disable_revocation_policy_check)
 	}
 
-	fn make_revoked_commitment_cell(&self, commitment_seed: [u8; 32]) -> Arc<Mutex<u64>> {
-		let mut revoked_commitments = self.revoked_commitments.lock().unwrap();
-		if !revoked_commitments.contains_key(&commitment_seed) {
-			revoked_commitments.insert(commitment_seed, Arc::new(Mutex::new(INITIAL_REVOKED_COMMITMENT_NUMBER)));
+	fn make_enforcement_state_cell(&self, commitment_seed: [u8; 32]) -> Arc<Mutex<EnforcementState>> {
+		let mut states = self.enforcement_states.lock().unwrap();
+		if !states.contains_key(&commitment_seed) {
+			let state = EnforcementState::new();
+			states.insert(commitment_seed, Arc::new(Mutex::new(state)));
 		}
-		let cell = revoked_commitments.get(&commitment_seed).unwrap();
+		let cell = states.get(&commitment_seed).unwrap();
 		Arc::clone(cell)
 	}
 }


### PR DESCRIPTION
This helps the signer implement the following policies (from https://gitlab.com/lightning-signer/docs/-/blob/master/policy-controls.md)

- Ensure that we have a validated counterparty-signed holder commitment we can broadcast before revoking a commitment. (policies `policy-v2-revoke-new-commitment-signed` and `policy-v2-revoke-new-commitment-valid`)
- Ensure we sign a counterparty commitment only after a revocation - there can be a maximum of two counterparty broadcastable commitments at a time (`policy-v2-commitment-previous-revoked`)
