### PR TITLE
Retries for spontaneous payments

### DIFF
--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -8,7 +8,7 @@ use bitcoin_hashes::Hash;
 use lightning::chain;
 use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lightning::chain::keysinterface::{Sign, KeysInterface};
-use lightning::ln::{PaymentHash, PaymentSecret};
+use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::ln::channelmanager::{ChannelDetails, ChannelManager, PaymentId, PaymentSendFailure, MIN_FINAL_CLTV_EXPIRY};
 use lightning::ln::msgs::LightningError;
 use lightning::routing;
@@ -139,6 +139,13 @@ where
 		&self, route: &Route, payment_hash: PaymentHash, payment_secret: &Option<PaymentSecret>
 	) -> Result<PaymentId, PaymentSendFailure> {
 		self.send_payment(route, payment_hash, payment_secret)
+	}
+
+	fn send_spontaneous_payment(
+		&self, route: &Route, payment_preimage: PaymentPreimage,
+	) -> Result<PaymentId, PaymentSendFailure> {
+		self.send_spontaneous_payment(route, Some(payment_preimage))
+			.map(|(_, payment_id)| payment_id)
 	}
 
 	fn retry_payment(

--- a/lightning-invoice/src/utils.rs
+++ b/lightning-invoice/src/utils.rs
@@ -112,8 +112,8 @@ impl<G, L: Deref> DefaultRouter<G, L> where G: Deref<Target = NetworkGraph>, L::
 impl<G, L: Deref, S: routing::Score> Router<S> for DefaultRouter<G, L>
 where G: Deref<Target = NetworkGraph>, L::Target: Logger {
 	fn find_route(
-		&self, payer: &PublicKey, params: &RouteParameters, first_hops: Option<&[&ChannelDetails]>,
-		scorer: &S
+		&self, payer: &PublicKey, params: &RouteParameters, _payment_hash: &PaymentHash,
+		first_hops: Option<&[&ChannelDetails]>, scorer: &S
 	) -> Result<Route, LightningError> {
 		find_route(payer, params, &*self.network_graph, first_hops, &*self.logger, scorer)
 	}


### PR DESCRIPTION
`InvoicePayer` handles retries not only when handling `PaymentPathFailed` events but also for some types of `PaymentSendFailure` on the initial send. Expand `InvoicePayer`'s interface with a `pay_pubkey` function for spontaneous (keysend) payments. Add a `send_spontaneous_payment` function to the `Payer` trait to support this and implement it for `ChannelManager`.

Closes #1156.