### PR TITLE
fix: peer is disconnected for not responding to ping

### DIFF
--- a/lightning-background-processor/src/lib.rs
+++ b/lightning-background-processor/src/lib.rs
@@ -50,7 +50,13 @@ const FRESHNESS_TIMER: u64 = 60;
 #[cfg(test)]
 const FRESHNESS_TIMER: u64 = 1;
 
+#[cfg(not(debug_assertions))]
 const PING_TIMER: u64 = 5;
+/// Signature operations take a lot longer without compiler optimisations.
+/// Increasing the ping timer allows for this but slower devices will be disconnected if the
+/// timeout is reached.
+#[cfg(debug_assertions)]
+const PING_TIMER: u64 = 30;
 
 /// Trait which handles persisting a [`ChannelManager`] to disk.
 ///


### PR DESCRIPTION
I'm testing syncing the mainnet graph from LND. Found that the peer_handler disconnects a peer after PING_TIMER (5 seconds) if it has not responded to a ping message. It does this even in the middle of syncing when there are many pending messages to process before getting to the pong.

I checked LND, it adds the response to its outgoing queue as soon as it receives the ping https://github.com/lightningnetwork/lnd/blob/dee9b9a9b13737309bc8c1b57e0ee6a68bfee492/peer/brontide.go#L1371

I've fixed it with an extra check to see if there are currently messages from the peer being processed. Can see that both peers are sending and receiving pings/pongs during sync now. 

Not sure if its correct to use pending_read_is_header for this though? Could maybe keep an Instant of the last message of any type received and check that is less than the PING_TIMER.