### PR TITLE
Fix trailing semicolon warnings on latest rustc nightly

### DIFF
--- a/lightning/src/ln/functional_tests.rs
+++ b/lightning/src/ln/functional_tests.rs
@@ -4048,7 +4048,7 @@ fn test_invalid_channel_announcement() {
 				bitcoin_key_1: if were_node_one { as_bitcoin_key } else { bs_bitcoin_key },
 				bitcoin_key_2: if were_node_one { bs_bitcoin_key } else { as_bitcoin_key },
 				excess_data: Vec::new(),
-			};
+			}
 		}
 	}
 

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -739,7 +739,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref> PeerManager<D
 												},
 											}
 										}
-									};
+									}
 								}
 							}
 

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -160,7 +160,7 @@ macro_rules! log_spendable {
 #[macro_export]
 macro_rules! log_internal {
 	($logger: expr, $lvl:expr, $($arg:tt)+) => (
-		$logger.log(&$crate::util::logger::Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()));
+		$logger.log(&$crate::util::logger::Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()))
 	);
 }
 


### PR DESCRIPTION
Latest rustc nightly compiles are filled with warnings like the
following, which we fix here:

```
warning: trailing semicolon in macro used in expression position
   --> lightning/src/util/macro_logger.rs:163:114
    |
163 |         $logger.log(&$crate::util::logger::Record::new($lvl, format_args!($($arg)+), module_path!(), file!(), line!()));
    |                                                                                                                        ^
    |
   ::: lightning/src/chain/chainmonitor.rs:165:9
    |
165 |         log_debug!(self.logger, "New best block {} at height {} provided via block_connected", header.block_hash(), height);
    |         -------------------------------------------------------------------------------------------------------------------- in this macro invocation
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `log_internal` (in Nightly builds, run with -Z macro-backtrace for more info)
```