### PR TITLE
Fixed 'Advancing Bitcoin' video URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In general, Rust-Lightning does not provide (but LDK has implementations of):
   hardware wallets.
 
 LDK's customizability was presented about at Advancing Bitcoin in February 2020:
-https://vimeo.com/showcase/7131712/video/418412286
+https://vimeo.com/showcase/8372504/video/412818125
 
 Design Goal
 -----------


### PR DESCRIPTION
The old link lead to a shortened version of the talk. This should be the full recording now.