### PR TITLE
Use Infallible for the unconstructable default custom message type

### DIFF
--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -32,7 +32,6 @@ use routing::network_graph::NetGraphMsgHandler;
 use prelude::*;
 use io;
 use alloc::collections::LinkedList;
-use alloc::fmt::Debug;
 use sync::{Arc, Mutex};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{cmp, hash, fmt, mem};
@@ -470,7 +469,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 		CM::Target: ChannelMessageHandler,
 		RM::Target: RoutingMessageHandler,
 		L::Target: Logger,
-		CMH::Target: CustomMessageHandler + wire::CustomMessageReader {
+		CMH::Target: CustomMessageHandler {
 	/// Constructs a new PeerManager with the given message handlers and node_id secret key
 	/// ephemeral_random_data is used to derive per-connection ephemeral keys and must be
 	/// cryptographically secure random bytes.
@@ -720,7 +719,7 @@ impl<Descriptor: SocketDescriptor, CM: Deref, RM: Deref, L: Deref, CMH: Deref> P
 	}
 
 	/// Append a message to a peer's pending outbound/write buffer, and update the map of peers needing sends accordingly.
-	fn enqueue_message<M: wire::Type + Writeable + Debug>(&self, peer: &mut Peer, message: &M) {
+	fn enqueue_message<M: wire::Type>(&self, peer: &mut Peer, message: &M) {
 		let mut buffer = VecWriter(Vec::with_capacity(2048));
 		wire::write(message, &mut buffer).unwrap(); // crash if the write failed
 		let encoded_message = buffer.0;

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -101,7 +101,7 @@ impl wire::CustomMessageReader for IgnoringMessageHandler {
 }
 
 impl CustomMessageHandler for IgnoringMessageHandler {
-	fn handle_custom_message(&self, _msg: Self::CustomMessage, _sender_node_id: &PublicKey) -> Result<(), LightningError> {
+	fn handle_custom_message(&self, _msg: Infallible, _sender_node_id: &PublicKey) -> Result<(), LightningError> {
 		// Since we always return `None` in the read the handle method should never be called.
 		unreachable!();
 	}

--- a/lightning/src/ln/peer_handler.rs
+++ b/lightning/src/ln/peer_handler.rs
@@ -37,6 +37,7 @@ use sync::{Arc, Mutex};
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{cmp, hash, fmt, mem};
 use core::ops::Deref;
+use core::convert::Infallible;
 #[cfg(feature = "std")] use std::error;
 
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -80,21 +81,21 @@ impl Deref for IgnoringMessageHandler {
 	fn deref(&self) -> &Self { self }
 }
 
-impl wire::Type for () {
+// Implement Type for Infallible, note that it cannot be constructed, and thus you can never call a
+// method that takes self for it.
+impl wire::Type for Infallible {
 	fn type_id(&self) -> u16 {
-		// We should never call this for `DummyCustomType`
 		unreachable!();
 	}
 }
-
-impl Writeable for () {
+impl Writeable for Infallible {
 	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
 		unreachable!();
 	}
 }
 
 impl wire::CustomMessageReader for IgnoringMessageHandler {
-	type CustomMessage = ();
+	type CustomMessage = Infallible;
 	fn read<R: io::Read>(&self, _message_type: u16, _buffer: &mut R) -> Result<Option<Self::CustomMessage>, msgs::DecodeError> {
 		Ok(None)
 	}

--- a/lightning/src/ln/wire.rs
+++ b/lightning/src/ln/wire.rs
@@ -457,6 +457,10 @@ mod tests {
 		}
 	}
 
+	impl Type for () {
+		fn type_id(&self) -> u16 { unreachable!(); }
+	}
+
 	#[test]
 	fn is_even_message_type() {
 		let message = Message::<()>::Unknown(42);

--- a/lightning/src/util/ser.rs
+++ b/lightning/src/util/ser.rs
@@ -879,6 +879,11 @@ impl<A: Writeable, B: Writeable, C: Writeable> Writeable for (A, B, C) {
 	}
 }
 
+impl Writeable for () {
+	fn write<W: Writer>(&self, _: &mut W) -> Result<(), io::Error> {
+		Ok(())
+	}
+}
 impl Readable for () {
 	fn read<R: Read>(_r: &mut R) -> Result<Self, DecodeError> {
 		Ok(())
@@ -892,7 +897,6 @@ impl Writeable for String {
 		w.write_all(self.as_bytes())
 	}
 }
-
 impl Readable for String {
 	#[inline]
 	fn read<R: Read>(r: &mut R) -> Result<Self, DecodeError> {


### PR DESCRIPTION
When we landed custom messages, we used the empty tuple for the
custom message type for `IgnoringMessageHandler`. This was fine,
except that we also implemented `Writeable` to panic when writing
a `()`. Later, we added support for anchor output construction in
CommitmentTransaction, signified by setting a field to `Some(())`,
which is serialized as-is.

This causes us to panic when writing a `CommitmentTransaction`
with `opt_anchors` set. Note that we never set it inside of LDK,
but downstream users may.

Instead, we implement `Writeable` to write nothing for `()` and use
`core::convert::Infallible` for the default custom message type as
it is, appropriately, unconstructable.

This also makes it easier to implement various things in bindings,
as we can always assume `Infallible`-conversion logic is
unreachable.