### PR TITLE
Include source and destination nodes in routing::Score

### DIFF
--- a/lightning/src/routing/mod.rs
+++ b/lightning/src/routing/mod.rs
@@ -13,10 +13,13 @@ pub mod network_graph;
 pub mod router;
 pub mod scorer;
 
+use routing::network_graph::NodeId;
+
 /// An interface used to score payment channels for path finding.
 ///
 ///	Scoring is in terms of fees willing to be paid in order to avoid routing through a channel.
 pub trait Score {
-	/// Returns the fee in msats willing to be paid to avoid routing through the given channel.
-	fn channel_penalty_msat(&self, short_channel_id: u64) -> u64;
+	/// Returns the fee in msats willing to be paid to avoid routing through the given channel
+	/// in the direction from `source` to `target`.
+	fn channel_penalty_msat(&self, short_channel_id: u64, source: &NodeId, target: &NodeId) -> u64;
 }

--- a/lightning/src/routing/scorer.rs
+++ b/lightning/src/routing/scorer.rs
@@ -44,6 +44,8 @@
 
 use routing;
 
+use routing::network_graph::NodeId;
+
 /// [`routing::Score`] implementation that provides reasonable default behavior.
 ///
 /// Used to apply a fixed penalty to each channel, thus avoiding long paths when shorter paths with
@@ -71,5 +73,9 @@ impl Default for Scorer {
 }
 
 impl routing::Score for Scorer {
-	fn channel_penalty_msat(&self, _short_channel_id: u64) -> u64 { self.base_penalty_msat }
+	fn channel_penalty_msat(
+		&self, _short_channel_id: u64, _source: &NodeId, _target: &NodeId
+	) -> u64 {
+		self.base_penalty_msat
+	}
 }


### PR DESCRIPTION
Expand `routing::Score::channel_penalty_msat` to include the source and target node ids of the channel. This allows scorers to avoid certain nodes altogether if desired.