### PR TITLE
Fix fuzzer-found panic from duplicate channel outpoint

### DIFF
--- a/lightning/src/chain/mod.rs
+++ b/lightning/src/chain/mod.rs
@@ -203,6 +203,9 @@ pub trait Watch<ChannelSigner: Sign> {
 	/// with any spends of outputs returned by [`get_outputs_to_watch`]. In practice, this means
 	/// calling [`block_connected`] and [`block_disconnected`] on the monitor.
 	///
+	/// Note: this interface MUST error with `ChannelMonitorUpdateErr::PermanentFailure` if
+	/// the given `funding_txo` has previously been registered via `watch_channel`.
+	///
 	/// [`get_outputs_to_watch`]: channelmonitor::ChannelMonitor::get_outputs_to_watch
 	/// [`block_connected`]: channelmonitor::ChannelMonitor::block_connected
 	/// [`block_disconnected`]: channelmonitor::ChannelMonitor::block_disconnected


### PR DESCRIPTION
And update `Watch` docs. See added comments for more details.

Fuzz fail repro script:
```
export TARGET="full_stack" # adjust for your output
export HEX="010100001300000000000000000000000000000000000000000000000000
000000000000010003000000000000000000000000000000000000000000
000000000000000000000203003200030000000000feffffff0000000000
000000000000000000000000000000000002030000000000000000000000
00000000030012000a0300000000000000000000000000000003001a0010
000220000002200003000000000000000000000000000000030012014103
0000000000000000000000000000000300fe002075000000000000000000
00000000000000000000000000000000000000000000ff4f00f805273c1b
203bb5ebf8436bfde57b3be8c2f5e95d9491dbb181909679000000000000
c3500000000000000000000000000000014affffffffffffffff00000000
000002220000000000000000000000fd000601e303000000000000000000
000000000000000000000000000000000000000000000103000000000000
000000000000000000000000000000000000000000000000000203000000
000000000000000000000000000000000000000000000000000000000303
2d0000000000000000000000000000000000000000000000000000000000
000403005303000000000000000000000000000000000000000000000000
00000000000000050209000000000000000000000000000000000000ffff
ffffffffffffff74000000010300000000000000000000000000000000fd
00fd00fd0300120084030000000000000000000000000000000300940022
ff4f00f805273c1b203bb5ebf8436bfde57b3be8c2f5e95d9491dbb18190
96793a000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000000000000000000000
000000000000002101000000000000000000000000000000000000000000
00000000000000000000030000000000000000000000000000000c005e02
000000010000000000000000000000000000000000000000000000000000
0000000000000000000000ffffffff0150c3000000000000220020ae0000
000000000000000000000000000000000000000000000000000000000000
0000000c00000c00000c00000c00000c00000e000c00000c00000c00000c
00000c00000c00000c000003001200430300000000000000000000000000
000003005300243d00000000000000000000000000000000000000000000
000000000000000000020800000000000000000000000000000000000000
000000000000000000000000030000000000000000000000000000000103
013200030000000000000000000000000000000000000000000000000000
000000000007030000000000000000000000000000000301420003020000
000000000000000000000000000000000000000000000000000000000003
000000000000000000000000000000030000000000000000000000000000
00030112000a0100000000000000000000000000000003011a0010000220
000002200001000000000000000000000000000000050103020000000000
000000000000000000000000000000000000000000000000000000c35000
03e800fd0301120110010000000000000000000000000000000301ff0021
000000000000000000000000000000000000000000000000000000000000
0e05000000000000014a00000000004c4b4000000000000003e800000000
000003e80000000203f00005030000000000000000000000000000000000
000000000000000000000000000100030000000000000000000000000000
000000000000000000000000000000000200030000000000000000000000
000000000000000000000000000000000000000300030000000000000000
000000000000000000000000000000000000000000000400030000000000
000000000000000000000000000000000000000000000000000500026600
000000000000000000000000000301210000000000000000000000000000
000000010000000000000000000000000000000a03011200620100000000
000000000000000000000003017200233a00000000000000000000000000
000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000007c00010000000000000000
000000000000000000000000000000000000000000000100000000000000
000000000000000003001201410300000000000000000000000000000003
00fe00207500000000000000000000000000000000000000000000000000
000000000000ff4f00f805273c1b203bb5ebf8436bfde57b3be8c2f5e95d
9491dbb181909679000000000000c3500000000000000000000000000000
014affffffffffffffff00000000000002220000000000000000000000fd
000601e30300000000000000000000000000000000000000000000000000
000000000000010300000000000000000000000000000000000000000000
000000000000000000020300000000000000000000000000000000000000
00000000000000000000000003032d000000000000000000000000000000
000000000000000000000000000000040300530300000000000000000000
000000000000000000000000000000000000000000050209000000000000
000000000000000000000000ffffffffffffffffff740000000103000000
00000000000000000000000000fd00fd00fd030012008403000000000000
0000000000000000000300940022ff4f00f805273c1b203bb5ebf8436bfd
e57b3be8c2f5e95d9491dbb1819096793d00000000000000000000000000
000000000000000000000000000000000000000000000000000000000000
000000000000000000000000000000000000000000210100000000000000
000000000000000000000000000000000000000000000000030000000000
000000000000000000000c005e0200000001000000000000000000000000
00000000000000000000000000000000000000000000000000ffffffff01
50c3000000000000220020ae000000000000000000000000000000000000
00000000000000000000000000000000000c00000c00000c00000c00000c
00000e000c00000c00000000000000000000000000000100000000000000
00000000000000000b0301120000000000000b0301120000000000000000
000000000000000000000300000000000000000000000000"

mkdir -p ./test_cases/$TARGET
echo $HEX | xxd -r -p > ./test_cases/$TARGET/any_filename_works

export RUSTFLAGS="--cfg=fuzzing"
export RUST_BACKTRACE=1
cargo test &> output.txt
