### PR TITLE
Multi-Hop Route Hint now considered. Added in unit tests for same.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ lightning-c-bindings/a.out
 **/*.rs.bk
 Cargo.lock
 .idea
-
+lightning/target


### PR DESCRIPTION
This PR solves Issue #945 which deals with using multi-hop route hints from the invoice from payee. Previous behaviour was to only consider the last route hop hint per route. This PR solves the problems with PR #1030 and also includes the unit tests for testing out the Route Hint in a multi-hop setup.

Edit: Commit [914c159](https://github.com/rust-bitcoin/rust-lightning/pull/1040/commits/914c159b3f4e69259157f3e1334c7823bb551712) solves a previously failing test where the channel capacity was calculated to be 0 which skipped certain hints.

Edit: The above has been squashed into fd4d3f