### PR TITLE
Make `ChannelMonitor` serialization slightly more upgradable

### DIFF
--- a/lightning/src/chain/onchaintx.rs
+++ b/lightning/src/chain/onchaintx.rs
@@ -29,7 +29,7 @@ use chain::channelmonitor::{ANTI_REORG_DELAY, CLTV_SHARED_CLAIM_BUFFER};
 use chain::keysinterface::{Sign, KeysInterface};
 use chain::package::PackageTemplate;
 use util::logger::Logger;
-use util::ser::{Readable, ReadableArgs, Writer, Writeable, VecWriter};
+use util::ser::{Readable, ReadableArgs, MaybeReadable, Writer, Writeable, VecWriter};
 use util::byte_utils;
 
 use io;
@@ -79,20 +79,43 @@ enum OnchainEvent {
 	}
 }
 
-impl_writeable_tlv_based!(OnchainEventEntry, {
-	(0, txid, required),
-	(2, height, required),
-	(4, event, required),
-});
+impl Writeable for OnchainEventEntry {
+	fn write<W: Writer>(&self, writer: &mut W) -> Result<(), io::Error> {
+		write_tlv_fields!(writer, {
+			(0, self.txid, required),
+			(2, self.height, required),
+			(4, self.event, required),
+		});
+		Ok(())
+	}
+}
 
-impl_writeable_tlv_based_enum!(OnchainEvent,
+impl MaybeReadable for OnchainEventEntry {
+	fn read<R: io::Read>(reader: &mut R) -> Result<Option<Self>, DecodeError> {
+		let mut txid = Default::default();
+		let mut height = 0;
+		let mut event = None;
+		read_tlv_fields!(reader, {
+			(0, txid, required),
+			(2, height, required),
+			(4, event, ignorable),
+		});
+		if let Some(ev) = event {
+			Ok(Some(Self { txid, height, event: ev }))
+		} else {
+			Ok(None)
+		}
+	}
+}
+
+impl_writeable_tlv_based_enum_upgradable!(OnchainEvent,
 	(0, Claim) => {
 		(0, claim_request, required),
 	},
 	(1, ContentiousOutpoint) => {
 		(0, package, required),
 	},
-;);
+);
 
 impl Readable for Option<Vec<Option<(usize, Signature)>>> {
 	fn read<R: io::Read>(reader: &mut R) -> Result<Self, DecodeError> {
@@ -296,7 +319,9 @@ impl<'a, K: KeysInterface> ReadableArgs<&'a K> for OnchainTxHandler<K::Signer> {
 		let waiting_threshold_conf_len: u64 = Readable::read(reader)?;
 		let mut onchain_events_awaiting_threshold_conf = Vec::with_capacity(cmp::min(waiting_threshold_conf_len as usize, MAX_ALLOC_SIZE / 128));
 		for _ in 0..waiting_threshold_conf_len {
-			onchain_events_awaiting_threshold_conf.push(Readable::read(reader)?);
+			if let Some(val) = MaybeReadable::read(reader)? {
+				onchain_events_awaiting_threshold_conf.push(val);
+			}
 		}
 
 		read_tlv_fields!(reader, {});

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -1477,8 +1477,8 @@ impl<Signer: Sign, M: Deref, T: Deref, K: Deref, F: Deref, L: Deref> ChannelMana
 
 		let mut chacha = ChaCha20::new(&rho, &[0u8; 8]);
 		let mut chacha_stream = ChaChaReader { chacha: &mut chacha, read: Cursor::new(&msg.onion_routing_packet.hop_data[..]) };
-		let (next_hop_data, next_hop_hmac) = {
-			match msgs::OnionHopData::read(&mut chacha_stream) {
+		let (next_hop_data, next_hop_hmac): (msgs::OnionHopData, _) = {
+			match <msgs::OnionHopData as Readable>::read(&mut chacha_stream) {
 				Err(err) => {
 					let error_code = match err {
 						msgs::DecodeError::UnknownVersion => 0x4000 | 1, // unknown realm byte

--- a/lightning/src/util/ser_macros.rs
+++ b/lightning/src/util/ser_macros.rs
@@ -371,7 +371,7 @@ macro_rules! read_ver_prefix {
 /// Reads a suffix added by write_tlv_fields.
 macro_rules! read_tlv_fields {
 	($stream: expr, {$(($type: expr, $field: ident, $fieldty: tt)),* $(,)*}) => { {
-		let tlv_len = ::util::ser::BigSize::read($stream)?;
+		let tlv_len: ::util::ser::BigSize = ::util::ser::Readable::read($stream)?;
 		let mut rd = ::util::ser::FixedLengthReader::new($stream, tlv_len.0);
 		decode_tlv_stream!(&mut rd, {$(($type, $field, $fieldty)),*});
 		rd.eat_remaining().map_err(|_| ::ln::msgs::DecodeError::ShortRead)?;


### PR DESCRIPTION
This is the first two commits from #1034, which make the `ChannelMonitor` serialization slightly more upgradable and include an additional macro for tlv-based enum serialization using the `MaybeReadable` trait. I'd like some feedback about maybe including this in 0.0.100 to avoid additional serialization breakages in 0.0.101.