### PR TITLE
Derive `Clone` and friends on additional public structs

### DIFF
--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -940,6 +940,7 @@ impl BuiltCommitmentTransaction {
 ///
 /// This class can be used inside a signer implementation to generate a signature given the relevant
 /// secret key.
+#[derive(Clone, Hash, PartialEq)]
 pub struct ClosingTransaction {
 	to_holder_value_sat: u64,
 	to_counterparty_value_sat: u64,

--- a/lightning/src/ln/script.rs
+++ b/lightning/src/ln/script.rs
@@ -21,7 +21,7 @@ use io;
 pub struct ShutdownScript(ShutdownScriptImpl);
 
 /// An error occurring when converting from [`Script`] to [`ShutdownScript`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct InvalidShutdownScript {
 	/// The script that did not meet the requirements from [BOLT #2].
 	///


### PR DESCRIPTION
We've been carrying these patches specific to the Java (and, I believe, Swift) bindings for a few releases, but there's really no reason to, they should just be upstream.