### PR TITLE
Allow multiple calls to `monitor_update_failed`

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -80,6 +80,7 @@ mkdir -p ./test_cases/$TARGET
 echo $HEX | xxd -r -p > ./test_cases/$TARGET/any_filename_works
 
 export RUST_BACKTRACE=1
+export RUSTFLAGS="--cfg=fuzzing"
 cargo test
 ```
 

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -3060,13 +3060,10 @@ impl<Signer: Sign> Channel<Signer> {
 	/// monitor update failure must *not* have been sent to the remote end, and must instead
 	/// have been dropped. They will be regenerated when monitor_updating_restored is called.
 	pub fn monitor_update_failed(&mut self, resend_raa: bool, resend_commitment: bool, mut pending_forwards: Vec<(PendingHTLCInfo, u64)>, mut pending_fails: Vec<(HTLCSource, PaymentHash, HTLCFailReason)>) {
-		assert_eq!(self.channel_state & ChannelState::MonitorUpdateFailed as u32, 0);
-		self.monitor_pending_revoke_and_ack = resend_raa;
-		self.monitor_pending_commitment_signed = resend_commitment;
-		assert!(self.monitor_pending_forwards.is_empty());
-		mem::swap(&mut pending_forwards, &mut self.monitor_pending_forwards);
-		assert!(self.monitor_pending_failures.is_empty());
-		mem::swap(&mut pending_fails, &mut self.monitor_pending_failures);
+		self.monitor_pending_revoke_and_ack |= resend_raa;
+		self.monitor_pending_commitment_signed |= resend_commitment;
+		self.monitor_pending_forwards.append(&mut pending_forwards);
+		self.monitor_pending_failures.append(&mut pending_fails);
 		self.channel_state |= ChannelState::MonitorUpdateFailed as u32;
 	}
 


### PR DESCRIPTION
There's a few open TODOs/questions.

Found by the fuzzer. Repro script:
```
export TARGET="chanmon_consistency" # adjust for your output
export HEX="04000000ffffffffffffffffffff00000006ffff6200000000000011000c 0021181800000011000c002118181c181818211720000000343201000000 00001000011b181821172000001f5a32010021172000001f5a3201000000 00000000011b6b00450000200a2000001d0000ff00002fca000000000100 0000000000200000" # adjust for your output

mkdir -p ./test_cases/$TARGET
echo $HEX | xxd -r -p > ./test_cases/$TARGET/any_filename_works

export RUST_BACKTRACE=full
export RUSTFLAGS="--cfg=fuzzing"
cargo test -- --nocapture &> output.txt
