### PR TITLE
Introduce GOSSIP log level to PeerHandler

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -21,6 +21,7 @@ max_level_error = []
 max_level_warn = []
 max_level_info = []
 max_level_debug = []
+max_level_trace = []
 # Allow signing of local transactions that may have been revoked or will be revoked, for functional testing (e.g. justice tx handling).
 # This is unsafe to use in production because it may result in the counterparty publishing taking our funds.
 unsafe_revoked_tx_signing = []

--- a/lightning/src/routing/network_graph.rs
+++ b/lightning/src/routing/network_graph.rs
@@ -299,7 +299,7 @@ where C::Target: chain::Access, L::Target: Logger
 
 	fn handle_channel_announcement(&self, msg: &msgs::ChannelAnnouncement) -> Result<bool, LightningError> {
 		self.network_graph.update_channel_from_announcement(msg, &self.chain_access, &self.secp_ctx)?;
-		log_trace!(self.logger, "Added channel_announcement for {}{}", msg.contents.short_channel_id, if !msg.contents.excess_data.is_empty() { " with excess uninterpreted data!" } else { "" });
+		log_gossip!(self.logger, "Added channel_announcement for {}{}", msg.contents.short_channel_id, if !msg.contents.excess_data.is_empty() { " with excess uninterpreted data!" } else { "" });
 		Ok(msg.contents.excess_data.len() <= MAX_EXCESS_BYTES_FOR_RELAY)
 	}
 
@@ -848,7 +848,7 @@ impl NetworkGraph {
 			Some(node) => {
 				if let Some(node_info) = node.announcement_info.as_ref() {
 					if node_info.last_update  >= msg.timestamp {
-						return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Trace)});
+						return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
 					}
 				}
 
@@ -977,7 +977,7 @@ impl NetworkGraph {
 					Self::remove_channel_in_nodes(&mut nodes, &entry.get(), msg.short_channel_id);
 					*entry.get_mut() = chan_info;
 				} else {
-					return Err(LightningError{err: "Already have knowledge of channel".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Trace)})
+					return Err(LightningError{err: "Already have knowledge of channel".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)})
 				}
 			},
 			BtreeEntry::Vacant(entry) => {
@@ -1083,7 +1083,7 @@ impl NetworkGraph {
 					( $target: expr, $src_node: expr) => {
 						if let Some(existing_chan_info) = $target.as_ref() {
 							if existing_chan_info.last_update >= msg.timestamp {
-								return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Trace)});
+								return Err(LightningError{err: "Update older than last processed update".to_owned(), action: ErrorAction::IgnoreAndLog(Level::Gossip)});
 							}
 							chan_was_enabled = existing_chan_info.enabled;
 						} else {

--- a/lightning/src/util/logger.rs
+++ b/lightning/src/util/logger.rs
@@ -17,11 +17,13 @@
 use core::cmp;
 use core::fmt;
 
-static LOG_LEVEL_NAMES: [&'static str; 5] = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"];
+static LOG_LEVEL_NAMES: [&'static str; 6] = ["GOSSIP", "TRACE", "DEBUG", "INFO", "WARN", "ERROR"];
 
 /// An enum representing the available verbosity levels of the logger.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Level {
+	/// Designates extremely verbose information, including gossip-induced messages
+	Gossip,
 	/// Designates very low priority, often extremely verbose, information
 	Trace,
 	/// Designates lower priority information
@@ -78,7 +80,7 @@ impl Level {
 	/// Returns the most verbose logging level.
 	#[inline]
 	pub fn max() -> Level {
-		Level::Trace
+		Level::Gossip
 	}
 }
 
@@ -163,13 +165,14 @@ mod tests {
 			log_info!(self.logger, "This is an info");
 			log_debug!(self.logger, "This is a debug");
 			log_trace!(self.logger, "This is a trace");
+			log_gossip!(self.logger, "This is a gossip");
 		}
 	}
 
 	#[test]
 	fn test_logging_macros() {
 		let mut logger = TestLogger::new();
-		logger.enable(Level::Trace);
+		logger.enable(Level::Gossip);
 		let logger : Arc<Logger> = Arc::new(logger);
 		let wrapper = WrapperLog::new(Arc::clone(&logger));
 		wrapper.call_macros();
@@ -189,7 +192,10 @@ mod tests {
 		assert!(Level::Debug > Level::Trace);
 		assert!(Level::Debug >= Level::Trace);
 		assert!(Level::Debug >= Level::Debug);
+		assert!(Level::Trace > Level::Gossip);
+		assert!(Level::Trace >= Level::Gossip);
 		assert!(Level::Trace >= Level::Trace);
+		assert!(Level::Gossip >= Level::Gossip);
 
 		assert!(Level::Error <= Level::Error);
 		assert!(Level::Warn < Level::Error);
@@ -204,5 +210,8 @@ mod tests {
 		assert!(Level::Trace < Level::Debug);
 		assert!(Level::Trace <= Level::Debug);
 		assert!(Level::Trace <= Level::Trace);
+		assert!(Level::Gossip < Level::Trace);
+		assert!(Level::Gossip <= Level::Trace);
+		assert!(Level::Gossip <= Level::Gossip);
 	}
 }

--- a/lightning/src/util/macro_logger.rs
+++ b/lightning/src/util/macro_logger.rs
@@ -174,6 +174,8 @@ macro_rules! log_given_level {
 			$crate::util::logger::Level::Debug => log_internal!($logger, $lvl, $($arg)*),
 			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug")))]
 			$crate::util::logger::Level::Trace => log_internal!($logger, $lvl, $($arg)*),
+			#[cfg(not(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug", feature = "max_level_trace")))]
+			$crate::util::logger::Level::Gossip => log_internal!($logger, $lvl, $($arg)*),
 
 			#[cfg(any(feature = "max_level_off", feature = "max_level_error", feature = "max_level_warn", feature = "max_level_info", feature = "max_level_debug"))]
 			_ => {
@@ -214,5 +216,12 @@ macro_rules! log_debug {
 macro_rules! log_trace {
 	($logger: expr, $($arg:tt)*) => (
 		log_given_level!($logger, $crate::util::logger::Level::Trace, $($arg)*)
+	)
+}
+
+/// Log a gossip log.
+macro_rules! log_gossip {
+	($logger: expr, $($arg:tt)*) => (
+		log_given_level!($logger, $crate::util::logger::Level::Gossip, $($arg)*);
 	)
 }


### PR DESCRIPTION
As requested in #1140, this PR introduces a new `GOSSIP` log level for gossip messages. Thereby, it should make logs more readable at the `TRACE` level. 

Note that I left the logging events concerning connection management at the `TRACE` level, because I figured they may still be of interest (and are likely not cluttering the logs too much?).