### PR TITLE
Make `NetworkGraph` Clone-able again

### DIFF
--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -58,6 +58,18 @@ pub struct NetworkGraph {
 	nodes: RwLock<BTreeMap<PublicKey, NodeInfo>>,
 }
 
+impl Clone for NetworkGraph {
+	fn clone(&self) -> Self {
+		let channels = self.channels.read().unwrap();
+		let nodes = self.nodes.read().unwrap();
+		Self {
+			genesis_hash: self.genesis_hash.clone(),
+			channels: RwLock::new(channels.clone()),
+			nodes: RwLock::new(nodes.clone()),
+		}
+	}
+}
+
 /// A read-only view of [`NetworkGraph`].
 pub struct ReadOnlyNetworkGraph<'a> {
 	channels: RwLockReadGuard<'a, BTreeMap<u64, ChannelInfo>>,


### PR DESCRIPTION
There isn't a lot of user-utility for cloning `NetworkGraph`
directly (its a rather large struct, and there probably isn't a lot
of reason to have *multiple* `NetworkGraph`s). Thus, when locks
were pushed down into it, the `Clone`-ability of it was dropped as
well.

Sadly, mapping the Java memory model onto:
 * `Read`-ing a `NetworkGraph`, creating a Java-owned
   `NetworkGraph` object that the JVM will destruct for us,
 * Passing it to a `NetGraphMsgHandler`, which now expects to own
   the `NetworkGraph`, including destructing it,
isn't really practical without adding a clone in between.

Given this, and the fact that there's nothing inherently wrong with
clone-ing a `NetworkGraph`, we simply re-add `Clone` here.