### PR TITLE
Move trait bounds on `wire::Type` from use to the trait itself

### DIFF
--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -20,7 +20,7 @@ use util::ser::{Readable, Writeable, Writer};
 /// decoders.
 pub trait CustomMessageReader {
 	/// The type of the message decoded by the implementation.
-	type CustomMessage: core::fmt::Debug + Type + Writeable;
+	type CustomMessage: Type;
 	/// Decodes a custom message to `CustomMessageType`. If the given message type is known to the
 	/// implementation and the message could be decoded, must return `Ok(Some(message))`. If the
 	/// message type is unknown to the implementation, must return `Ok(None)`. If a decoding error
@@ -245,12 +245,12 @@ pub(crate) use self::encode::Encode;
 /// Defines a type identifier for sending messages over the wire.
 ///
 /// Messages implementing this trait specify a type and must be [`Writeable`].
-pub trait Type {
+pub trait Type: core::fmt::Debug + Writeable {
 	/// Returns the type identifying the message payload.
 	fn type_id(&self) -> u16;
 }
 
-impl<T> Type for T where T: Encode {
+impl<T: core::fmt::Debug + Writeable> Type for T where T: Encode {
 	fn type_id(&self) -> u16 {
 		T::TYPE
 	}


### PR DESCRIPTION
`wire::Type` is only (publicly) used as the `CustomMessage`
associated type in `CustomMessageReader`, where it has additional
trait bounds on `Debug` and `Writeable`. The documentation for
`Type` even mentions that you need to implement `Writeable` because
this is the one place it is used.

To make this more clear, we move the type bounds onto the trait
itself and not on the associated type.

This is also the only practical way to build C bindings for `Type`
as we cannot have a concrete, single, `Type` struct in C which only
optionally implements various subtraits, at least not without
runtime checking of the type bounds.

Gonna need this for 0.0.101 bindings due to the above.