### PR TITLE
Expose ReadOnlyNetworkGraph::get_addresses to C by cloning result

### DIFF
--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -1213,12 +1213,10 @@ impl ReadOnlyNetworkGraph<'_> {
 	/// Get network addresses by node id.
 	/// Returns None if the requested node is completely unknown,
 	/// or if node announcement for the node was never received.
-	///
-	/// (C-not exported) as there is no practical way to track lifetimes of returned values.
-	pub fn get_addresses(&self, pubkey: &PublicKey) -> Option<&Vec<NetAddress>> {
+	pub fn get_addresses(&self, pubkey: &PublicKey) -> Option<Vec<NetAddress>> {
 		if let Some(node) = self.nodes.get(&NodeId::from_pubkey(&pubkey)) {
 			if let Some(node_info) = node.announcement_info.as_ref() {
-				return Some(&node_info.addresses)
+				return Some(node_info.addresses.clone())
 			}
 		}
 		None


### PR DESCRIPTION
We cannot expose ReadOnlyNetworkGraph::get_addresses as is in C as
it returns a list of references to an enum, which the bindings
dont support. Instead, we simply clone the result so that it
doesn't contain references.

There's a few options for how to deal with this, one suggested here. We could:
 * take this as-is,
 * have a cfg-flag for building bindings which switches the method's return type and adds the clone,
 * eat the cost and just always clone.

I admittedly don't actually feel super strongly for any of them, just have one here to demonstrate.